### PR TITLE
Various CI fixes for parity-signer

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,7 +28,7 @@ cache:
 #    - rust 
 android-build:
   stage: build
-  image: parity/parity-android
+  image: parity/android-sdk
   only:
     - beta
     - tags
@@ -37,21 +37,15 @@ android-build:
     - master
   script:
     - curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
-    # To fix, put these in a docker image
-    - apt-get install -y nodejs openjdk-8-jdk
-    - mkdir -p /opt/android-sdk && cd /opt/android-sdk && wget -q https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip && unzip *tools*linux*.zip && rm *tools*linux*.zip && cd /builds/parity/parity-signer 
-
-    - echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu xenial main" | tee /etc/apt/sources.list.d/webupd8team-java.list
-    - echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu xenial main" | tee -a /etc/apt/sources.list.d/webupd8team-java.list
-    - apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886
-    - apt-get update
-    - echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 select true" | sudo debconf-set-selections
-    - apt-get install -y oracle-java8-installer
-    - yes | /opt/android-sdk/tools/bin/sdkmanager --licenses || true
+    - apt-get install -y nodejs
     - echo "ndk.dir=/usr/local/android-ndk-r16b" > android/local.properties
     - echo "sdk.dir=/opt/android-sdk" >> android/local.properties
     - npm install -g yarn
     - bash ./setup_linux.sh
-    - npm run android
+    - bash ./gen_key.sh
+    - cd android && ./gradlew assembleRelease
   tags:
     - rust 
+  artifacts:
+    paths:
+    - ./android/app/build/outputs/apk/release/app-release.apk

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -19,3 +19,7 @@
 
 android.useDeprecatedNdk=true
 android.enableAapt2=false
+MYAPP_RELEASE_STORE_FILE=apk.keystore
+MYAPP_RELEASE_KEY_ALIAS=testing
+MYAPP_RELEASE_STORE_PASSWORD=testing
+MYAPP_RELEASE_KEY_PASSWORD=testing

--- a/gen_key.sh
+++ b/gen_key.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+rm -rf android/app/apk.keystore
+
 keytool -genkey -noprompt \
  -alias testing \
  -keysize 2048 \


### PR DESCRIPTION
- Move SDK install to container
- Enable key creation and apk build
- Collect artfifacts in gitlab