### PR TITLE
Make release flag implicit

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -144,7 +144,6 @@ android {
     }
     buildTypes {
         release {
-            applicationIdSuffix "release"
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }


### PR DESCRIPTION
closes : https://github.com/paritytech/parity-signer/issues/350

tested:
- build an apk and add to the google playstore console --> accepted (unlike before).
- install with `yarn start` and `yarn android` --> can do screenshots.
- install release apk --> can't do screenshots.