### PR TITLE
feat: add ECCrypto native module with hardware-back key storage / secure enclave .

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -179,6 +179,8 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.0.0'
     implementation 'com.facebook.react:react-native:0.60.3'
 
+    compile 'com.google.crypto.tink:tink-android:1.3.0-rc1'
+
     if (useIntlJsc) {
         implementation 'org.webkit:android-jsc-intl:+'
     } else {

--- a/android/app/src/main/java/io/parity/signer/ECCryptoModule.java
+++ b/android/app/src/main/java/io/parity/signer/ECCryptoModule.java
@@ -1,0 +1,120 @@
+// Copyright 2015-2019 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+package io.parity.signer;
+
+import android.os.Build;
+import android.util.Base64;
+import android.util.Log;
+import com.facebook.react.bridge.*;
+import com.google.crypto.tink.HybridDecrypt;
+import com.google.crypto.tink.HybridEncrypt;
+import com.google.crypto.tink.KeysetHandle;
+import com.google.crypto.tink.hybrid.HybridConfig;
+import com.google.crypto.tink.hybrid.HybridDecryptFactory;
+import com.google.crypto.tink.hybrid.HybridEncryptFactory;
+import com.google.crypto.tink.hybrid.HybridKeyTemplates;
+import com.google.crypto.tink.integration.android.AndroidKeysetManager;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ECCryptoModule extends ReactContextBaseJavaModule {
+    private static final String KEYSTORE_PROVIDER_NAME = "parity.singer.keystore";
+    private static final String SHARED_PREF_FILE_NAME = "parity.signer.shared.pref";
+    private static final String ANDORID_KEYSTORE_PREFIX = "android-keystore://";
+    private static final Map<Integer, String> sizeToName = new HashMap<Integer, String>();
+    private static final Map<Integer, byte[]> sizeToHead = new HashMap<Integer, byte[]>();
+
+    private final boolean isModern = android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M;
+    private KeysetHandle keysetHandle;
+
+    public ECCryptoModule(ReactApplicationContext reactContext) {
+        super(reactContext);
+        try {
+            HybridConfig.init();
+        } catch (GeneralSecurityException ex) {
+            Log.e("init ECCrypto Module", "ERR", ex);
+        }
+    }
+
+    private static String getKeyUri(String keyLabel) {
+        return ANDORID_KEYSTORE_PREFIX + keyLabel;
+    }
+
+    private static String toBase64(byte[] bytes) {
+        return Base64.encodeToString(bytes, Base64.NO_WRAP);
+    }
+
+    private static byte[] fromBase64(String str) {
+        return Base64.decode(str, Base64.NO_WRAP);
+    }
+
+    @Override
+    public String getName() {
+        return "ECCrypto";
+    }
+
+    @ReactMethod
+    public void encrypt(ReadableMap map, Promise promise) {
+        try {
+            KeysetHandle keysetHandle = getOrGenerateNewKeysetHandle(map.getString("label"));
+            KeysetHandle publicKeysetHandle = keysetHandle.getPublicKeysetHandle();
+            String clearTextString = map.getString("data");
+            byte[] plainText = clearTextString.getBytes("UTF-8");
+            byte[] contextInfo = fromBase64(SHARED_PREF_FILE_NAME);
+
+            HybridEncrypt hybridEncrypt = HybridEncryptFactory.getPrimitive(publicKeysetHandle);
+            byte[] cipherText = hybridEncrypt.encrypt(plainText, contextInfo);
+
+            promise.resolve(toBase64(cipherText));
+        } catch (Exception e) {
+            Log.e("ECCrypto", "encryption error", e);
+            promise.reject("ECCrypto error", e);
+            return;
+        }
+    }
+
+    @ReactMethod
+    public void decrypt(ReadableMap map, Promise promise) {
+        try {
+            KeysetHandle keysetHandle = getOrGenerateNewKeysetHandle(map.getString("label"));
+            String cipherTextString = map.getString("data");
+            byte[] cipherText = fromBase64(cipherTextString);
+            byte[] contextInfo = fromBase64(SHARED_PREF_FILE_NAME);
+
+            HybridDecrypt hybridDecrypt = HybridDecryptFactory.getPrimitive(keysetHandle);
+            byte[] clearText = hybridDecrypt.decrypt(cipherText, contextInfo);
+
+            promise.resolve(new String(clearText, "UTF-8"));
+        } catch (Exception e) {
+            Log.e("ECCrypto", "decrypt error", e);
+            promise.reject("ECCrypto error", e);
+            return;
+        }
+    }
+
+    private KeysetHandle getOrGenerateNewKeysetHandle(String keyUri) throws IOException, GeneralSecurityException {
+        return new AndroidKeysetManager.Builder()
+                .withSharedPref(getReactApplicationContext(), KEYSTORE_PROVIDER_NAME, SHARED_PREF_FILE_NAME)
+                .withKeyTemplate(HybridKeyTemplates.ECIES_P256_HKDF_HMAC_SHA256_AES128_CTR_HMAC_SHA256)
+                .withMasterKeyUri(getKeyUri(keyUri))
+                .build()
+                .getKeysetHandle();
+    }
+}

--- a/android/app/src/main/java/io/parity/signer/ECCryptoPackage.java
+++ b/android/app/src/main/java/io/parity/signer/ECCryptoPackage.java
@@ -1,0 +1,48 @@
+// Copyright 2015-2019 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+package io.parity.signer;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.JavaScriptModule;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class ECCryptoPackage implements ReactPackage {
+
+  @Override
+  public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+    List<NativeModule> modules = new ArrayList<>();
+
+    modules.add(new ECCryptoModule(reactContext));
+
+    return modules;
+  }
+
+  @Override
+  public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+    return Collections.emptyList();
+  }
+
+  public List<Class<? extends JavaScriptModule>> createJSModules() {
+    return Collections.emptyList();
+  }
+}

