### PR TITLE
fix: Error handling for hash functions

### DIFF
--- a/android/app/src/main/java/io/parity/signer/EthkeyBridge.java
+++ b/android/app/src/main/java/io/parity/signer/EthkeyBridge.java
@@ -74,12 +74,20 @@ public class EthkeyBridge extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void keccak(String data, Promise promise) {
-        promise.resolve(ethkeyKeccak(data));
+        try {
+            promise.resolve(ethkeyKeccak(data));
+        } catch (Exception e) {
+            promise.reject("invalid data, expected hex-encoded string", "invalid data, expected hex-encoded string");
+        }
     }
 
     @ReactMethod
     public void blake2s(String data, Promise promise) {
-        promise.resolve(ethkeyBlake(data));
+        try {
+            promise.resolve(ethkeyBlake(data));
+        } catch (Exception e) {
+            promise.reject("invalid data, expected hex-encoded string", "invalid data, expected hex-encoded string");
+        }
     }
 
     @ReactMethod

--- a/ios/NativeSigner/EthkeyBridge.swift
+++ b/ios/NativeSigner/EthkeyBridge.swift
@@ -61,7 +61,11 @@ class EthkeyBridge: NSObject {
     let hash = String.fromStringPtr(ptr: hash_rust_str_ptr!.pointee)
     rust_string_ptr_destroy(hash_rust_str_ptr)
     rust_string_destroy(hash_rust_str)
-    resolve(hash)
+    if (error == 0) {
+      resolve(hash)
+    } else {
+      reject("invalid data, expected hex-encoded string", nil, nil)
+    }
   }
 
   @objc func blake2s(_ data: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
@@ -72,7 +76,11 @@ class EthkeyBridge: NSObject {
     let hash = String.fromStringPtr(ptr: hash_rust_str_ptr!.pointee)
     rust_string_ptr_destroy(hash_rust_str_ptr)
     rust_string_destroy(hash_rust_str)
-    resolve(hash)
+    if (error == 0) {
+      resolve(hash)
+    } else {
+      reject("invalid data, expected hex-encoded string", nil, nil)
+    }
   }
 
   @objc func ethSign(_ data: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {


### PR DESCRIPTION
`keccak` and `blake2s` should `reject` when fed ill-formatted data.