### PR TITLE
fix: disable auto complete when user input recovery phrase

### DIFF
--- a/src/components/AccountSeed.js
+++ b/src/components/AccountSeed.js
@@ -131,6 +131,8 @@ export default class AccountSeed extends Component {
         <TextInput
           style={[styles.input, invalidStyles]}
           multiline
+          autoCorrect={false}
+          autoCompleteType="off"
           autoCapitalize="none"
           textAlignVertical="top"
           onSelectionChange={this.handleCursorPosition}


### PR DESCRIPTION
closes #269 

Currently autoComplete function in Android does not work as expected, it is a known issue of [React Native](https://github.com/facebook/react-native/pull/25549), we need bump React Native when the fix is included into new React Native release.

![out](https://user-images.githubusercontent.com/6014309/62375449-9db51180-b53e-11e9-9c52-0069973b39da.gif)