--- a/android/app/src/main/java/io/parity/signer/MainApplication.java
+++ b/android/app/src/main/java/io/parity/signer/MainApplication.java
@@ -36,6 +36,7 @@ public class MainApplication extends Application implements ReactApplication {
           new NetInfoPackage(),
           new RandomBytesPackage(),
           new EthkeyBridgePackage(),
+          new ECCryptoPackage(),
           new RNGestureHandlerPackage()
       );
     }

--- a/e2e/native.spec.js
+++ b/e2e/native.spec.js
@@ -1,0 +1,16 @@
+import testIDs from "./testIDs";
+
+describe('First test', () => {
+	beforeEach(async () => {
+		// await device.clearKeychain();
+	});
+
+	it('should pass all the eccrypto function', async () => {
+		await expect(element(by.id(testIDs.TacScreen.tacView))).toBeVisible();
+		await element(by.id(testIDs.TacScreen.nativeModuleTestButton)).tap();
+		await expect(element(by.id(testIDs.NativeTestScreen.nativeTestView))).toBeVisible();
+		await expect(element(by.id(testIDs.NativeTestScreen.succeedView))).toNotExist();
+		await element(by.id(testIDs.NativeTestScreen.startButton)).tap();
+		await expect(element(by.id(testIDs.NativeTestScreen.succeedView))).toExist();
+	})
+});

--- a/e2e/screens/NativeModuleTest.js
+++ b/e2e/screens/NativeModuleTest.js
@@ -1,0 +1,51 @@
+// Copyright 2015-2019 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+import React, {useState} from 'react';
+import {View} from 'react-native';
+import {encryptWithSecureKeystore, decryptWithSecureKeystore} from "../../src/util/native";
+import testIDs from "../testIDs";
+import Button from "../../src/components/Button";
+
+const testSeed = '0xf49cd2aa6bda43467abc6aa0a4f37c5b1378146855f80f491e5dd6d053fa4279';
+const testPublicAddress = '0x5Cc5dc62be3c95C771C142C2e30358B398265de21111';
+
+export default function NativeModuleTest() {
+
+	const [testSucceed, setTestResult] = useState(false);
+
+	const generateTestResult = (expectedResult, actualResult) => expectedResult === actualResult ? setTestResult(true) : setTestResult(false);
+
+	const testECCryptoModule = async () => {
+		const encryptedSeed = await encryptWithSecureKeystore(testSeed, testPublicAddress);
+		const decryptedText = await decryptWithSecureKeystore(encryptedSeed, testPublicAddress);
+		generateTestResult(testSeed, decryptedText)
+	};
+
+	const startTest = async () => {
+		try {
+			await testECCryptoModule();
+		} catch (e) {
+			console.log('error is', e);
+			setTestResult(false)
+		}
+	};
+
+	return <View testID={testIDs.NativeTestScreen.nativeTestView}>
+		<Button title="Start Test" onPress={startTest} testID={testIDs.NativeTestScreen.startButton}/>
+		{testSucceed && <View testID={testIDs.NativeTestScreen.succeedView}/>}
+	</View>
+}

