### PR TITLE
fix: Update script instructions command to install NDK

### DIFF
--- a/create-ndk-standalone.sh
+++ b/create-ndk-standalone.sh
@@ -20,7 +20,7 @@ if [ -x "$MAKER" ]; then
     echo 'Creating standalone NDK...'
 else
     printf '\e[91;1mPlease install `android-ndk`!\e[0m\n\n'
-    printf '$ brew install android-ndk\n'
+    printf '$ brew cask install android-ndk\n'
     exit 1
 fi
 


### PR DESCRIPTION
Note that `brew install android-ndk` returns `Error: No available formula with the name "android-ndk" ... It was migrated from homebrew/core to homebrew/cask.`