### PR TITLE
Refactor updateNewAccount

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "@react-native-community/netinfo": "^4.1.1",
     "bignumber.js": "^4.0.0",
-    "debounce": "^1.0.0",
     "hoist-non-react-statics": "^2.5.0",
     "lodash": "^4.17.15",
     "prop-types": "^15.6.1",

--- a/src/screens/AccountNew.js
+++ b/src/screens/AccountNew.js
@@ -74,7 +74,7 @@ class AccountNewView extends React.Component {
               <AccountIconChooser
                 value={selected && selected.seed && selected.address}
                 onChange={({ address, seed, bip39 }) => {
-                  accounts.updateNew({ address, seed, validBip39Seed: bip39 }, false);
+                  accounts.updateNew({ address, seed, validBip39Seed: bip39 });
                 }}
               />
               <Text style={styles.title}>ACCOUNT NAME</Text>

--- a/src/screens/AccountRecover.js
+++ b/src/screens/AccountRecover.js
@@ -59,7 +59,7 @@ class AccountRecoverView extends React.Component {
     const { accounts } = this.props;
     
     brainWalletAddress(seed)
-    .then(({ address, bip39 }) => accounts.updateNew({address, validBip39Seed: bip39}))
+    .then(({ address, bip39 }) => accounts.updateNew({address, seed, validBip39Seed: bip39}))
     .catch(console.error);
   }
 
@@ -118,6 +118,7 @@ class AccountRecoverView extends React.Component {
               title="Next Step"
               onPress={() => {
                 const validation = validateSeed(selected.seed, selected.validBip39Seed);
+
                 if (!validation.valid) {
                   Alert.alert(
                     'Warning:',
@@ -143,6 +144,7 @@ class AccountRecoverView extends React.Component {
                   );
                   return;
                 }
+                
                 this.props.navigation.navigate('AccountPin', {
                   isWelcome: this.props.navigation.getParam('isWelcome'),
                   isNew: true

--- a/src/stores/AccountsStore.js
+++ b/src/stores/AccountsStore.js
@@ -16,11 +16,10 @@
 
 // @flow
 
-import debounce from 'debounce';
 import { Container } from 'unstated';
 import { accountId, empty } from '../util/account';
 import { loadAccounts, saveAccount } from '../util/db';
-import { brainWalletAddress, decryptData, encryptData } from '../util/native';
+import { decryptData, encryptData } from '../util/native';
 
 export type Account = {
   name: string,
@@ -65,35 +64,8 @@ export default class AccountsStore extends Container<AccountsState> {
     });
   }
 
-  updateNew(accountUpdate: Object, recalculateAddress: boolean = true) {
-    // Object.assign(this.state.newAccount, accountUpdate);
-    // const { seed } = this.state.newAccount;
-    // if (typeof seed === 'string') {
-    //   debounce(async () => {
-    //     const { bip39, address } = await brainWalletAddress(seed);
-
-    //     Object.assign(this.state.newAccount, { address, validBip39Seed: bip39 });
-    //     this.setState({});
-    //   }, 200)();
-    // }
-    // this.setState({});
-    
-    const { newAccount } = this.state;
-    const { seed } = accountUpdate;
-    console.log('hop',accountUpdate)
-
-    if ( seed && recalculateAddress ){
-      this.setState({newAccount :{...newAccount, seed}});
-      debounce(async () => {
-        const { bip39, address } = await brainWalletAddress(seed);
-        console.log('back',{ newAccount : {...newAccount, ...accountUpdate, address, validBip39Seed: bip39} })
-        this.setState({ newAccount : {...newAccount, ...accountUpdate, address, validBip39Seed: bip39} })
-        console.log('we update to',{ newAccount : {...newAccount, ...accountUpdate, address, validBip39Seed: bip39} })
-      }, 200)()
-    } else {
-      this.setState({ newAccount : {...newAccount, ...accountUpdate} })
-      console.log('without calculation',{ newAccount : {...newAccount, ...accountUpdate} })
-    }
+  updateNew(accountUpdate: Object) {
+    this.setState({ newAccount : {...this.state.newAccount, ...accountUpdate} })
   }
 
   getNew(): Account {

--- a/src/util/debounce.js
+++ b/src/util/debounce.js
@@ -1,0 +1,22 @@
+/**
+ * Creates and returns a new debounced version of the passed function that will 
+ * postpone its execution until after wait milliseconds have elapsed since 
+ * the last time it was invoked.
+ *
+ * @type  {T}                item    type
+ * @param {(any) => any}     function to debounce
+ * @param {number}           time in milliseconds
+ * 
+ *
+ * @return {any}            the debounced function
+ */
+export function debounce (fn, time) {
+  let timeout;
+
+  return function() {
+    const functionCall = () => fn.apply(this, arguments);
+
+    clearTimeout(timeout);
+    timeout = setTimeout(functionCall, time);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2191,7 +2191,7 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
-debounce@^1.0.0, debounce@^1.2.0:
+debounce@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.0.tgz#44a540abc0ea9943018dc0eaa95cce87f65cd131"
   integrity sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==


### PR DESCRIPTION
- debounce is now debouncing.
- icon selection isn't lagging anymore.
- removed a direct dependency to `debounce`

What it effectively solves:

On account recovery, debounce is working, the device used to calculate the address at every key stroke. Now it's effectively debouncing (after/before):
![debounce](https://i.imgur.com/aANAJu0.gif)

On new account, the icon selection doesn't re-render.
I do exactly the same in each example, I click on new account and click on the 4 first icons **consecutively**. You can see the selection is jumping. (before/after)
![image](https://i.imgur.com/H1ZFV3v.gif)

 