--- a/e2e/testIDs.js
+++ b/e2e/testIDs.js
@@ -3,11 +3,17 @@ const testIDs = {
 		tacView: 'tac_view',
 		agreeTacButton: 'tac_agree',
 		agreePrivacyButton: 'tac_privacy',
+		nativeModuleTestButton: 'tac_native_test',
 		nextButton: 'tac_next'
 	},
 	AccountListScreen: {
-		accountList: 'accountList',
-	}
+		accountList: 'accountList'
+	},
+	NativeTestScreen: {
+		nativeTestView: 'native_test_view',
+		startButton: 'native_test_start',
+		succeedView: 'native_test_success'
+	},
 };
 
 export default testIDs;

--- a/ios/ECCrypto/ECCrypto.h
+++ b/ios/ECCrypto/ECCrypto.h
@@ -1,0 +1,33 @@
+// Copyright 2015-2019 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+//
+//  ECCrypto.h
+//
+
+#import <Foundation/Foundation.h>
+#import <React/RCTBridgeModule.h>
+
+@interface ECCrypto : NSObject <RCTBridgeModule>
+
+- (NSString * _Nonnull) toPublicIdentifier:(NSString * _Nonnull)keyPairTag;
+- (SecKeyRef _Nullable) getPublicKeyRef:(NSString * _Nullable)publicKeyTag errMsg:(NSString *_Nullable*_Nullable)errMsg;
+- (SecKeyRef _Nullable) getPrivateKeyRef:(NSString * _Nullable)privateKeyTag errMsg:(NSString *_Nullable*_Nullable)errMsg;
+- (SecKeyRef _Nullable) getOrGenerateNewPublicKeyRef:(NSDictionary * _Nonnull) options
+                                              errMsg:(NSString *_Nullable*_Nullable)errMsg;
+- (NSString * _Nonnull) uuidString;
+- (NSData * _Nullable)encrypt:(NSDictionary* _Nonnull)options errMsg:(NSString *_Nullable*_Nullable) errMsg;
+- (NSData * _Nullable)decrypt:(NSDictionary* _Nonnull)options errMsg:(NSString *_Nullable*_Nullable) errMsg;
+@end

