### PR TITLE
(WIP) refactor delete &  archived account

### DIFF
--- a/src/screens/AccountDetails.js
+++ b/src/screens/AccountDetails.js
@@ -71,7 +71,7 @@ class AccountDetailsView extends React.Component {
 This account can only be recovered with its associated recovery phrase.`,
       [
         {
-          text: 'Delete',
+          text: 'Delete & Archive Account',
           style: 'destructive',
           onPress: () => {
             accounts.deleteAccount(selected);
@@ -125,7 +125,7 @@ This account can only be recovered with its associated recovery phrase.`,
                 { value: 'AccountEdit', text: 'Edit' },
                 { value: 'AccountPin', text: 'Change Pin' },
                 { value: 'AccountBackup', text: 'View Recovery Phrase' },
-                { value: 'AccountDelete', text: 'Delete', textStyle: styles.deleteText }]}
+                { value: 'AccountDelete', text: 'Delete & Archive Account', textStyle: styles.deleteText }]}
             />
           </View>
         </View>

--- a/src/stores/AccountsStore.js
+++ b/src/stores/AccountsStore.js
@@ -90,7 +90,7 @@ export default class AccountsStore extends Container {
     }
   }
   update(accountUpdate) {
-    let account = this.state.accounts.get(accountId(accountUpdate));
+    let account = this.safeGet(accountId(accountUpdate));
     if (!account) {
       this.state.accounts.set(accountId(accountUpdate), accountUpdate);
       account = this.state.accounts.get(accountId(accountUpdate));
@@ -116,7 +116,7 @@ export default class AccountsStore extends Container {
       if (pin && account.seed) {
         account.encryptedSeed = await encryptData(account.seed, pin);
       }
-      
+
       const accountToSave = this.deleteSensitiveData(account);
 
       accountToSave.updatedAt = new Date().getTime();
@@ -163,7 +163,7 @@ export default class AccountsStore extends Container {
     delete account.seedPhrase;
     delete account.derivationPassword;
     delete account.derivationPath;
-    
+
     return account
   }
 
@@ -188,7 +188,7 @@ export default class AccountsStore extends Container {
   }
 
   getById(account) {
-    return this.state.accounts.get(accountId(account)) || empty(account);
+    return this.safeGet(accountId(account)) || empty(account);
   }
 
   getByAddress(address) {
@@ -198,7 +198,15 @@ export default class AccountsStore extends Container {
   }
 
   getSelected() {
-    return this.state.accounts.get(this.state.selected);
+    return this.safeGet(this.state.selected);
+  }
+
+  safeGet(key) {
+    const account = this.state.accounts.get(key);
+    if (account !== undefined && account.archived === false) {
+      return account;
+    }
+    return undefined;
   }
 
   getAccounts() {


### PR DESCRIPTION
resolve #323 

- [x] Use `safeGet` instead of `get` to filter the archived account (any suggestion on the function name?) 5f7d2c6
- [x] Rename the delete button to `Delete & Archive Account` (better ideas?) fea19f4
- [ ]  Create `Delete All Archived Account` Button in the account list page. ( it will be a little weird since the menu button on main page is a "+", but not a dot men)