### PR TITLE
Make sure the recovery phrase is emptied upon process abortion

### DIFF
--- a/src/screens/AccountRecover.js
+++ b/src/screens/AccountRecover.js
@@ -17,7 +17,7 @@
 'use strict';
 
 import React from 'react';
-import { Alert, findNodeHandle, KeyboardAvoidingView, StyleSheet, ScrollView, Text, View } from 'react-native';
+import { Alert, KeyboardAvoidingView, StyleSheet, ScrollView, Text } from 'react-native';
 import { Subscribe } from 'unstated';
 import colors from '../colors';
 import AccountCard from '../components/AccountCard';
@@ -47,6 +47,10 @@ export default class AccountRecover extends React.Component {
 class AccountRecoverView extends React.Component {
   constructor(...args) {
     super(...args);
+  }
+  componentWillUnmount = function () {
+    // called when the user goes back, or finishes the whole recovery process
+    this.props.accounts.updateNew({seed : ''});
   }
 
   render () {
@@ -107,9 +111,7 @@ class AccountRecoverView extends React.Component {
           </Text>
           <AccountSeed
             valid={validateSeed(selected.seed, selected.validBip39Seed).valid}
-            onChangeText={seed => {
-              accounts.updateNew({ seed });
-            }}
+            onChangeText={seed => accounts.updateNew({ seed })}
             value={selected.seed}
           />
           <AccountCard

--- a/src/stores/AccountsStore.js
+++ b/src/stores/AccountsStore.js
@@ -85,11 +85,15 @@ export default class AccountsStore extends Container<AccountsState> {
 
   async submitNew(pin) {
     const account = this.state.newAccount;
-    await this.save(account, pin);
-    this.setState({
-      accounts: this.state.accounts.set(accountId(account), account),
-      newAccount: empty()
-    });
+
+    // only save the account if the seed isn't empty
+    if (account.seed) {
+      await this.save(account, pin);
+      this.setState({
+        accounts: this.state.accounts.set(accountId(account), account),
+        newAccount: empty()
+      });
+    }
   }
 
   update(accountUpdate) {

--- a/src/stores/AccountsStore.js
+++ b/src/stores/AccountsStore.js
@@ -85,15 +85,11 @@ export default class AccountsStore extends Container<AccountsState> {
 
   async submitNew(pin) {
     const account = this.state.newAccount;
-
-    // only save the account if the seed isn't empty
-    if (account.seed) {
-      await this.save(account, pin);
-      this.setState({
-        accounts: this.state.accounts.set(accountId(account), account),
-        newAccount: empty()
-      });
-    }
+    await this.save(account, pin);
+    this.setState({
+      accounts: this.state.accounts.set(accountId(account), account),
+      newAccount: empty()
+    });
   }
 
   update(accountUpdate) {


### PR DESCRIPTION
- closes https://github.com/paritytech/parity-signer/issues/261(the second bug mentioned)

Users could set a seed for the `new` account in `AccountRecover`. This seed remained in the `AccountStore` state upon unmount. It needed to be manually removed in case a user doesn't finish the process.