--- a/ios/ECCrypto/ECCrypto.m
+++ b/ios/ECCrypto/ECCrypto.m
@@ -1,0 +1,319 @@
+// Copyright 2015-2019 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+//
+//  ECCrypto.m
+//
+
+#import "ECCrypto.h"
+#import <Foundation/Foundation.h>
+#import <React/RCTUtils.h>
+
+#define encryptAlgorithm        kSecKeyAlgorithmECIESEncryptionStandardX963SHA256AESGCM
+
+#if TARGET_OS_SIMULATOR
+static BOOL isSimulator = YES;
+#else
+static BOOL isSimulator = NO;
+#endif
+
+@implementation ECCrypto
+
+RCT_EXPORT_MODULE();
+
+/**
+ * @return base64 pub key string
+ */
+- (SecKeyRef) generateECPair:(nonnull NSDictionary*) options
+                      errMsg:(NSString **)errMsg
+{
+  CFErrorRef sacErr = NULL;
+  SecAccessControlRef sacObject;
+  sacObject = SecAccessControlCreateWithFlags(kCFAllocatorDefault,
+                                              kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+                                              kSecAccessControlUserPresence | kSecAccessControlPrivateKeyUsage,
+                                              &sacErr);
+  
+  if (sacErr) {
+    *errMsg = [(__bridge NSError *)sacErr description];
+    return nil;
+  }
+  
+  // Create parameters dictionary for key generation.
+  NSString* uuid = [options valueForKey:@"label"];
+  
+  if(uuid == nil) {
+    uuid = [self uuidString];
+  }
+  NSString* publicKeyTag = [self toPublicIdentifier:uuid];
+  
+  NSMutableDictionary *privateKeyAttrs = [NSMutableDictionary dictionaryWithDictionary: @{
+                                                                                          (__bridge id)kSecAttrIsPermanent: @YES,
+                                                                                          (__bridge id)kSecAttrApplicationTag: uuid,
+                                                                                          }];
+  if (!isSimulator) {
+    [privateKeyAttrs setObject:(__bridge_transfer id)sacObject forKey:(__bridge id)kSecAttrAccessControl];
+  }
+  NSDictionary *publicKeyAttrs = @{
+                                   (__bridge id)kSecAttrIsPermanent: isSimulator ? @YES : @NO,
+                                   (__bridge id)kSecAttrApplicationLabel: publicKeyTag,
+                                   };
+  NSMutableDictionary *parameters = [NSMutableDictionary dictionaryWithDictionary: @{
+                                                                                     (__bridge id)kSecAttrKeyType: (__bridge id)kSecAttrKeyTypeEC,
+                                                                                     (__bridge id)kSecAttrKeySizeInBits: @256,
+                                                                                     (__bridge id)kSecPrivateKeyAttrs: privateKeyAttrs,
+                                                                                     (__bridge id)kSecPublicKeyAttrs: publicKeyAttrs,
+                                                                                     }];
+  if (!isSimulator) {
+    [parameters setObject:(__bridge id)kSecAttrTokenIDSecureEnclave forKey:(__bridge id)kSecAttrTokenID];
+  }
+  CFErrorRef error = NULL;
+  SecKeyRef privateKey = SecKeyCreateRandomKey((__bridge CFDictionaryRef)parameters,
+                                               &error);
+  if (!privateKey) {
+    *errMsg = [CFBridgingRelease(error) description];  // ARC takes ownership
+    return nil;
+  }
+  
+  SecKeyRef publicKey = SecKeyCopyPublicKey(privateKey);
+  
+  // Save public Key
+  OSStatus status = SecItemAdd((__bridge CFDictionaryRef)@{
+                                                           (__bridge id)kSecClass: (__bridge id)kSecClassKey,
+                                                           (__bridge id)kSecAttrKeyClass: (__bridge id)kSecAttrKeyClassPublic,
+                                                           (__bridge id)kSecAttrApplicationTag: publicKeyTag,
+                                                           (__bridge id)kSecValueRef: (__bridge id)publicKey
+                                                           }, nil);
+  
+  if (status != errSecSuccess) {
+    CFRelease(privateKey);
+    CFRelease(publicKey);
+    *errMsg = keychainStatusToString(status);
+    return nil;
+  }
+  
+  CFRelease(privateKey);
+  return publicKey;
+}
+
+RCT_EXPORT_METHOD(decrypt:(nonnull NSDictionary *)options
+                  findEventsWithResolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    NSString* errMsg;
+    NSData* clearText = [self decrypt:options errMsg:&errMsg];
+    if (!clearText) {
+      reject(@"ECCrypto", errMsg, eccryptoMakeError(errMsg));
+      return;
+    }
+    NSString* base64ClearText = [[NSString alloc] initWithData:clearText encoding:NSUTF8StringEncoding];
+    resolve(base64ClearText);
+  });
+}
+
+-(NSData *)decrypt:(nonnull NSDictionary *)options
+            errMsg:(NSString **) errMsg
+{
+  NSString* keyPairTag = [options valueForKey:@"label"];
+  SecKeyRef privateKeyRef = [self getPrivateKeyRef:keyPairTag errMsg:errMsg];
+  if(!privateKeyRef)
+    return nil;
+  BOOL canDecrypt = SecKeyIsAlgorithmSupported(privateKeyRef,
+                                               kSecKeyOperationTypeDecrypt,
+                                               encryptAlgorithm);
+  if(!canDecrypt) {
+    *errMsg = @"can't decrypt";
+    return nil;
+  }
+  NSData* clearText = nil;
+  NSString* base64Data = [options valueForKey:@"data"];
+  NSData *data = [[NSData alloc] initWithBase64EncodedString:base64Data options:0];
+  CFErrorRef error = NULL;
+  clearText = (NSData*)CFBridgingRelease(       // ARC takes ownership
+                                         SecKeyCreateDecryptedData(privateKeyRef,
+                                                                   encryptAlgorithm,
+                                                                   (__bridge CFDataRef)data,
+                                                                   &error));
+  CFRelease(privateKeyRef);
+  if (!clearText) {
+    *errMsg = [CFBridgingRelease(error) description]; // ARC takes ownership
+    return nil;
+  }
+  return clearText;
+}
+
+RCT_EXPORT_METHOD(encrypt:(nonnull NSDictionary *)options
+                  findEventsWithResolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    NSString* errMsg;
+    NSData* cipherText = [self encrypt:options errMsg:&errMsg];
+    if (!cipherText) {
+      reject(@"ECCrypto", errMsg, eccryptoMakeError(errMsg));
+      return;
+    }
+    
+    NSString* base64cipherText = [cipherText base64EncodedStringWithOptions:0];
+    resolve(base64cipherText);
+  });
+}
+
+- (NSData *)encrypt:(nonnull NSDictionary *)options
+             errMsg:(NSString **) errMsg
+{
+  SecKeyRef publicKeyRef = [self getOrGenerateNewPublicKeyRef:options errMsg: errMsg];
+  
+  if(!publicKeyRef)
+    return nil;
+  
+  BOOL canEncrypt = SecKeyIsAlgorithmSupported(publicKeyRef,
+                                               kSecKeyOperationTypeEncrypt,
+                                               encryptAlgorithm);
+  if(!canEncrypt) {
+    *errMsg = @"can't encrypt";
+    return nil;
+  }
+  NSData* cipherText = nil;
+  CFErrorRef error = NULL;
+  NSString* base64Data = [options valueForKey:@"data"];
+  NSData *data = [base64Data dataUsingEncoding:NSUTF8StringEncoding];
+  //Releasing the data?
+  cipherText = (NSData*)CFBridgingRelease(      // ARC takes ownership
+                                          SecKeyCreateEncryptedData(publicKeyRef,
+                                                                    encryptAlgorithm,
+                                                                    (__bridge CFDataRef)data,
+                                                                    &error));
+  if (!cipherText) {
+    *errMsg = [CFBridgingRelease(error) description];  // ARC takes ownership
+    return nil;
+  }
+  
+  CFRelease(publicKeyRef);
+  return cipherText;
+}
+
+- (SecKeyRef) getOrGenerateNewPublicKeyRef:(nonnull NSDictionary*) options
+                                    errMsg:(NSString **)errMsg
+{
+  NSString* keyPairTag = [options valueForKey:@"label"];
+  
+  SecKeyRef publicKeyRef = [self getPublicKeyRef:[self toPublicIdentifier:keyPairTag] errMsg:errMsg];
+  if (!publicKeyRef) {
+    publicKeyRef = [self generateECPair:options errMsg:errMsg];
+    
+    if (!publicKeyRef)
+      return nil;
+  }
+  return publicKeyRef;
+}
+
+-(SecKeyRef)getPrivateKeyRef:(NSString *)privateKeyTag errMsg:(NSString **)errMsg
+{
+  NSDictionary *getPrivateKeyQuery = @{
+                                       (__bridge id)kSecClass: (__bridge id)kSecClassKey,
+                                       (__bridge id)kSecAttrKeyClass: (__bridge id)kSecAttrKeyClassPrivate,
+                                       (__bridge id)kSecAttrApplicationTag: privateKeyTag,
+                                       (__bridge id)kSecReturnRef:  @YES,
+                                       };
+  
+  SecKeyRef privateKeyRef = NULL;
+  OSStatus statusGetPrivateKey = SecItemCopyMatching((__bridge CFDictionaryRef)getPrivateKeyQuery,
+                                                     (CFTypeRef *)&privateKeyRef);
+  
+  if (statusGetPrivateKey!=errSecSuccess) {
+    *errMsg = keychainStatusToString(statusGetPrivateKey);
+    //Is the SecKeyRef now still NULL? Need CFRelease the SecKeyRef?
+    return nil;
+  }
+  if (!privateKeyRef) {
+    *errMsg = @"can't find public key";
+    return nil;
+  }
+  
+  return privateKeyRef;
+}
+
+- (SecKeyRef)getPublicKeyRef:(NSString *)publicKeyTag errMsg:(NSString **)errMsg
+{
+  NSDictionary *getPublicKeyQuery = @{
+                                      (__bridge id)kSecClass: (__bridge id)kSecClassKey,
+                                      (__bridge id)kSecAttrKeyClass: (__bridge id)kSecAttrKeyClassPublic,
+                                      (__bridge id)kSecAttrApplicationTag: publicKeyTag,
+                                      (__bridge id)kSecReturnRef:  @YES,
+                                      };
+  SecKeyRef publicKeyRef = NULL;
+  
+  OSStatus statusGetPublicKey = SecItemCopyMatching((__bridge CFDictionaryRef)getPublicKeyQuery,
+                                                    (CFTypeRef *)&publicKeyRef);
+  if (statusGetPublicKey != errSecSuccess) {
+    *errMsg = keychainStatusToString(statusGetPublicKey);
+    //Is the SecKeyRef now still NULL? Need CFRelease the SecKeyRef?
+    return nil;
+  }
+  if (!publicKeyRef) {
+    *errMsg = @"can't find public key";
+    return nil;
+  }
+  
+  return publicKeyRef;
+}
+
+NSString *keychainStatusToString(OSStatus status) {
+  NSString *message = [NSString stringWithFormat:@"%ld", (long)status];
+  
+  switch (status) {
+    case errSecSuccess:
+      message = @"success";
+      break;
+      
+    case errSecDuplicateItem:
+      message = @"error item already exists";
+      break;
+      
+    case errSecItemNotFound :
+      message = @"error item not found";
+      break;
+      
+    case errSecAuthFailed:
+      message = @"error item authentication failed";
+      break;
+      
+    default:
+      message = [NSString stringWithFormat:@"error with OSStatus %d", status];
+      break;
+  }
+  
+  return message;
+}
+
+- (NSString *) toPublicIdentifier:(NSString *)keyPairTag
+{
+  return [keyPairTag stringByAppendingString:@"-pub"];
+}
+
+- (NSString *)uuidString {
+  CFUUIDRef uuid = CFUUIDCreate(kCFAllocatorDefault);
+  NSString *uuidString = (__bridge_transfer NSString *)CFUUIDCreateString(kCFAllocatorDefault, uuid);
+  CFRelease(uuid);
+  
+  return uuidString;
+}
+
+NSError* eccryptoMakeError(NSString* errMsg)
+{
+  return [NSError errorWithDomain:@"ECCrypto" code:1 userInfo:@{NSLocalizedDescriptionKey:errMsg}];
+}
+
+@end

