### PR TITLE
fix: enable screenshot in dev mode

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -143,8 +143,12 @@ android {
     }
     buildTypes {
         release {
+            applicationIdSuffix "release"
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+        }
+        debug {
+            applicationIdSuffix "dev"
         }
     }
     // applicationVariants are e.g. debug, release

--- a/android/app/src/main/java/io/parity/signer/MainActivity.java
+++ b/android/app/src/main/java/io/parity/signer/MainActivity.java
@@ -22,8 +22,11 @@ public class MainActivity extends ReactActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE,
-                           WindowManager.LayoutParams.FLAG_SECURE);
+        if (!BuildConfig.DEBUG) {
+            getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE,
+                                       WindowManager.LayoutParams.FLAG_SECURE);
+        }
+
     }
 
     @Override


### PR DESCRIPTION
close #230 
Self explained.

Use negative value `!BuildConfig.DEBUG` for comparison since it has only been tested on `DEBUG` mode now.