### PR TITLE
Pull react-native-secure-storage from Parity repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "react-native-keyboard-aware-scroll-view": "^0.8.0",
     "react-native-markdown-renderer": "^3.2.8",
     "react-native-popup-menu": "^0.15.6",
-    "react-native-secure-storage": "git+https://github.com/debris/react-native-secure-storage.git",
+    "react-native-secure-storage": "git+https://github.com/paritytech/react-native-secure-storage.git",
     "react-native-simple-picker": "^2.1.0",
     "react-native-tabs": "^1.0.9",
     "react-native-vector-icons": "^6.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5864,9 +5864,9 @@ react-native-safe-area-view@^0.14.1:
   dependencies:
     debounce "^1.2.0"
 
-"react-native-secure-storage@git+https://github.com/debris/react-native-secure-storage.git":
+"react-native-secure-storage@git+https://github.com/paritytech/react-native-secure-storage.git":
   version "1.0.0"
-  resolved "git+https://github.com/debris/react-native-secure-storage.git#7751c428cb2ab3b292fd9942eef40a43c1611363"
+  resolved "git+https://github.com/paritytech/react-native-secure-storage.git#3263537d637ddfc67e243b40ba50e5d05367d20b"
 
 react-native-simple-picker@^2.1.0:
   version "2.3.1"


### PR DESCRIPTION
- closes: https://github.com/paritytech/parity-signer/issues/299 after https://github.com/paritytech/react-native-secure-storage/pull/8

tested successfully on android