--- a/ios/NativeSigner.xcodeproj/project.pbxproj
+++ b/ios/NativeSigner.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		5DC40D98E51D492C8FF692B5 /* Manifold-CF-Light.otf in Resources */ = {isa = PBXBuildFile; fileRef = 31AAF2CB51C04377BFC79634 /* Manifold-CF-Light.otf */; };
 		6686E5A219254E3D8880285E /* Octicons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F2FB2DDD90964B3BB1FC813C /* Octicons.ttf */; };
 		6701864923270B1100A14061 /* assets in Resources */ = {isa = PBXBuildFile; fileRef = 6701864823270B1100A14061 /* assets */; };
+		67854D1C234A4F650032B3D5 /* ECCrypto.m in Sources */ = {isa = PBXBuildFile; fileRef = 67854D1A234A4F650032B3D5 /* ECCrypto.m */; };
 		6FBA1E2F42104B26A94F3EE0 /* Ionicons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 84D1117E71B04C839F00F619 /* Ionicons.ttf */; };
 		740B033F930D4E6FB906D8C2 /* MaterialCommunityIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = CB5C4A7F0E8B4E4E98E06EFD /* MaterialCommunityIcons.ttf */; };
 		768CDFD4C47549429C87DEDD /* Entypo.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 6A7AB3BD3C1A4E0EB3C4B3B6 /* Entypo.ttf */; };
