### PR TITLE
chore: Refactor protocol

### DIFF
--- a/src/screens/AccountList.js
+++ b/src/screens/AccountList.js
@@ -115,8 +115,6 @@ class AccountListView extends React.PureComponent {
     const hasNoAccount = accounts.length < 1;
     const { navigate } = navigation;
 
-    console.log('accounts',accounts);
-
     return (
       <View style={styles.body}>
         <Background />

--- a/src/screens/AccountList.js
+++ b/src/screens/AccountList.js
@@ -115,6 +115,8 @@ class AccountListView extends React.PureComponent {
     const hasNoAccount = accounts.length < 1;
     const { navigate } = navigation;
 
+    console.log('accounts',accounts);
+
     return (
       <View style={styles.body}>
         <Background />

--- a/src/screens/AccountNetworkChooser.js
+++ b/src/screens/AccountNetworkChooser.js
@@ -60,7 +60,7 @@ class AccountNetworkChooserView extends React.PureComponent {
               }
             ]}
             onPress={() => {
-              accounts.updateNew({ networkKey, protocol: networkParams.protocol });
+              accounts.updateNew({ networkKey });
               navigation.goBack();
             }}
           >

--- a/src/screens/SignedTx.js
+++ b/src/screens/SignedTx.js
@@ -26,7 +26,7 @@ import AccountCard from '../components/AccountCard';
 import PayloadDetailsCard from '../components/PayloadDetailsCard';
 import TxDetailsCard from '../components/TxDetailsCard';
 import QrView from '../components/QrView';
-import { NetworkProtocols, TX_DETAILS_MSG } from '../constants';
+import { NETWORK_LIST, NetworkProtocols, TX_DETAILS_MSG } from '../constants';
 import fonts from '../fonts';
 import AccountsStore from '../stores/AccountsStore';
 import ScannerStore from '../stores/ScannerStore';
@@ -71,7 +71,7 @@ export class SignedTxView extends React.PureComponent {
         </View>
         <Text style={styles.title}>TRANSACTION DETAILS</Text>
         {
-          sender.protocol === NetworkProtocols.ETHEREUM
+          NETWORK_LIST[sender.networkKey].protocol === NetworkProtocols.ETHEREUM
             ? (
               <React.Fragment>
                 <TxDetailsCard

--- a/src/screens/TxDetails.js
+++ b/src/screens/TxDetails.js
@@ -20,7 +20,9 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { ScrollView, StyleSheet, Text } from 'react-native';
 import { Subscribe } from 'unstated';
+
 import colors from '../colors';
+import { NETWORK_LIST } from '../constants';
 import fonts from "../fonts";
 import AccountCard from '../components/AccountCard';
 import Background from '../components/Background';
@@ -99,7 +101,7 @@ export class TxDetailsView extends React.PureComponent {
         <Text style={styles.title}>TRANSACTION DETAILS</Text>
 
         {
-          this.props.sender.protocol === NetworkProtocols.ETHEREUM
+          NETWORK_LIST[this.props.sender.networkKey].protocol === NetworkProtocols.ETHEREUM
             ? (
               <React.Fragment>
                 <TxDetailsCard

--- a/src/stores/ScannerStore.js
+++ b/src/stores/ScannerStore.js
@@ -195,7 +195,6 @@ export default class ScannerStore extends Container<ScannerState> {
     const networkKey = isEthereum ? tx.ethereumChainId : txRequest.data.data.genesisHash.toHex();
 
     const sender = accountsStore.getById({
-      protocol,
       networkKey,
       address: txRequest.data.account
     });
@@ -211,14 +210,13 @@ export default class ScannerStore extends Container<ScannerState> {
     }
 
     const recipient = accountsStore.getById({
-      protocol,
       networkKey: networkKey,
       address: isEthereum ? tx.action : txRequest.data.account
     });
 
     // For Eth, always sign the keccak hash.
     // For Substrate, only sign the blake2 hash if payload bytes length > 256 bytes (handled in decoder.js).
-    const dataToSign = sender.protocol === NetworkProtocols.ETHEREUM ? await keccak(txRequest.data.rlp) : txRequest.data.data;
+    const dataToSign = NETWORK_LIST[sender.networkKey].protocol === NetworkProtocols.ETHEREUM ? await keccak(txRequest.data.rlp) : txRequest.data.data;
 
     this.setState({
       type: 'transaction',
@@ -236,7 +234,7 @@ export default class ScannerStore extends Container<ScannerState> {
     const { isHash, sender, type } = this.state;
 
     const seed = await decryptData(sender.encryptedSeed, pin);
-    const isEthereum = sender.protocol === NetworkProtocols.ETHEREUM;
+    const isEthereum = NETWORK_LIST[sender.networkKey].protocol === NetworkProtocols.ETHEREUM;
 
     let signedData;
 


### PR DESCRIPTION
The property protocol is linked to a network, it should not be linked to an account directly (an account has a network key, which gives us the protocol).

- needed for https://github.com/paritytech/parity-signer/pull/352 so that I don't have to create a protocol property for new accounts.

Tested on Android for Eth and Polka Dev account