### PR TITLE
chore: show tab correctly

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,16 +1,18 @@
 root = true
+
 [*]
-indent_style=space
-indent_size=2
-tab_width=2
-end_of_line=lf
-charset=utf-8
-trim_trailing_whitespace=true
-max_line_length=120
-insert_final_newline=true
+indent_style = space
+indent_size = 2
+tab_width = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+max_line_length = 80
+insert_final_newline = true
 
 [*.plist]
-indent_style=tab
-indent_size=4
-tab_width=4
-end_of_line=lf
+indent_size = 4
+tab_width = 4
+
+[*.{js,jsx}]
+indent_style = tab


### PR DESCRIPTION
As we are using "tabs" instead of "spaces" on Javascript file, Github show the indentation of tab always as 4 spaces, it will make confusion when we check the diff on Github, especially for #337.