### PR TITLE
Ethereum accountId should have a 0x

### DIFF
--- a/src/components/QrView.js
+++ b/src/components/QrView.js
@@ -19,7 +19,7 @@
 import { isHex } from '@polkadot/util';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Dimensions, Image, StyleSheet, View } from 'react-native';
+import { Dimensions, Image, StyleSheet, Text, View } from 'react-native';
 
 import { qrCode, qrHex } from '../util/native';
 

--- a/src/components/QrView.js
+++ b/src/components/QrView.js
@@ -19,7 +19,7 @@
 import { isHex } from '@polkadot/util';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Dimensions, Image, StyleSheet, Text, View } from 'react-native';
+import { Dimensions, Image, StyleSheet, View } from 'react-native';
 
 import { qrCode, qrHex } from '../util/native';
 

--- a/src/util/account.js
+++ b/src/util/account.js
@@ -14,7 +14,7 @@ export function accountId({
   if (protocol === NetworkProtocols.SUBSTRATE){ 
     return `${protocol}:${address}:${genesisHash}`;
   } else {
-    return `${protocol}:${address.toLowerCase()}@${ethereumChainId}`;
+    return `${protocol}:0x${address.toLowerCase()}@${ethereumChainId}`;
   }
 }
 


### PR DESCRIPTION
My bad, I've messed that up in the account management PR.
The accountId used to have `0x`, like [here](https://github.com/paritytech/parity-signer/blob/eb55ff68bb1dddc861c72205de72168502f5edc6/src/util/account.js#L11) and also specified in the [ERC](https://github.com/ethereum/EIPs/issues/67).

Right now this prevents MyCrypto from actually reading the account.