### PR TITLE
Don't allow empty seed phrase recovery

### DIFF
--- a/src/screens/AccountRecover.js
+++ b/src/screens/AccountRecover.js
@@ -105,7 +105,7 @@ class AccountRecoverView extends React.Component {
                 const validation = validateSeed(selected.seed, selected.validBip39Seed);
                 if (!validation.valid) {
                   if (validation.accountRecoveryAllowed){
-                    Alert.alert(
+                    return Alert.alert(
                       'Warning:',
                       `${validation.reason}`,
                       [
@@ -127,9 +127,8 @@ class AccountRecoverView extends React.Component {
                         }
                       ]
                     );
-                    return;
                   } else {
-                    Alert.alert(
+                    return Alert.alert(
                       'Error:',
                       `${validation.reason}`,
                       [
@@ -139,7 +138,6 @@ class AccountRecoverView extends React.Component {
                         }
                       ]
                     );
-                    return;
                   }
                 }
                 this.props.navigation.navigate('AccountPin', {

--- a/src/screens/AccountRecover.js
+++ b/src/screens/AccountRecover.js
@@ -104,29 +104,43 @@ class AccountRecoverView extends React.Component {
               onPress={() => {
                 const validation = validateSeed(selected.seed, selected.validBip39Seed);
                 if (!validation.valid) {
-                  Alert.alert(
-                    'Warning:',
-                    `${validation.reason}`,
-                    [
-                      {
-                        text: 'I understand the risks',
-                        style: 'default',
-                        onPress: () => {
-                          this.props.navigation.navigate('AccountPin', {
-                            isWelcome: this.props.navigation.getParam(
-                              'isWelcome'
-                            ),
-                            isNew: true
-                          });
+                  if (validation.accountRecoveryAllowed){
+                    Alert.alert(
+                      'Warning:',
+                      `${validation.reason}`,
+                      [
+                        {
+                          text: 'I understand the risks',
+                          style: 'default',
+                          onPress: () => {
+                            this.props.navigation.navigate('AccountPin', {
+                              isWelcome: this.props.navigation.getParam(
+                                'isWelcome'
+                              ),
+                              isNew: true
+                            });
+                          }
+                        },
+                        {
+                          text: 'Back',
+                          style: 'cancel'
                         }
-                      },
-                      {
-                        text: 'Back',
-                        style: 'cancel'
-                      }
-                    ]
-                  );
-                  return;
+                      ]
+                    );
+                    return;
+                  } else {
+                    Alert.alert(
+                      'Error:',
+                      `${validation.reason}`,
+                      [
+                        {
+                          text: 'Back',
+                          style: 'cancel'
+                        }
+                      ]
+                    );
+                    return;
+                  }
                 }
                 this.props.navigation.navigate('AccountPin', {
                   isWelcome: this.props.navigation.getParam('isWelcome'),

--- a/src/stores/AccountsStore.js
+++ b/src/stores/AccountsStore.js
@@ -85,11 +85,15 @@ export default class AccountsStore extends Container<AccountsState> {
 
   async submitNew(pin) {
     const account = this.state.newAccount;
-    await this.save(account, pin);
-    this.setState({
-      accounts: this.state.accounts.set(accountId(account), account),
-      newAccount: empty()
-    });
+
+    // only save the account if the seed isn't empty
+    if (account.seed) {
+      await this.save(account, pin);
+      this.setState({
+        accounts: this.state.accounts.set(accountId(account), account),
+        newAccount: empty()
+      });
+    }
   }
 
   update(accountUpdate) {

--- a/src/util/account.js
+++ b/src/util/account.js
@@ -31,8 +31,9 @@ export function empty(account = {}) {
 export function validateSeed(seed, validBip39Seed) {
   if (seed.length === 0) {
     return {
-      valid: false,
-      reason: `You're trying to recover from an empty seed phrase`
+      accountRecoveryAllowed: false,
+      reason: `A seed phrase is required.`,
+      valid: false
     };
   }
   const words = seed.split(' ');
@@ -40,21 +41,24 @@ export function validateSeed(seed, validBip39Seed) {
   for (let word of words) {
     if (word === '') {
       return {
-        valid: false,
-        reason: `Extra whitespace found`
+        accountRecoveryAllowed: true,
+        reason: `Extra whitespace found.`,
+        valid: false
       };
     }
   }
 
   if (!validBip39Seed) {
     return {
-      valid: false,
-      reason: `This recovery phrase will be treated as a legacy Parity brain wallet`
+      accountRecoveryAllowed: true,
+      reason: `This recovery phrase will be treated as a legacy Parity brain wallet.`,
+      valid: false
+      
     };
   }
 
   return {
-    valid: true,
-    reason: null
+    reason: null,
+    valid: true
   };
 }


### PR DESCRIPTION
- closes https://github.com/paritytech/parity-signer/issues/203
- alphabetical order cleanup

An empty account never got persisted in storage (since https://github.com/paritytech/parity-signer/pull/235/files) however it was still added to the `AccountStore` state and ended up being listed on the account overview. This doesn't happen anymore.

We now also don't allow users to recover an account with an empty seed.