@@ -477,6 +478,8 @@
 		5F744F56289845F0A1085BBB /* Roboto-MediumItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Roboto-MediumItalic.ttf"; path = "../res/fonts/Roboto-MediumItalic.ttf"; sourceTree = "<group>"; };
 		624E6C0FF4A64A97A7D51BEF /* Manifold-CF-Bold.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Manifold-CF-Bold.otf"; path = "../res/fonts/Manifold-CF-Bold.otf"; sourceTree = "<group>"; };
 		6701864823270B1100A14061 /* assets */ = {isa = PBXFileReference; lastKnownFileType = folder; path = assets; sourceTree = "<group>"; };
+		67854D1A234A4F650032B3D5 /* ECCrypto.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ECCrypto.m; sourceTree = "<group>"; };
+		67854D1B234A4F650032B3D5 /* ECCrypto.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ECCrypto.h; sourceTree = "<group>"; };
 		6A7AB3BD3C1A4E0EB3C4B3B6 /* Entypo.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Entypo.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Entypo.ttf"; sourceTree = "<group>"; };
 		6C53A63D96B24FDD95AF1C97 /* Fontisto.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Fontisto.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Fontisto.ttf"; sourceTree = "<group>"; };
 		7733AB637FF54DE5B174F42C /* Zocial.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Zocial.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Zocial.ttf"; sourceTree = "<group>"; };
@@ -754,6 +757,15 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		67854D19234A4F650032B3D5 /* ECCrypto */ = {
+			isa = PBXGroup;
+			children = (
+				67854D1A234A4F650032B3D5 /* ECCrypto.m */,
+				67854D1B234A4F650032B3D5 /* ECCrypto.h */,
+			);
+			path = ECCrypto;
+			sourceTree = "<group>";
+		};
 		6D14AF58F6CE45DDBA2DE41C /* Resources */ = {
 			isa = PBXGroup;
 			children = (
@@ -839,6 +851,7 @@
 		83CBB9F61A601CBA00E9B192 = {
 			isa = PBXGroup;
 			children = (
+				67854D19234A4F650032B3D5 /* ECCrypto */,
 				6701864823270B1100A14061 /* assets */,
 				39B6F6102315B550009C3C05 /* main.jsbundle */,
 				13B07FAE1A68108700A75B9A /* NativeSigner */,
@@ -1472,6 +1485,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				67854D1C234A4F650032B3D5 /* ECCrypto.m in Sources */,
 				1F426F9C208D358500CA43DB /* EthkeyBridge.swift in Sources */,
 				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
 				1F426F9D208D358500CA43DB /* String.swift in Sources */,

--- a/src/App.js
+++ b/src/App.js
@@ -50,6 +50,7 @@ import AccountRecover from './screens/AccountRecover';
 import { AccountUnlock, AccountUnlockAndSign } from './screens/AccountUnlock';
 import Loading from './screens/Loading';
 import MessageDetails from './screens/MessageDetails';
+import NativeModuleTest from '../e2e/screens/NativeModuleTest';
 import PrivacyPolicy from './screens/PrivacyPolicy';
 import QrScanner from './screens/QrScanner';
 import Security from './screens/Security';
@@ -206,6 +207,9 @@ const Screens = createStackNavigator(
 					},
 					MessageDetails: {
 						screen: MessageDetails
+					},
+					NativeModuleTest: {
+						screen: NativeModuleTest
 					},
 					QrScanner: {
 						screen: QrScanner

--- a/src/screens/TermsAndConditions.js
+++ b/src/screens/TermsAndConditions.js
@@ -17,7 +17,13 @@
 'use strict';
 
 import React from 'react';
-import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import {
+	ScrollView,
+	StyleSheet,
+	Text,
+	View,
+	TouchableOpacity
+} from 'react-native';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import toc from '../../docs/terms-and-conditions.md';
 import colors from '../colors';
@@ -108,6 +114,14 @@ export default class TermsAndConditions extends React.PureComponent {
 						navigation.dispatch(firstScreenActions);
 					}}
 				/>
+				{__DEV__ && (
+					<TouchableOpacity
+						onPress={() => navigation.navigate('NativeModuleTest')}
+						testID={testIDs.TacScreen.nativeModuleTestButton}
+					>
+						<View style={{ height: 1, width: 1 }} />
+					</TouchableOpacity>
+				)}
 			</View>
 		);
 	}

--- a/src/util/native.js
+++ b/src/util/native.js
@@ -16,7 +16,7 @@
 
 'use strict';
 
-import { EthkeyBridge } from 'NativeModules';
+import { EthkeyBridge, ECCrypto } from 'NativeModules';
 import { checksummedAddress } from './checksum';
 
 /**
@@ -105,6 +105,14 @@ export function encryptData(data, password) {
 
 export function decryptData(data, password) {
 	return EthkeyBridge.decryptData(data, password);
+}
+
+export function encryptWithSecureKeystore(data, label) {
+	return ECCrypto.encrypt({ data, label });
+}
+
+export function decryptWithSecureKeystore(data, label) {
+	return ECCrypto.decrypt({ data, label });
 }
 
 // Creates a QR code for the UTF-8 representation of a string


### PR DESCRIPTION
This is the first PR for #222 According to [Parity-Signer Secure Key Storage Proposal](https://gist.github.com/hanwencheng/736cc28834a06d9cbd4198c03a7c6033)

To avoid the PR become too large, and also to be available to switch to another high priority issues, I would rather split this PR into multiple parts.

As development goes by, the `react-native-ecc` is not 100% fits to our use case, I have implement an `ECCrypto` module which both works in iOS (with Secure Enclave) and Android (with Hard-ware backed Keystore).

So in this PR the following parts are finished:

- [x] iOS Encryption and decryption function.
- [x] Android Encryption and decryption function.
- [x] Integrate with iOS touchID.
- [ ] ~~Integrate with Android Fingerprint.~~
- [x] Add Integration Test for the encryption and decryption bridge

Rest parts are:

- [ ] Refactor Account to store the encrypted account data with secure storage
- [ ] Save the hashed pin in to system normal storage.

I am using Google [Tink](https://github.com/google/tink) library on Android for simplify the code and workflow but currently the BiometricPrompt is not integrated yet, there is an [issue](https://github.com/google/tink/issues/211#issue-445852940) discussing it.

### Usage

```javascript

import { ECCrypto } from 'NativeModules';

const encryptAndThenDecrypt = async () => {
  try {
    //Encrypt
    const cipherText = await ECCrypto.encrypt({
      data: 'I am a seed data',
      label: '0x5Cc5dc62be3c95C771C142C2e30358B398265deF' //any identical string, e.g. public address 
    });
    //Decrypt
    const clearText = await ECCrypto.decrypt({
      data: cipherText,
      label: '0x5Cc5dc62be3c95C771C142C2e30358B398265deF' //the same identical string
    });
    console.log('decrypt result is ', clearText);
  } catch(e) {
    console.log(e);
  }
};
```


------ORIGINAL DESCRIPTION BELOW------

[React-native-ecc](https://github.com/tradle/react-native-ecc/) has implement secure enclave with ecc sign and verify function. We could use to replace `react-native-secure-storage`, I am currently creating an [PR](https://github.com/tradle/react-native-ecc/pull/6) to add the encryption and decryption function to fulfill our goal.

On the Android system we will also need to store the encrypted data into Keystore so I will also implement the encryption and decryption function on Android based on React-native-ecc as well.