### PR TITLE
Refactor new account state management

### DIFF
--- a/src/components/AccountIconChooser.js
+++ b/src/components/AccountIconChooser.js
@@ -50,7 +50,7 @@ export default class AccountIconChooser extends React.PureComponent<{
           .split(' ')
           .map(async () => {
             const seed = await words();
-            const { bip39, address } = await brainWalletAddress(seed);
+            const { address } = await brainWalletAddress(seed);
 
             return {
               seed,
@@ -70,14 +70,15 @@ export default class AccountIconChooser extends React.PureComponent<{
   render() {
     const { value, onChange } = this.props;
     const { icons } = this.state;
-    console.log(icons);
+
     return (
       <View style={styles.body}>
         <FlatList
+          extraData={value}
           style={styles.icons}
           data={icons}
           horizontal
-          renderItem={({ item, index, separators }) => {
+          renderItem={({ item, index }) => {
             const selected = item.address.toLowerCase() === value.toLowerCase();
             const style = [styles.icon];
 
@@ -85,14 +86,12 @@ export default class AccountIconChooser extends React.PureComponent<{
               <TouchableOpacity
                 key={index}
                 style={[styles.iconBorder, selected ? styles.selected : {}]}
-                onPress={() =>
-                  this.props.onChange({
+                onPress={() => {
+                  onChange({
                     address: item.address,
                     seed: item.seed,
-                  })
-                }
-                onShowUnderlay={separators.highlight}
-                onHideUnderlay={separators.unhighlight}
+                  });
+                }}
               >
                 <AccountIcon style={style} seed={'0x' + item.address} />
               </TouchableOpacity>

--- a/src/screens/AccountList.js
+++ b/src/screens/AccountList.js
@@ -39,6 +39,7 @@ export default class AccountList extends React.PureComponent {
     return (
       <Subscribe to={[AccountsStore]}>
         {accounts => {
+          console.log(accounts)
           return (
             <AccountListView
               {...this.props}

--- a/src/screens/AccountList.js
+++ b/src/screens/AccountList.js
@@ -39,7 +39,6 @@ export default class AccountList extends React.PureComponent {
     return (
       <Subscribe to={[AccountsStore]}>
         {accounts => {
-          console.log(accounts)
           return (
             <AccountListView
               {...this.props}

--- a/src/screens/AccountNetworkChooser.js
+++ b/src/screens/AccountNetworkChooser.js
@@ -18,11 +18,9 @@
 
 import React from 'react';
 import { ScrollView, StyleSheet, Text } from 'react-native';
-import { Subscribe } from 'unstated';
 import colors from '../colors';
 import TouchableItem from '../components/TouchableItem';
 import { DEFAULT_NETWORK_COLOR, NETWORK_COLOR, NETWORK_LIST, NETWORK_TITLES } from '../constants';
-import AccountsStore from '../stores/AccountsStore';
 
 export default class AccountNetworkChooser extends React.PureComponent {
   static navigationOptions = {
@@ -31,20 +29,7 @@ export default class AccountNetworkChooser extends React.PureComponent {
   };
 
   render() {
-    return (
-      <Subscribe to={[AccountsStore]}>
-        {accounts => (
-          <AccountNetworkChooserView {...this.props} accounts={accounts} />
-        )}
-      </Subscribe>
-    );
-  }
-}
-
-class AccountNetworkChooserView extends React.PureComponent {
-  render() {
     const { navigation } = this.props;
-    const { accounts } = this.props;
     return (
       <ScrollView style={styles.body} contentContainerStyle={{ padding: 20 }}>
         <Text style={styles.title}>CHOOSE NETWORK</Text>
@@ -59,7 +44,7 @@ class AccountNetworkChooserView extends React.PureComponent {
               }
             ]}
             onPress={() => {
-              accounts.updateNew({ chainId });
+              navigation.getParam('onChange')(chainId);
               navigation.goBack();
             }}
           >

--- a/src/screens/AccountRecover.js
+++ b/src/screens/AccountRecover.js
@@ -83,7 +83,10 @@ class AccountRecoverView extends React.Component {
                 }
               ]}
               onPress={() =>
-                this.props.navigation.navigate('AccountNetworkChooser')
+                this.props.navigation.navigate(
+                  'AccountNetworkChooser',
+                  { onChange: (chainId) => accounts.updateNew({chainId}) }
+                )
               }
             >
               <Text


### PR DESCRIPTION
- closes https://github.com/paritytech/parity-signer/issues/258

While digging into this bug, I realized that the way we managed new account info in the `AccountNew` screen was a little heavy. Calling `updateNew` every time anything changes is demanding for the device. In master when you click quickly between identicons, the device is lagging so much that weird things appear (this is introduced by persisting each change). I chose to store the new account first in a local state and to submit it to the account store only when tapping the *next step* button.

This required a very small change in `NetworkChooser` component, it doesn't access the AccountStore anymore.

What it fixes:

I do exactly the same in each example, I click on new account and click on the 4 first icons **consecutively**. You can see the selection is jumping.
Before :-1: 
![image](https://i.imgur.com/GBc0OjK.gif)

After :+1: 
![image](https://i.imgur.com/35DkLU0.gif)