### PR TITLE
Yarn start for react-native start preventing out of memory

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build-rust-android": "cd rust/signer && make android",
     "ios": "yarn run build-rust-ios && react-native run-ios",
     "android": "yarn run build-rust-android && react-native run-android",
-    "start": "yarn run ios",
+    "start": "NODE_OPTIONS=--max_old_space_size=8192 react-native start",
     "postinstall": "jetify",
     "test": "jest",
     "lint": "eslint",


### PR DESCRIPTION
self explanatory. I keep doing `yarn start` because it's a standard.. and end up with an ios error..