### PR TITLE
fix: some code fix catched by eslint

### DIFF
--- a/src/stores/ScannerStore.js
+++ b/src/stores/ScannerStore.js
@@ -97,7 +97,7 @@ export default class ScannerStore extends Container<ScannerState> {
     }
 
     if (parsedData.isMultipart) {
-      this.setPartData(parseData.frame, parsedData.frameCount, parseData.partData, accountsStore);
+      this.setPartData(parsedData.frame, parsedData.frameCount, parsedData.partData, accountsStore);
       return;
     }
 
@@ -198,7 +198,7 @@ export default class ScannerStore extends Container<ScannerState> {
       networkKey,
       address: txRequest.data.account
     });
-    
+
     const networkTitle = NETWORK_LIST[networkKey].title;
 
     if (!sender || !sender.encryptedSeed) {
@@ -240,7 +240,7 @@ export default class ScannerStore extends Container<ScannerState> {
 
     if (isEthereum) {
       signedData = await brainWalletSign(seed, this.state.dataToSign);
-      
+
     } else {
       let signable;
 
@@ -257,7 +257,7 @@ export default class ScannerStore extends Container<ScannerState> {
 
     this.setState({ signedData });
 
-    if (type == 'transaction') {
+    if (type === 'transaction') {
       await saveTx({
         hash: (isEthereum || isHash) ? this.state.dataToSign : await blake2s(this.state.dataToSign.toHex()),
         tx: this.state.tx,

--- a/src/util/array.js
+++ b/src/util/array.js
@@ -70,7 +70,6 @@ export function zip(left, right) {
       rindex += 1;
     } else {
       out[oindex] = lword;
-      result.push(lword);
       lindex += 1;
       rindex += 1;
     }

--- a/src/util/decoders.js
+++ b/src/util/decoders.js
@@ -136,7 +136,7 @@ export async function constructDataFromBytes(bytes) {
         if (action === 'signData') {
           data['data']['rlp'] = uosAfterFrames[13];
         } else if (action === 'signTransaction') {
-          data['data']['data'] = rawAfterFrames[13];
+          data['data']['data'] = uosAfterFrames[13];
         } else {
           throw new Error('Could not determine action type.');
         }
@@ -150,7 +150,7 @@ export async function constructDataFromBytes(bytes) {
           const publicKeyAsBytes = hexToU8a('0x' + pubKeyHex);
           const hexEncodedData = '0x' + uosAfterFrames.slice(70);
           const rawPayload = hexToU8a(hexEncodedData);
-          
+
           const isOversized = rawPayload.length > 256;
           const defaultPrefix = SUBSTRATE_NETWORK_LIST[SubstrateNetworkKeys.KUSAMA].prefix;
           let extrinsicPayload;
@@ -262,8 +262,8 @@ export function hexToAscii(hexBytes) {
 }
 
 export function isJsonString(str) {
-  if (!str) { 
-    return false; 
+  if (!str) {
+    return false;
   }
 
   try {
@@ -275,8 +275,8 @@ export function isJsonString(str) {
 }
 
 export function isAddressString(str) {
-  if (!str) { 
-    return false; 
+  if (!str) {
+    return false;
   }
 
   return str.substr(0, 2) === '0x' ||


### PR DESCRIPTION
As #337 includes so many file changes.

Here I cherrypicked some errors catched by ESLint, which could be merged earlier to prevent any bugs on V3.

1. The undefined value should be changed:
`parseData` -> `parsedData`
`rawAfterFrames` -> `uosAfterFrames`

2. One redundant line `result.push(lword);` should be deleted