### PR TITLE
fix: clear account state when changing network

### DIFF
--- a/src/screens/AccountBackup.js
+++ b/src/screens/AccountBackup.js
@@ -28,7 +28,7 @@ import Button from '../components/Button';
 import TouchableItem from '../components/TouchableItem';
 import DerivationPasswordVerify from '../components/DerivationPasswordVerify';
 import AccountsStore from '../stores/AccountsStore';
-import {NETWORK_LIST, NetworkProtocols} from "../constants";
+import { NetworkProtocols, NETWORK_LIST } from '../constants';
 
 
 export default class AccountBackup extends React.PureComponent {

--- a/src/screens/AccountBackup.js
+++ b/src/screens/AccountBackup.js
@@ -28,6 +28,7 @@ import Button from '../components/Button';
 import TouchableItem from '../components/TouchableItem';
 import DerivationPasswordVerify from '../components/DerivationPasswordVerify';
 import AccountsStore from '../stores/AccountsStore';
+import {NETWORK_LIST, NetworkProtocols} from "../constants";
 
 
 export default class AccountBackup extends React.PureComponent {
@@ -75,7 +76,8 @@ class AccountBackupView extends React.PureComponent {
     const {navigate} = navigation;
     const isNew = navigation.getParam('isNew');
     const {address, derivationPassword, derivationPath, name, networkKey, seed, seedPhrase} = isNew ? accounts.getNew() : accounts.getSelected();
-    
+    const {protocol} = NETWORK_LIST[networkKey];
+
     return (
       <ScrollView
         style={styles.body}
@@ -108,7 +110,11 @@ class AccountBackupView extends React.PureComponent {
                     text: 'Copy anyway',
                     style: 'default',
                     onPress: () => {
-                      Clipboard.setString(`${seedPhrase}${derivationPath}`);
+                      if (protocol === NetworkProtocols.SUBSTRATE) {
+                        Clipboard.setString(`${seedPhrase}${derivationPath}`);
+                      } else {
+                        Clipboard.setString(seed)
+                      }
                     }
                   },
                   {
@@ -117,7 +123,7 @@ class AccountBackupView extends React.PureComponent {
                   }
                 ]
               );
-            } 
+            }
           }}
         >
           <Text style={styles.seedText}>

--- a/src/screens/AccountNetworkChooser.js
+++ b/src/screens/AccountNetworkChooser.js
@@ -24,7 +24,7 @@ import fonts from "../fonts";
 import TouchableItem from '../components/TouchableItem';
 import { NETWORK_LIST } from '../constants';
 import AccountsStore from '../stores/AccountsStore';
-import { empty } from "../util/account";
+import { empty } from '../util/account';
 
 export default class AccountNetworkChooser extends React.PureComponent {
   static navigationOptions = {
@@ -61,7 +61,7 @@ class AccountNetworkChooserView extends React.PureComponent {
               }
             ]}
             onPress={() => {
-              accounts.updateNew({ ...empty(), networkKey });
+              accounts.updateNew({ ...empty('', networkKey) });
               navigation.goBack();
             }}
           >

--- a/src/screens/AccountNetworkChooser.js
+++ b/src/screens/AccountNetworkChooser.js
@@ -24,6 +24,7 @@ import fonts from "../fonts";
 import TouchableItem from '../components/TouchableItem';
 import { NETWORK_LIST } from '../constants';
 import AccountsStore from '../stores/AccountsStore';
+import { empty } from "../util/account";
 
 export default class AccountNetworkChooser extends React.PureComponent {
   static navigationOptions = {
@@ -45,7 +46,7 @@ class AccountNetworkChooserView extends React.PureComponent {
   render() {
     const { navigation } = this.props;
     const { accounts } = this.props;
-    
+
     return (
       <ScrollView style={styles.body} contentContainerStyle={{ padding: 20 }}>
         <Text style={styles.title}>CHOOSE NETWORK</Text>
@@ -60,7 +61,7 @@ class AccountNetworkChooserView extends React.PureComponent {
               }
             ]}
             onPress={() => {
-              accounts.updateNew({ networkKey });
+              accounts.updateNew({ ...empty(), networkKey });
               navigation.goBack();
             }}
           >


### PR DESCRIPTION
close #363 .

1. Clear the state when choosing the new network. (Which may cause more bugs if user switch network between Substrate and Ethereum).
2. Copy the seed when creating an Ethereum account in DEV mode. 

Fixed behaviour here:

![out](https://user-images.githubusercontent.com/6014309/64508799-1ec89c80-d293-11e9-96f5-ad20f8d7bb08.gif)
