### PR TITLE
Flexible text box for recovery phrase

### DIFF
--- a/src/screens/AccountBackup.js
+++ b/src/screens/AccountBackup.js
@@ -111,7 +111,7 @@ class AccountBackupView extends React.PureComponent {
           <Text
             style={{
               padding: 10,
-              height: 160,
+              minHeight: 160,
               lineHeight: 26,
               fontSize: 20,
               backgroundColor: colors.card_bg


### PR DESCRIPTION
- Tested on Android for both account creation and "view backup phrase" scenario.
  - first scenario tested by hardcoding an incredibly long phrase as the seed of any new account. It get showed entirely and the screen is scrollable
  - second simply by recovering an extremely long phrase and then going to account>show recover phrase
- addresses https://github.com/paritytech/parity-signer/issues/248 but possibly not entirely as only one character is truncated..
- note that I didn't touch the recovery phrase input field as this one is scrollable.