### PR TITLE
Show seed type and green field if valid bip39

### DIFF
--- a/src/components/AccountCard.js
+++ b/src/components/AccountCard.js
@@ -28,7 +28,7 @@ export default class AccountCard extends React.PureComponent<{
   address: string,
   chainId: string,
   onPress: () => any,
-  title: ?string,
+  title?: string,
   seedType?: string,
 }> {
   static propTypes = {
@@ -50,7 +50,7 @@ export default class AccountCard extends React.PureComponent<{
     title = title.length ? title : AccountCard.defaultProps.title;
     let seedTypeDisplay = ''
 
-    if (seedType && seedType!== ''){
+    if (seedType && seedType !== ''){
       seedTypeDisplay = 'seed: '+ seedType;
     }
 

--- a/src/components/AccountCard.js
+++ b/src/components/AccountCard.js
@@ -48,11 +48,7 @@ export default class AccountCard extends React.PureComponent<{
     const { address, chainId, onPress, seedType, style } = this.props;
     let { title } = this.props;
     title = title.length ? title : AccountCard.defaultProps.title;
-    let seedTypeDisplay = ''
-
-    if (seedType && seedType !== ''){
-      seedTypeDisplay = 'seed: '+ seedType;
-    }
+    const seedTypeDisplay = seedType || '';
 
     return (
       <TouchableItem

--- a/src/components/AccountCard.js
+++ b/src/components/AccountCard.js
@@ -25,17 +25,19 @@ import AccountIcon from './AccountIcon';
 import TouchableItem from './TouchableItem';
 
 export default class AccountCard extends React.PureComponent<{
-  title: ?string,
   address: string,
   chainId: string,
-  onPress: () => any
+  onPress: () => any,
+  title: ?string,
+  seedType?: string,
 }> {
   static propTypes = {
-    title: PropTypes.string,
     address: PropTypes.string.isRequired,
-    style: ViewPropTypes.style,
     chainId: PropTypes.string,
-    onPress: PropTypes.func
+    onPress: PropTypes.func,
+    seedType: PropTypes.string,
+    style: ViewPropTypes.style,
+    title: PropTypes.string,
   };
 
   static defaultProps = {
@@ -43,9 +45,14 @@ export default class AccountCard extends React.PureComponent<{
   };
 
   render() {
-    const { address, chainId, style, onPress } = this.props;
+    const { address, chainId, onPress, seedType, style } = this.props;
     let { title } = this.props;
     title = title.length ? title : AccountCard.defaultProps.title;
+    let seedTypeDisplay = ''
+
+    if (seedType && seedType!== ''){
+      seedTypeDisplay = 'seed: '+ seedType;
+    }
 
     return (
       <TouchableItem
@@ -80,7 +87,19 @@ export default class AccountCard extends React.PureComponent<{
           >
             <Text
               style={[
-                styles.footerText,
+                styles.footerSeedType,
+                {
+                  color: NETWORK_COLOR[chainId]
+                    ? colors.card_bg
+                    : colors.card_text
+                }
+              ]}
+            >
+              {seedTypeDisplay}
+            </Text>
+            <Text
+              style={[
+                styles.footerNetwork,
                 {
                   color: NETWORK_COLOR[chainId]
                     ? colors.card_bg
@@ -118,7 +137,8 @@ const styles = StyleSheet.create({
   },
   footer: {
     backgroundColor: '#977CF6',
-    flexDirection: 'row-reverse',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
     padding: 5
   },
   titleText: {
@@ -131,7 +151,11 @@ const styles = StyleSheet.create({
     fontWeight: '500',
     fontSize: 14
   },
-  footerText: {
+  footerSeedType: {
+    fontFamily: 'Roboto',
+    color: colors.card_bg
+  },
+  footerNetwork: {
     fontFamily: 'Roboto',
     color: colors.card_bg,
     fontWeight: 'bold'

--- a/src/screens/AccountNew.js
+++ b/src/screens/AccountNew.js
@@ -112,9 +112,9 @@ class AccountNewView extends React.Component {
             <Button
               buttonStyles={styles.nextStep}
               title="Next Step"
-              disabled={ !validateSeed(selected.seed).valid }
+              disabled={ !validateSeed(selected.seed, selected.validBip39Seed).valid }
               onPress={() => {
-                validateSeed(selected.seed).valid &&
+                validateSeed(selected.seed, selected.validBip39Seed).valid &&
                   this.props.navigation.navigate('AccountBackup', {
                     isNew: true,
                     isWelcome: this.props.navigation.getParam('isWelcome')

--- a/src/screens/AccountRecover.js
+++ b/src/screens/AccountRecover.js
@@ -54,6 +54,7 @@ class AccountRecoverView extends React.Component {
     const { accounts } = this.props;
     const selected = accounts.getNew();
     const chainId = selected.chainId;
+
     return (
       <View style={styles.body}>
         <Background />
@@ -109,7 +110,7 @@ class AccountRecoverView extends React.Component {
             onFocus={e => {
               this.scroll.props.scrollToFocusedInput(findNodeHandle(e.target));
             }}
-            valid={validateSeed(selected.seed).valid}
+            valid={validateSeed(selected.seed, selected.validBip39Seed).valid}
             onChangeText={seed => {
               accounts.updateNew({ seed });
             }}
@@ -120,12 +121,13 @@ class AccountRecoverView extends React.Component {
             address={selected.address || ''}
             chainId={selected.chainId || ''}
             title={selected.name}
+            seedType={selected.validBip39Seed ? 'bip39' : 'brain wallet'}
           />
           <Button
             buttonStyles={{ marginBottom: 40 }}
             title="Next Step"
             onPress={() => {
-              const validation = validateSeed(selected.seed);
+              const validation = validateSeed(selected.seed, selected.validBip39Seed);
               if (!validation.valid) {
                 Alert.alert(
                   'Warning: seed phrase is not secure',

--- a/src/screens/AccountRecover.js
+++ b/src/screens/AccountRecover.js
@@ -130,7 +130,7 @@ class AccountRecoverView extends React.Component {
               const validation = validateSeed(selected.seed, selected.validBip39Seed);
               if (!validation.valid) {
                 Alert.alert(
-                  'Warning: seed phrase is not secure',
+                  'Warning:',
                   `${validation.reason}`,
                   [
                     {

--- a/src/stores/AccountsStore.js
+++ b/src/stores/AccountsStore.js
@@ -31,7 +31,8 @@ export type Account = {
   encryptedSeed: string,
   createdAt: number,
   updatedAt: number,
-  archived: boolean
+  archived: boolean,
+  validBip39Seed: boolean
 };
 
 type AccountsState = {
@@ -71,7 +72,7 @@ export default class AccountsStore extends Container<AccountsState> {
       debounce(async () => {
         const { bip39, address } = await brainWalletAddress(seed);
 
-        Object.assign(this.state.newAccount, { address });
+        Object.assign(this.state.newAccount, { address, validBip39Seed: bip39 });
         this.setState({});
       }, 200)();
     }

--- a/src/util/account.js
+++ b/src/util/account.js
@@ -23,11 +23,12 @@ export function empty (account = {}) {
     updatedAt: new Date().getTime(),
     archived: false,
     encryptedSeed: null,
+    validBip39Seed: false,
     ...account
   };
 }
 
-export function validateSeed (seed) {
+export function validateSeed (seed, validBip39Seed) {
   if (seed.length === 0) {
     return {
       valid: false,
@@ -36,13 +37,6 @@ export function validateSeed (seed) {
   }
   const words = seed.split(' ');
 
-  if (words.length < 11) {
-    return {
-      valid: false,
-      reason: `Add ${11 - words.length} more unique word(s) to compose a secure seed phrase`
-    }
-  }
-
   for (let word of words) {
     if (word === '') {
       return {
@@ -50,6 +44,13 @@ export function validateSeed (seed) {
         reason: `Extra whitespace found`
       };
     }
+  }
+
+  if (!validBip39Seed) {
+    return {
+      valid: false,
+      reason: `This recovery phrase will be treated as a "legacy Parity brain wallet"`
+    };
   }
 
   return {

--- a/src/util/account.js
+++ b/src/util/account.js
@@ -49,7 +49,7 @@ export function validateSeed (seed, validBip39Seed) {
   if (!validBip39Seed) {
     return {
       valid: false,
-      reason: `This recovery phrase will be treated as a "legacy Parity brain wallet"`
+      reason: `This recovery phrase will be treated as a legacy Parity brain wallet`
     };
   }
 


### PR DESCRIPTION
- add validBip39Seed to new account's state in `AccountStore`
- only mark the recovery field as valid if the bip39 checksum passes
- show in the account card the seed type
- warn users if they recover a brain wallet (e.g no bip39 type)

Here is how it looks: (valid bip39, invalid bip39, warning)
![image](https://user-images.githubusercontent.com/33178835/58659025-3900ef00-8322-11e9-8a20-b5c6c61a4abe.png)
![image](https://user-images.githubusercontent.com/33178835/58659036-40c09380-8322-11e9-90f3-6edf864d1054.png)
![image](https://user-images.githubusercontent.com/33178835/58659420-2f2bbb80-8323-11e9-940a-3905926d0101.png)

