### PR TITLE
feat: Show accounts with unknown network

### DIFF
--- a/src/components/AccountCard.js
+++ b/src/components/AccountCard.js
@@ -23,7 +23,7 @@ import { StyleSheet, Text, View, ViewPropTypes } from 'react-native';
 import AccountIcon from './AccountIcon';
 import Address from './Address';
 import colors from '../colors';
-import { NETWORK_LIST } from '../constants';
+import { NETWORK_LIST, NetworkProtocols } from '../constants';
 import fonts from '../fonts';
 import TouchableItem from './TouchableItem';
 
@@ -48,7 +48,7 @@ export default class AccountCard extends React.PureComponent {
     let { title } = this.props;
     title = title.length ? title : AccountCard.defaultProps.title;
     const seedTypeDisplay = seedType || '';
-    const network = NETWORK_LIST[networkKey];
+    const network = NETWORK_LIST[networkKey] || NETWORK_LIST[NetworkProtocols.UNKNOWN];
 
     return (
       <TouchableItem

--- a/src/components/AccountIcon.js
+++ b/src/components/AccountIcon.js
@@ -20,7 +20,9 @@ import Identicon from '@polkadot/reactnative-identicon';
 import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 import { Image } from 'react-native';
+import Icon from 'react-native-vector-icons/MaterialIcons';
 
+import colors from '../colors';
 import { NetworkProtocols } from '../constants'
 import { blockiesIcon } from '../util/native';
 
@@ -64,7 +66,14 @@ export default function AccountIcon (props) {
         style={style || { width: 47, height: 47 }}
       />
     );
+  } else {
+    // if there's no protocol or it's unknown we return a warning
+    return (
+      <Icon
+        color={colors.bg}
+        name={'error'}
+        size={style.width || 50 }
+      />
+    )
   }
-
-  return null;
 }

--- a/src/components/AccountSeed.js
+++ b/src/components/AccountSeed.js
@@ -21,7 +21,7 @@ import { StyleSheet, Text, View } from 'react-native';
 import colors from '../colors';
 import fonts from "../fonts";
 import PARITY_WORDS from '../../res/parity_wordlist.json';
-import BIP39_WORDS from '../../res/bip39_wordlist.json';;
+import BIP39_WORDS from '../../res/bip39_wordlist.json';
 import TextInput from './TextInput';
 import TouchableItem from './TouchableItem';
 import { binarySearch } from '../util/array';

--- a/src/constants.js
+++ b/src/constants.js
@@ -23,11 +23,7 @@ export const EthereumNetworkKeys = Object.freeze({
 
 // genesisHash is used as Network key for Substrate networks
 export const SubstrateNetworkKeys = Object.freeze({
-<<<<<<< HEAD
-  KUSAMA: '0x61a39861e787b41a2b14268c8ec14d36bc6182d591c160dbc2f378ad224d802c', // https://polkascan.io/pre/kusama/block/0
-=======
   KUSAMA: '0xe3777fa922cafbff200cadeaea1a76bd7898ad5b89f7848999058b50e715f636', // https://polkascan.io/pre/kusama-cc2/block/0
->>>>>>> master
   // SUBSTRATE_DEV: '0x4393a679e1830a487e8ae92733f089a80f3e24ba515b08dd8adb40fc6cedee8d', // substrate --dev commit ac6a2a783f0e1f4a814cf2add40275730cd41be1 hosted on wss://dev-node.substrate.dev .
 });
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,7 +2,13 @@ import colors from './colors';
 
 export const NetworkProtocols = Object.freeze({
   ETHEREUM: 'ethereum',
-  SUBSTRATE: 'substrate'
+  SUBSTRATE: 'substrate',
+  UNKNOWN: 'unknown'
+});
+
+// accounts for which the network couldn't be found (failed migration, removed network)
+export const UnKnownNetworkKeys = Object.freeze({
+  UNKNOWN: 'unknown'
 });
 
 // ethereumChainId is used as Network key for Ethereum networks
@@ -17,9 +23,18 @@ export const EthereumNetworkKeys = Object.freeze({
 
 // genesisHash is used as Network key for Substrate networks
 export const SubstrateNetworkKeys = Object.freeze({
-  KUSAMA: '0x3fd7b9eb6a00376e5be61f01abb429ffb0b104be05eaff4d458da48fcd425baf', // https://polkascan.io/pre/kusama/block/0
+  KUSAMA: '0x61a39861e787b41a2b14268c8ec14d36bc6182d591c160dbc2f378ad224d802c', // https://polkascan.io/pre/kusama/block/0
   // SUBSTRATE_DEV: '0x4393a679e1830a487e8ae92733f089a80f3e24ba515b08dd8adb40fc6cedee8d', // substrate --dev commit ac6a2a783f0e1f4a814cf2add40275730cd41be1 hosted on wss://dev-node.substrate.dev .
 });
+
+const unknownNetworkBase = {
+  [UnKnownNetworkKeys.UNKNOWN]: {
+    color: colors.bg_alert,
+    protocol: NetworkProtocols.UNKNOWN,
+    secondaryColor: colors.card_bg,
+    title: 'Unknown network'
+  }
+}
 
 const substrateNetworkBase = {
   [SubstrateNetworkKeys.KUSAMA]: {
@@ -101,8 +116,10 @@ function setDefault(networkBase, defaultProps) {
 
 export const ETHEREUM_NETWORK_LIST = Object.freeze(setDefault(ethereumNetworkBase, ethereumDefaultValues));
 export const SUBSTRATE_NETWORK_LIST = Object.freeze(setDefault(substrateNetworkBase, substrateDefaultValues));
+export const UNKNOWN_NETWORK = Object.freeze(unknownNetworkBase);
+
 export const NETWORK_LIST = Object.freeze(
-  Object.assign({}, SUBSTRATE_NETWORK_LIST, ETHEREUM_NETWORK_LIST)
+  Object.assign({}, SUBSTRATE_NETWORK_LIST, ETHEREUM_NETWORK_LIST, UNKNOWN_NETWORK)
 );
 
 export const TX_DETAILS_MSG = "After signing and publishing you will have sent";

--- a/src/screens/AccountBackup.js
+++ b/src/screens/AccountBackup.js
@@ -76,7 +76,7 @@ class AccountBackupView extends React.PureComponent {
     const {navigate} = navigation;
     const isNew = navigation.getParam('isNew');
     const {address, derivationPassword, derivationPath, name, networkKey, seed, seedPhrase} = isNew ? accounts.getNew() : accounts.getSelected();
-    const protocol = NETWORK_LIST[networkKey].protocol || '';
+    const protocol = NETWORK_LIST[networkKey] && NETWORK_LIST[networkKey].protocol || '';
 
     return (
       <ScrollView

--- a/src/screens/AccountBackup.js
+++ b/src/screens/AccountBackup.js
@@ -62,10 +62,10 @@ class AccountBackupView extends React.PureComponent {
 
   componentWillUnmount() {
     const {accounts} = this.props;
-    const selected = accounts.getSelected();
+    const selectedKey = accounts.getSelectedKey();
 
-    if (selected) {
-      accounts.lockAccount(selected);
+    if (selectedKey) {
+      accounts.lockAccount(selectedKey);
     }
 
     AppState.removeEventListener('change', this._handleAppStateChange);

--- a/src/screens/AccountBackup.js
+++ b/src/screens/AccountBackup.js
@@ -76,7 +76,7 @@ class AccountBackupView extends React.PureComponent {
     const {navigate} = navigation;
     const isNew = navigation.getParam('isNew');
     const {address, derivationPassword, derivationPath, name, networkKey, seed, seedPhrase} = isNew ? accounts.getNew() : accounts.getSelected();
-    const {protocol} = NETWORK_LIST[networkKey];
+    const protocol = NETWORK_LIST[networkKey].protocol || '';
 
     return (
       <ScrollView

--- a/src/screens/AccountDetails.js
+++ b/src/screens/AccountDetails.js
@@ -104,7 +104,7 @@ This account can only be recovered with its associated recovery phrase.`,
     return (
       <View style={styles.warningView}>
         <Text style={{...styles.title, ...styles.warningTitle}}>Warning</Text>
-        <Text style={styles.warning}>
+        <Text>
           This account wasn't retrieved successfully. This could be because its network isn't supported,
           or you upgraded Parity Signer without wiping your device and this account couldn't be migrated.
           {'\n'}{'\n'}

--- a/src/screens/AccountDetails.js
+++ b/src/screens/AccountDetails.js
@@ -56,11 +56,11 @@ class AccountDetailsView extends React.Component {
     super(props);
   }
 
-  componentDidMount() {
-    this.subscription = this.props.navigation.addListener('willFocus', t => {
-      this.props.txStore.loadTxsForAccount(this.props.accounts.getSelected());
-    });
-  }
+  // componentDidMount() {
+  //   this.subscription = this.props.navigation.addListener('willFocus', t => {
+  //     this.props.txStore.loadTxsForAccount(this.props.accounts.getSelected());
+  //   });
+  // }
 
   onDelete = () => {
     const accounts = this.props.accounts
@@ -92,9 +92,9 @@ This account can only be recovered with its associated recovery phrase.`,
     );
   }
 
-  componentWillUnmount() {
-    this.subscription.remove();
-  }
+  // componentWillUnmount() {
+  //   this.subscription.remove();
+  // }
 
   onOptionSelect = (value) => {
     const navigate = this.props.navigation.navigate
@@ -127,7 +127,6 @@ This account can only be recovered with its associated recovery phrase.`,
   }
 
   render() {
-    console.log('render account details');
     const account = this.props.accounts.getSelected();
 
     if (!account) {

--- a/src/screens/AccountDetails.js
+++ b/src/screens/AccountDetails.js
@@ -155,8 +155,8 @@ This account can only be recovered with its associated recovery phrase.`,
         <View style={styles.qr}>
           {
             protocol !== NetworkProtocols.UNKNOWN
-            ? <QrView data={selectedKey} />
-            : this.renderWarningUnknownAccount()
+              ? <QrView data={selectedKey} />
+              : this.renderWarningUnknownAccount()
           }
         </View>
       </ScrollView>

--- a/src/screens/AccountDetails.js
+++ b/src/screens/AccountDetails.js
@@ -18,6 +18,7 @@
 
 import React from 'react';
 import { Alert, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { NavigationActions, StackActions } from 'react-navigation';
 import { Subscribe } from 'unstated';
 
 import colors from '../colors';
@@ -28,6 +29,7 @@ import AccountsStore from '../stores/AccountsStore';
 import TxStore from '../stores/TxStore';
 import { accountId } from '../util/account';
 import PopupMenu from '../components/PopupMenu'
+import { NETWORK_LIST, NetworkProtocols } from '../constants';
 
 export default class AccountDetails extends React.Component {
   static navigationOptions = {
@@ -67,7 +69,7 @@ class AccountDetailsView extends React.Component {
 
     Alert.alert(
       'Delete Account',
-      `Do you really want to delete ${selected.name || selected.address}?
+      `Do you really want to delete ${selected.name || selected.address || 'this account'}?
 This account can only be recovered with its associated recovery phrase.`,
       [
         {
@@ -75,7 +77,12 @@ This account can only be recovered with its associated recovery phrase.`,
           style: 'destructive',
           onPress: () => {
             accounts.deleteAccount(selected);
-            this.props.navigation.navigate('AccountList');
+            const resetAction = StackActions.reset({
+              index: 0,
+              key: undefined, // FIXME workaround for now, use SwitchNavigator later: https://github.com/react-navigation/react-navigation/issues/1127#issuecomment-295841343
+              actions: [NavigationActions.navigate({ routeName: 'AccountList' })]
+            });
+            this.props.navigation.dispatch(resetAction);
           }
         },
         {
@@ -103,12 +110,32 @@ This account can only be recovered with its associated recovery phrase.`,
     }
   }
 
+  renderWarningUnknownAccount = function () {
+    return (
+      <View style={styles.warningView}>
+        <Text style={{...styles.title, ...styles.warningTitle}}>Warning</Text>
+        <Text style={styles.warning}>
+          This account wasn't retrieved successfully. This could be because its network isn't supported,
+          or you upgraded Parity Signer without wiping your device and this account couldn't be migrated.
+          {'\n'}{'\n'}
+          To be able to use this account you need to:{'\n'}
+          - write down its recovery phrase{'\n'}
+          - delete it{'\n'}
+          - recover it{'\n'}
+        </Text>
+      </View>
+    )
+  }
+
   render() {
+    console.log('render account details');
     const account = this.props.accounts.getSelected();
 
     if (!account) {
       return null;
     }
+
+    const protocol = account.networkKey && NETWORK_LIST[account.networkKey] && NETWORK_LIST[account.networkKey].protocol || NetworkProtocols.UNKNOWN ;
 
     return (
       <ScrollView
@@ -135,7 +162,11 @@ This account can only be recovered with its associated recovery phrase.`,
           title={account.name}
         />
         <View style={styles.qr}>
-          <QrView data={accountId(account)} />
+          {
+            protocol !== NetworkProtocols.UNKNOWN
+            ? <QrView data={accountId(account)} />
+            : this.renderWarningUnknownAccount()
+          }
         </View>
       </ScrollView>
     );
@@ -157,7 +188,7 @@ const styles = StyleSheet.create({
     backgroundColor: colors.card_bg
   },
   deleteText: {
-    color: 'red'
+    color: colors.bg_alert
   },
   header: {
     flexDirection: 'row',
@@ -169,12 +200,19 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: 'flex-end',
   },
-
   title: {
     color: colors.bg_text_sec,
     fontSize: 18,
     fontFamily: fonts.bold,
     flexDirection: 'column',
     justifyContent: 'center',
+  },
+  warningTitle: {
+    color: colors.bg_alert,
+    fontSize: 20,
+    marginBottom: 10
+  },
+  warningView: {
+    padding: 20
   }
 });

--- a/src/screens/AccountDetails.js
+++ b/src/screens/AccountDetails.js
@@ -27,7 +27,6 @@ import AccountCard from '../components/AccountCard';
 import QrView from '../components/QrView';
 import AccountsStore from '../stores/AccountsStore';
 import TxStore from '../stores/TxStore';
-import { accountId } from '../util/account';
 import PopupMenu from '../components/PopupMenu'
 import { NETWORK_LIST, NetworkProtocols } from '../constants';
 
@@ -164,7 +163,7 @@ This account can only be recovered with its associated recovery phrase.`,
         <View style={styles.qr}>
           {
             protocol !== NetworkProtocols.UNKNOWN
-            ? <QrView data={accountId(account)} />
+            ? <QrView data={account.dbKey} />
             : this.renderWarningUnknownAccount()
           }
         </View>

--- a/src/screens/AccountDetails.js
+++ b/src/screens/AccountDetails.js
@@ -56,12 +56,6 @@ class AccountDetailsView extends React.Component {
     super(props);
   }
 
-  // componentDidMount() {
-  //   this.subscription = this.props.navigation.addListener('willFocus', t => {
-  //     this.props.txStore.loadTxsForAccount(this.props.accounts.getSelected());
-  //   });
-  // }
-
   onDelete = () => {
     const accounts = this.props.accounts
     const selected = accounts.getSelected();
@@ -92,10 +86,6 @@ This account can only be recovered with its associated recovery phrase.`,
       ]
     );
   }
-
-  // componentWillUnmount() {
-  //   this.subscription.remove();
-  // }
 
   onOptionSelect = (value) => {
     const navigate = this.props.navigation.navigate

--- a/src/screens/AccountDetails.js
+++ b/src/screens/AccountDetails.js
@@ -65,6 +65,7 @@ class AccountDetailsView extends React.Component {
   onDelete = () => {
     const accounts = this.props.accounts
     const selected = accounts.getSelected();
+    const selectedKey = accounts.getSelectedKey();
 
     Alert.alert(
       'Delete Account',
@@ -75,7 +76,7 @@ This account can only be recovered with its associated recovery phrase.`,
           text: 'Delete',
           style: 'destructive',
           onPress: () => {
-            accounts.deleteAccount(selected);
+            accounts.deleteAccount(selectedKey);
             const resetAction = StackActions.reset({
               index: 0,
               key: undefined, // FIXME workaround for now, use SwitchNavigator later: https://github.com/react-navigation/react-navigation/issues/1127#issuecomment-295841343
@@ -127,7 +128,9 @@ This account can only be recovered with its associated recovery phrase.`,
   }
 
   render() {
-    const account = this.props.accounts.getSelected();
+    const { accounts } = this.props
+    const account = accounts.getSelected();
+    const selectedKey = accounts.getSelectedKey();
 
     if (!account) {
       return null;
@@ -162,7 +165,7 @@ This account can only be recovered with its associated recovery phrase.`,
         <View style={styles.qr}>
           {
             protocol !== NetworkProtocols.UNKNOWN
-            ? <QrView data={account.dbKey} />
+            ? <QrView data={selectedKey} />
             : this.renderWarningUnknownAccount()
           }
         </View>

--- a/src/screens/AccountEdit.js
+++ b/src/screens/AccountEdit.js
@@ -60,7 +60,7 @@ export default class AccountEdit extends React.PureComponent {
               <TextInput
                 style={{ marginBottom: 40 }}
                 onChangeText={async (name) => {
-                  accounts.updateSelected({ name });
+                  accounts.updateSelectedAccount({ name });
                   await accounts.save(accounts.getSelected())
                 }}
                 value={selected.name}

--- a/src/screens/AccountEdit.js
+++ b/src/screens/AccountEdit.js
@@ -61,7 +61,7 @@ export default class AccountEdit extends React.PureComponent {
                 style={{ marginBottom: 40 }}
                 onChangeText={async (name) => {
                   accounts.updateSelectedAccount({ name });
-                  await accounts.save(accounts.getSelected())
+                  await accounts.save(accounts.getSelectedKey(), accounts.getSelected())
                 }}
                 value={selected.name}
                 placeholder="New name"

--- a/src/screens/AccountList.js
+++ b/src/screens/AccountList.js
@@ -43,8 +43,8 @@ export default class AccountList extends React.PureComponent {
             <AccountListView
               {...this.props}
               accounts={accounts.getAccounts()}
-              onAccountSelected={async account => {
-                await accounts.select(account);
+              onAccountSelected={key => {
+                accounts.select(key);
                 this.props.navigation.navigate('AccountDetails');
               }}
             />
@@ -57,11 +57,7 @@ export default class AccountList extends React.PureComponent {
 
 class AccountListView extends React.PureComponent {
   static propTypes = {
-    accounts: PropTypes.arrayOf(
-      PropTypes.shape({
-        address: PropTypes.string.isRequired,
-      })
-    ).isRequired,
+    accounts: PropTypes.object.isRequired,
     onAccountSelected: PropTypes.func.isRequired,
   };
 
@@ -112,8 +108,8 @@ class AccountListView extends React.PureComponent {
   render() {
     const { accounts, navigation, onAccountSelected } = this.props;
     const hasNoAccount = accounts.length < 1;
-    const { navigate } = navigation;
-
+    const { navigate } = navigation;;
+console.log('account list',accounts)
     return (
       <View style={styles.body}>
         <Background />
@@ -142,13 +138,13 @@ class AccountListView extends React.PureComponent {
           ItemSeparatorComponent={() => <View style={{ height: 20 }} />}
           renderItem={({ item: [key, value] }) => {
             const account = value;
-            console.log('key',key,'value',value)
+            // console.log('key',key,'value',value)
             return (
               <AccountCard
                 address={account.address}
                 networkKey={account.networkKey}
                 onPress={() => {
-                  onAccountSelected(account);
+                  onAccountSelected(key);
                 }}
                 style={{ paddingBottom: null }}
                 title={account.name}

--- a/src/screens/AccountList.js
+++ b/src/screens/AccountList.js
@@ -87,7 +87,7 @@ class AccountListView extends React.PureComponent {
   render() {
     const { accounts, navigation, onAccountSelected } = this.props;
     const hasNoAccount = accounts.length < 1;
-    const { navigate } = navigation;;
+    const { navigate } = navigation;
 
     return (
       <View style={styles.body}>

--- a/src/screens/AccountList.js
+++ b/src/screens/AccountList.js
@@ -88,7 +88,7 @@ class AccountListView extends React.PureComponent {
     const { accounts, navigation, onAccountSelected } = this.props;
     const hasNoAccount = accounts.length < 1;
     const { navigate } = navigation;;
-console.log('account list',accounts)
+
     return (
       <View style={styles.body}>
         <Background />
@@ -113,17 +113,15 @@ console.log('account list',accounts)
           }}
           style={styles.content}
           data={[...accounts.entries()]}
-          keyExtractor={([key, value]) => key}
+          keyExtractor={([key]) => key}
           ItemSeparatorComponent={() => <View style={{ height: 20 }} />}
-          renderItem={({ item: [key, value] }) => {
-            const account = value;
-            // console.log('key',key,'value',value)
+          renderItem={({ item: [accountKey, account] }) => {
             return (
               <AccountCard
                 address={account.address}
                 networkKey={account.networkKey}
                 onPress={() => {
-                  onAccountSelected(key);
+                  onAccountSelected(accountKey);
                 }}
                 style={{ paddingBottom: null }}
                 title={account.name}

--- a/src/screens/AccountList.js
+++ b/src/screens/AccountList.js
@@ -28,7 +28,6 @@ import Button from '../components/Button';
 import PopupMenu from '../components/PopupMenu';
 import fonts from "../fonts";
 import AccountsStore from '../stores/AccountsStore';
-import { accountId } from '../util/account';
 
 export default class AccountList extends React.PureComponent {
   static navigationOptions = {
@@ -75,7 +74,7 @@ class AccountListView extends React.PureComponent {
     const { accounts, navigation } = this.props;
     const id = navigation.getParam('accountId');
     const index = id
-      ? accounts.findIndex(a => id === accountId(a))
+      ? accounts.findIndex(a => id === a.dbKey)
       : navigation.getParam('index', -1);
     if (this.list && typeof index === 'number' && index !== -1) {
       navigation.setParams({ accountId: undefined, index: undefined });
@@ -139,7 +138,7 @@ class AccountListView extends React.PureComponent {
           }}
           style={styles.content}
           data={accounts}
-          keyExtractor={account => accountId(account)}
+          keyExtractor={account => account.dbKey}
           ItemSeparatorComponent={() => <View style={{ height: 20 }} />}
           renderItem={({ item: account }) => {
             return (

--- a/src/screens/AccountList.js
+++ b/src/screens/AccountList.js
@@ -43,8 +43,8 @@ export default class AccountList extends React.PureComponent {
             <AccountListView
               {...this.props}
               accounts={accounts.getAccounts()}
-              onAccountSelected={async address => {
-                await accounts.select(address);
+              onAccountSelected={async account => {
+                await accounts.select(account);
                 this.props.navigation.navigate('AccountDetails');
               }}
             />

--- a/src/screens/AccountList.js
+++ b/src/screens/AccountList.js
@@ -63,27 +63,6 @@ class AccountListView extends React.PureComponent {
 
   constructor(props) {
     super(props);
-    this.scrollToIndex = this.scrollToIndex.bind(this);
-  }
-
-  scrollToIndex() {
-    const { accounts, navigation } = this.props;
-    const id = navigation.getParam('accountId');
-    const index = id
-      ? accounts.findIndex(a => id === a.dbKey)
-      : navigation.getParam('index', -1);
-    if (this.list && typeof index === 'number' && index !== -1) {
-      navigation.setParams({ accountId: undefined, index: undefined });
-      this.list.scrollToIndex({ index });
-    }
-  }
-
-  componentDidMount() {
-    this.scrollToIndex();
-  }
-
-  componentDidUpdate() {
-    this.scrollToIndex();
   }
 
   showOnboardingMessage = () => {

--- a/src/screens/AccountList.js
+++ b/src/screens/AccountList.js
@@ -137,10 +137,12 @@ class AccountListView extends React.PureComponent {
             this.list = list;
           }}
           style={styles.content}
-          data={accounts}
-          keyExtractor={account => account.dbKey}
+          data={[...accounts.entries()]}
+          keyExtractor={([key, value]) => key}
           ItemSeparatorComponent={() => <View style={{ height: 20 }} />}
-          renderItem={({ item: account }) => {
+          renderItem={({ item: [key, value] }) => {
+            const account = value;
+            console.log('key',key,'value',value)
             return (
               <AccountCard
                 address={account.address}

--- a/src/screens/AccountNetworkChooser.js
+++ b/src/screens/AccountNetworkChooser.js
@@ -22,7 +22,7 @@ import { Subscribe } from 'unstated';
 import colors from '../colors';
 import fonts from "../fonts";
 import TouchableItem from '../components/TouchableItem';
-import { NETWORK_LIST, UnKnownNetworkKeys } from '../constants';
+import { NETWORK_LIST, UnknownNetworkKeys } from '../constants';
 import AccountsStore from '../stores/AccountsStore';
 import { empty } from '../util/account';
 

--- a/src/screens/AccountNetworkChooser.js
+++ b/src/screens/AccountNetworkChooser.js
@@ -22,7 +22,7 @@ import { Subscribe } from 'unstated';
 import colors from '../colors';
 import fonts from "../fonts";
 import TouchableItem from '../components/TouchableItem';
-import { NETWORK_LIST } from '../constants';
+import { NETWORK_LIST, UnKnownNetworkKeys } from '../constants';
 import AccountsStore from '../stores/AccountsStore';
 import { empty } from '../util/account';
 
@@ -50,32 +50,34 @@ class AccountNetworkChooserView extends React.PureComponent {
     return (
       <ScrollView style={styles.body} contentContainerStyle={{ padding: 20 }}>
         <Text style={styles.title}>CHOOSE NETWORK</Text>
-        { Object.entries(NETWORK_LIST).map(([networkKey, networkParams]) => (
-          <TouchableItem
-            key={networkKey}
-            style={[
-              styles.card,
-              {
-                marginTop: 20,
-                backgroundColor: networkParams.color
-              }
-            ]}
-            onPress={() => {
-              accounts.updateNew(empty('', networkKey));
-              navigation.goBack();
-            }}
-          >
-            <Text
+        { Object.entries(NETWORK_LIST)
+          .filter(([networkKey]) => networkKey !== UnKnownNetworkKeys.UNKNOWN )
+          .map(([networkKey, networkParams]) => (
+            <TouchableItem
+              key={networkKey}
               style={[
-                styles.cardText,
+                styles.card,
                 {
-                  color: networkParams.secondaryColor
+                  marginTop: 20,
+                  backgroundColor: networkParams.color
                 }
               ]}
+              onPress={() => {
+                accounts.updateNew(empty('', networkKey));
+                navigation.goBack();
+              }}
             >
-              {networkParams.title}
-            </Text>
-          </TouchableItem>
+              <Text
+                style={[
+                  styles.cardText,
+                  {
+                    color: networkParams.secondaryColor
+                  }
+                ]}
+              >
+                {networkParams.title}
+              </Text>
+            </TouchableItem>
         ))}
       </ScrollView>
     );

--- a/src/screens/AccountPin.js
+++ b/src/screens/AccountPin.js
@@ -68,7 +68,7 @@ class AccountPinView extends React.PureComponent {
         });
         this.props.navigation.dispatch(resetAction);
       } else {
-        await accounts.save(account, pin);
+        await accounts.save(accounts.getSelectedKey(), account, pin);
         const resetAction = StackActions.reset({
           index: 1,
           key: undefined, // FIXME workaround for now, use SwitchNavigator later: https://github.com/react-navigation/react-navigation/issues/1127#issuecomment-295841343

--- a/src/screens/AccountUnlock.js
+++ b/src/screens/AccountUnlock.js
@@ -76,7 +76,7 @@ export class AccountUnlock extends React.Component {
           <AccountUnlockView
             {...this.props}
             checkPin={async pin => {
-              return await accounts.unlockAccount(accounts.getSelected(), pin);
+              return await accounts.unlockAccount(accounts.getSelectedKey(), pin);
             }}
             navigate={() => {
               if (next === 'AccountDelete') {

--- a/src/screens/Loading.js
+++ b/src/screens/Loading.js
@@ -93,6 +93,7 @@ export default class Loading extends React.PureComponent {
     
     accounts.forEach(account => {
       try{
+        // will break, needs accountKey
         saveAccount(account);
       } catch(e){
         console.error(e);

--- a/src/screens/Loading.js
+++ b/src/screens/Loading.js
@@ -70,8 +70,7 @@ export default class Loading extends React.PureComponent {
     // networkKey property is missing since it was introduced in v3.
     const oldAccounts_v2 = await loadAccounts(2);
     const oldAccounts = [...oldAccounts_v1, ...oldAccounts_v2];
-
-      const accounts = oldAccounts.map(([_,value]) => {
+    const accounts = oldAccounts.map(([_,value]) => {
       let result = {}
       if (value.chainId) {
         // The networkKey for Ethereum accounts is the chain id
@@ -81,7 +80,7 @@ export default class Loading extends React.PureComponent {
       }
       return result
     })
-    
+  
     accounts.forEach(account => {
       try{
         saveAccount(accountId(account), account);

--- a/src/screens/Loading.js
+++ b/src/screens/Loading.js
@@ -62,6 +62,7 @@ export default class Loading extends React.PureComponent {
   }
 
   async migrateAccounts() {
+    //FIXME NOW THIS WILL BREAK
     const oldAccounts_v1 = await loadAccounts(1);
     // v2 (up to v2.2.2) are only ethereum accounts 
     // with now deprectaded `chainId` and `networkType: 'ethereum'` properties

--- a/src/screens/Loading.js
+++ b/src/screens/Loading.js
@@ -22,6 +22,7 @@ import { NavigationActions, StackActions } from 'react-navigation';
 
 import colors from '../colors';
 import { loadAccounts, loadToCAndPPConfirmation, saveAccount } from '../util/db';
+import { object } from 'prop-types';
 
 export default class Loading extends React.PureComponent {
   static navigationOptions = {
@@ -68,8 +69,19 @@ export default class Loading extends React.PureComponent {
     // with now deprectaded `chainId` and `networkType: 'ethereum'` properties
     // networkKey property is missing since it was introduced in v3.
     const oldAccounts_v2 = await loadAccounts(2);
-    const oldAccounts = [...oldAccounts_v1, ...oldAccounts_v2]
-    const accounts = oldAccounts.map(a => {
+    const oldAccounts = new Map([...oldAccounts_v1, ...oldAccounts_v2]);
+
+    // let accountMap = new Map();
+    // for (let [key, value] of Object.entries(oldAccounts)) {
+    //   let account = JSON.parse(value)
+    //   // The networkKey for Ethereum accounts is the chain id
+    //   account = {...account, networkKey: a.chainId, recovered: true}
+    //   delete account.chainId;
+    //   delete account.networkType;
+    //   accountMap.set(key,account)
+    // }
+
+    const accounts = Object.values(oldAccounts).map(a => {
       let result = {}
       if (a.chainId) {
         // The networkKey for Ethereum accounts is the chain id

--- a/src/screens/Loading.js
+++ b/src/screens/Loading.js
@@ -22,7 +22,6 @@ import { NavigationActions, StackActions } from 'react-navigation';
 
 import colors from '../colors';
 import { loadAccounts, loadToCAndPPConfirmation, saveAccount } from '../util/db';
-import { object } from 'prop-types';
 
 export default class Loading extends React.PureComponent {
   static navigationOptions = {
@@ -81,7 +80,7 @@ export default class Loading extends React.PureComponent {
     //   accountMap.set(key,account)
     // }
 
-      const accounts = oldAccounts.entries(([_,value]) => {
+      const accounts = Object.entries(oldAccounts).map(([_,value]) => {
       let result = {}
       if (value.chainId) {
         // The networkKey for Ethereum accounts is the chain id

--- a/src/screens/Loading.js
+++ b/src/screens/Loading.js
@@ -69,7 +69,7 @@ export default class Loading extends React.PureComponent {
     // with now deprectaded `chainId` and `networkType: 'ethereum'` properties
     // networkKey property is missing since it was introduced in v3.
     const oldAccounts_v2 = await loadAccounts(2);
-    const oldAccounts = [...oldAccounts_v1, ...oldAccounts_v2];
+    const oldAccounts = {...oldAccounts_v1, ...oldAccounts_v2};
 
     // let accountMap = new Map();
     // for (let [key, value] of Object.entries(oldAccounts)) {
@@ -81,7 +81,7 @@ export default class Loading extends React.PureComponent {
     //   accountMap.set(key,account)
     // }
 
-      const accounts = oldAccounts.map(([_,value]) => {
+      const accounts = oldAccounts.entries(([_,value]) => {
       let result = {}
       if (value.chainId) {
         // The networkKey for Ethereum accounts is the chain id

--- a/src/screens/Loading.js
+++ b/src/screens/Loading.js
@@ -69,7 +69,7 @@ export default class Loading extends React.PureComponent {
     // with now deprectaded `chainId` and `networkType: 'ethereum'` properties
     // networkKey property is missing since it was introduced in v3.
     const oldAccounts_v2 = await loadAccounts(2);
-    const oldAccounts = new Map([...oldAccounts_v1, ...oldAccounts_v2]);
+    const oldAccounts = [...oldAccounts_v1, ...oldAccounts_v2];
 
     // let accountMap = new Map();
     // for (let [key, value] of Object.entries(oldAccounts)) {
@@ -81,17 +81,17 @@ export default class Loading extends React.PureComponent {
     //   accountMap.set(key,account)
     // }
 
-    const accounts = Object.values(oldAccounts).map(a => {
+      const accounts = oldAccounts.map(([_,value]) => {
       let result = {}
-      if (a.chainId) {
+      if (value.chainId) {
         // The networkKey for Ethereum accounts is the chain id
-        result = { ...a, networkKey: a.chainId, recovered: true };
+        result = { ...value, networkKey: value.chainId, recovered: true };
         delete result.chainId;
         delete result.networkType;
       }
       return result
     })
-
+    
     accounts.forEach(account => {
       try{
         saveAccount(account);

--- a/src/screens/MessageDetails.js
+++ b/src/screens/MessageDetails.js
@@ -81,7 +81,7 @@ export class MessageDetailsView extends React.PureComponent {
   };
 
   render() {
-    const {dataToSign, isHash, message, onNext, sender} = this.props;
+    const { dataToSign, isHash, message, onNext, sender} = this.props;
 
     return (
       <ScrollView

--- a/src/screens/MessageDetails.js
+++ b/src/screens/MessageDetails.js
@@ -51,10 +51,6 @@ export default class MessageDetails extends React.PureComponent {
                 message={isU8a(message) ? u8aToHex(message) : message}
                 dataToSign={isU8a(dataToSign) ? u8aToHex(dataToSign) : dataToSign}
                 isHash={scannerStore.getIsHash()}
-                onPressAccount={async account => {
-                  await accounts.select(account);
-                  this.props.navigation.navigate('AccountDetails');
-                }}
                 onNext={async () => {
                   try {
                     this.props.navigation.navigate('AccountUnlockAndSign', {
@@ -85,7 +81,7 @@ export class MessageDetailsView extends React.PureComponent {
   };
 
   render() {
-    const {dataToSign, isHash, message, onNext, onPressAccount, sender} = this.props;
+    const {dataToSign, isHash, message, onNext, sender} = this.props;
 
     return (
       <ScrollView
@@ -99,9 +95,6 @@ export class MessageDetailsView extends React.PureComponent {
           title={sender.name}
           address={sender.address}
           networkKey={sender.networkKey}
-          onPress={() => {
-            onPressAccount(sender);
-          }}
         />
         <Text style={styles.title}>MESSAGE</Text>
         <Text style={styles.message}>

--- a/src/stores/AccountsStore.js
+++ b/src/stores/AccountsStore.js
@@ -205,18 +205,6 @@ export default class AccountsStore extends Container {
   }
 
   getAccounts() {
-    // console.log('this.state.accounts',this.state.accounts)
     return this.state.accounts
-    // return Array.from(this.state.accounts.values())
-    //   .filter(a => !!a.networkKey)
-    //   .sort((a, b) => {
-    //     if (a.name < b.name) {
-    //       return -1;
-    //     }
-    //     if (a.name > b.name) {
-    //       return 1;
-    //     }
-    //     return 0;
-    //   });
   }
 }

--- a/src/stores/AccountsStore.js
+++ b/src/stores/AccountsStore.js
@@ -26,7 +26,6 @@ import { decryptData, encryptData } from '../util/native';
 export type Account = {
   address: string,
   createdAt: number,
-  dbKey: string, // this is the key that is used in the db to save / delete.
   derivationPassword: string,
   derivationPath: string, // doesn't contain the ///password
   encryptedSeed: string,
@@ -75,7 +74,6 @@ export default class AccountsStore extends Container {
     // only save a new account if the seed isn't empty
     if (account.seed) {
       await this.save(account, pin);
-      account.dbKey = accountId(account);
       this.setState({
         accounts: this.state.accounts.set(accountId(account), account),
         newAccount: empty()
@@ -90,9 +88,6 @@ export default class AccountsStore extends Container {
     if (account && updatedAccount) {
       this.setState({ accounts: accounts.set(accountKey, {...account, ...updatedAccount}) });
     }
-    // debugger;
-    // Object.assign(account, accountUpdate);
-    // this.setState({});
   }
 
   updateSelectedAccount(updatedAccount) {
@@ -100,23 +95,7 @@ export default class AccountsStore extends Container {
   }
 
   async refreshList() {
-    // loadAccounts().then(accounts => {
-        // .then(accounts =>
-        // Object.values(accounts).map(account => JSON.parse(account))
-        // );
-
-        // let accounts = new Map();
-        // for (let [key, value] of Object.entries(res)) {
-        //   const account = JSON.parse(value)
-        //   accounts.set(key, {...account, dbKey: key})
-        // }
-
-      // const accounts = Object.entries(res).map(() => {
-      //   new Map(res.map(a => [accountId(a), a]));
-      // }) 
     loadAccounts().then(accounts => {
-      // const accounts = new Map(res.map(a => [accountId(a), a]));
-      // console.log('accounts refreshList',accounts)
       this.setState({ accounts });
     });
   }
@@ -138,12 +117,12 @@ export default class AccountsStore extends Container {
   }
 
 
-  async deleteAccount(account) {
+  async deleteAccount(accountKey) {
     const { accounts } = this.state;
 
-    accounts.delete(account.dbKey);
+    accounts.delete(accountKey);
     this.setState({ accounts });
-    await deleteDbAccount(account);
+    await deleteDbAccount(accountKey);
   }
 
   async unlockAccount(accountKey, pin) {
@@ -202,15 +181,10 @@ export default class AccountsStore extends Container {
   }
 
   getById(account) {
-    //const acc = this.state.accounts[account.dbKey] || empty(account.address, account.networkKey)
     return this.state.accounts.get(accountId(account)) || empty(account.address, account.networkKey);
   }
 
   getByAddress(address) {
-  //   const account = this.getAccounts().find(
-  //     a => a.address.toLowerCase() === address.toLowerCase()
-  //  );
-
    for (let v of this.state.accounts.values()) {
       if (v.address.toLowerCase() === address.toLowerCase()){
         return v;

--- a/src/stores/AccountsStore.js
+++ b/src/stores/AccountsStore.js
@@ -104,15 +104,17 @@ export default class AccountsStore extends Container {
   }
 
   async refreshList() {
-    loadAccounts().then(res => {
+    loadAccounts().then(accounts => {
         // .then(accounts =>
         // Object.values(accounts).map(account => JSON.parse(account))
         // );
-        let accounts = new Map();
-        for (let [key, value] of Object.entries(res)) {
-          const account = JSON.parse(value)
-          accounts.set(key, {...account, dbKey: key})
-        }
+
+        // let accounts = new Map();
+        // for (let [key, value] of Object.entries(res)) {
+        //   const account = JSON.parse(value)
+        //   accounts.set(key, {...account, dbKey: key})
+        // }
+
       // const accounts = Object.entries(res).map(() => {
       //   new Map(res.map(a => [accountId(a), a]));
       // }) 

--- a/src/stores/AccountsStore.js
+++ b/src/stores/AccountsStore.js
@@ -123,7 +123,7 @@ export default class AccountsStore extends Container {
     const { accounts } = this.state;
 
     accounts.delete(accountKey);
-    this.setState({ accounts });
+    this.setState({ accounts, selectedKey: '' });
     await deleteDbAccount(accountKey);
   }
 

--- a/src/stores/AccountsStore.js
+++ b/src/stores/AccountsStore.js
@@ -205,6 +205,6 @@ export default class AccountsStore extends Container {
   }
 
   getAccounts() {
-    return this.state.accounts
+    return this.state.accounts;
   }
 }

--- a/src/stores/AccountsStore.js
+++ b/src/stores/AccountsStore.js
@@ -87,6 +87,7 @@ export default class AccountsStore extends Container {
       });
     }
   }
+  
   update(accountUpdate) {
     let account = this.state.accounts.get(accountId(accountUpdate));
     if (!account) {

--- a/src/stores/AccountsStore.js
+++ b/src/stores/AccountsStore.js
@@ -201,7 +201,7 @@ export default class AccountsStore extends Container {
   }
 
   getSelectedKey() {
-    return this.state.selectedKey
+    return this.state.selectedKey;
   }
 
   getAccounts() {

--- a/src/stores/AccountsStore.js
+++ b/src/stores/AccountsStore.js
@@ -73,9 +73,11 @@ export default class AccountsStore extends Container {
 
     // only save a new account if the seed isn't empty
     if (account.seed) {
-      await this.save(account, pin);
+      const accountKey = accountId(account);
+
+      await this.save(accountKey, account, pin);
       this.setState({
-        accounts: this.state.accounts.set(accountId(account), account),
+        accounts: this.state.accounts.set(accountKey, account),
         newAccount: empty()
       });
     }
@@ -100,7 +102,7 @@ export default class AccountsStore extends Container {
     });
   }
 
-  async save(account, pin = null) {
+  async save(accountKey, account, pin = null) {
     try {
       // for account creation
       if (pin && account.seed) {
@@ -110,7 +112,7 @@ export default class AccountsStore extends Container {
       const accountToSave = this.deleteSensitiveData(account);
 
       accountToSave.updatedAt = new Date().getTime();
-      await saveAccount(accountToSave);
+      await saveAccount(accountKey, accountToSave);
     } catch (e) {
       console.error(e);
     }

--- a/src/stores/AccountsStore.js
+++ b/src/stores/AccountsStore.js
@@ -202,9 +202,8 @@ export default class AccountsStore extends Container {
   }
 
   getById(account) {
-    const acc = this.state.accounts[account.dbKey] || empty(account.address, account.networkKey)
-    debugger;
-    return acc;
+    //const acc = this.state.accounts[account.dbKey] || empty(account.address, account.networkKey)
+    return this.state.accounts.get(accountId(account)) || empty(account.address, account.networkKey);
   }
 
   getByAddress(address) {

--- a/src/stores/AccountsStore.js
+++ b/src/stores/AccountsStore.js
@@ -90,7 +90,7 @@ export default class AccountsStore extends Container {
     if (account && updatedAccount) {
       this.setState({ accounts: accounts.set(accountKey, {...account, ...updatedAccount}) });
     }
-    debugger;
+    // debugger;
     // Object.assign(account, accountUpdate);
     // this.setState({});
   }
@@ -202,14 +202,24 @@ export default class AccountsStore extends Container {
   }
 
   getById(account) {
-    return this.state.accounts[account.dbKey] || empty(account.address, account.networkKey);
+    const acc = this.state.accounts[account.dbKey] || empty(account.address, account.networkKey)
+    debugger;
+    return acc;
   }
 
   getByAddress(address) {
-    return this.getAccounts().find(
-      a => a.address.toLowerCase() === address.toLowerCase()
-    );
-  }
+  //   const account = this.getAccounts().find(
+  //     a => a.address.toLowerCase() === address.toLowerCase()
+  //  );
+
+   for (let v of this.state.accounts.values()) {
+      if (v.address.toLowerCase() === address.toLowerCase()){
+        return v;
+      } 
+    }
+
+    throw new Error(`no account found for the address: ${address}`);
+}
 
   getSelected() {
     return this.state.accounts.get(this.state.selectedKey);

--- a/src/stores/AccountsStore.js
+++ b/src/stores/AccountsStore.js
@@ -39,7 +39,7 @@ export type Account = {
 };
 
 type AccountsState = {
-  accounts: Map<string, Account>,
+  accounts: Object,
   newAccount: Account,
   selectedKey: string
 };
@@ -47,7 +47,7 @@ type AccountsState = {
 
 export default class AccountsStore extends Container {
   state = {
-    accounts: new Map(),
+    accounts: {},
     newAccount: empty(),
     selectedKey: ''
   };
@@ -84,17 +84,17 @@ export default class AccountsStore extends Container {
       await this.save(account, pin);
       account.dbKey = accountId(account);
       this.setState({
-        accounts: this.state.accounts.set(accountId(account), account),
+        accounts: {...accounts, account},
         newAccount: empty()
       });
     }
   }
   
   update(accountUpdate) {
-    let account = this.state.accounts.get(accountUpdate.dbKey);
+    let account = this.state.accounts[accountUpdate.dbKey];
     if (!account) {
-      this.state.accounts.set(accountUpdate.dbKey, accountUpdate);
-      account = this.state.accounts.get(accountUpdate.dbKey);
+      this.state.accounts[accountUpdate.dbKey] = accountUpdate;
+      account = this.state.accounts[accountUpdate.dbKey];
     }
     Object.assign(account, accountUpdate);
     this.setState({});
@@ -163,7 +163,7 @@ export default class AccountsStore extends Container {
       account.derivationPath = derivePath || '';
       account.derivationPassword = password || '';
       this.setState({
-        accounts: this.state.accounts.set(account.dbKey, account)
+        accounts: {...accounts, [account.dbKey]: account}
       });
     } catch (e) {
       return false;
@@ -183,10 +183,9 @@ export default class AccountsStore extends Container {
   lockAccount(account) {
     const {accounts} = this.state
 
-    if (accounts.get(account.dbKey)) {
+    if (accounts[account.dbKey]) {
       const lockedAccount = this.deleteSensitiveData(account)
-      accounts.set(account.dbKey, lockedAccount);
-      this.setState({ accounts });
+      this.setState({ accounts: {...accounts, [account.dbKey]: lockedAccount} });
     }
   }
 
@@ -201,7 +200,7 @@ export default class AccountsStore extends Container {
   }
 
   getById(account) {
-    return this.state.accounts.get(account.dbKey) || empty(account.address, account.networkKey);
+    return this.state.accounts[account.dbKey] || empty(account.address, account.networkKey);
   }
 
   getByAddress(address) {
@@ -211,7 +210,7 @@ export default class AccountsStore extends Container {
   }
 
   getSelected() {
-    return this.state.accounts.get(this.state.selectedKey);
+    return this.state.accounts[this.state.selectedKey];
   }
 
   getSelectedKey() {

--- a/src/stores/AccountsStore.js
+++ b/src/stores/AccountsStore.js
@@ -41,7 +41,7 @@ export type Account = {
 type AccountsState = {
   accounts: Map<string, Account>,
   newAccount: Account,
-  selected: Account
+  selectedKey: string
 };
 
 
@@ -49,7 +49,7 @@ export default class AccountsStore extends Container {
   state = {
     accounts: new Map(),
     newAccount: empty(),
-    selected: undefined
+    selectedKey: ''
   };
 
   constructor(props) {
@@ -60,7 +60,7 @@ export default class AccountsStore extends Container {
   async select(account) {
     return new Promise((res, rej) => {
       this.setState(
-        state => ({ selected: account.dbKey }),
+        state => ({ selectedKey: account.dbKey }),
         state => {
           res(state);
         }
@@ -82,6 +82,7 @@ export default class AccountsStore extends Container {
     // only save a new account if the seed isn't empty
     if (account.seed) {
       await this.save(account, pin);
+      account.dbKey = accountId(account);
       this.setState({
         accounts: this.state.accounts.set(accountId(account), account),
         newAccount: empty()
@@ -210,7 +211,11 @@ export default class AccountsStore extends Container {
   }
 
   getSelected() {
-    return this.state.accounts.get(this.state.selected);
+    return this.state.accounts.get(this.state.selectedKey);
+  }
+
+  getSelectedKey() {
+    return this.state.selectedKey
   }
 
   getAccounts() {

--- a/src/stores/ScannerStore.js
+++ b/src/stores/ScannerStore.js
@@ -21,7 +21,6 @@ import { decodeAddress, encodeAddress  } from '@polkadot/util-crypto';
 import { Container } from 'unstated';
 
 import { NETWORK_LIST, NetworkProtocols, SUBSTRATE_NETWORK_LIST } from '../constants';
-import { accountId } from '../util/account';
 import { saveTx } from '../util/db';
 import { isAscii } from '../util/message';
 import { blake2s, brainWalletSign, decryptData, keccak, ethSign, substrateSign } from '../util/native';

--- a/src/stores/ScannerStore.js
+++ b/src/stores/ScannerStore.js
@@ -21,6 +21,7 @@ import { decodeAddress, encodeAddress  } from '@polkadot/util-crypto';
 import { Container } from 'unstated';
 
 import { NETWORK_LIST, NetworkProtocols, SUBSTRATE_NETWORK_LIST } from '../constants';
+import { accountId } from '../util/account';
 import { saveTx } from '../util/db';
 import { isAscii } from '../util/message';
 import { blake2s, brainWalletSign, decryptData, keccak, ethSign, substrateSign } from '../util/native';
@@ -211,7 +212,7 @@ export default class ScannerStore extends Container<ScannerState> {
     }
 
     const recipient = accountsStore.getById({
-      networkKey: networkKey,
+      networkKey,
       address: isEthereum ? tx.action : txRequest.data.account
     });
 

--- a/src/stores/ScannerStore.js
+++ b/src/stores/ScannerStore.js
@@ -126,7 +126,7 @@ export default class ScannerStore extends Container<ScannerState> {
     // all the frames are filled
     if (Object.keys(this.state.multipartData.length) === frameCount) {
       // fixme: this needs to be concated to a binary blob
-      const concatMultipartData = Object.keys(this.state.multipartData).reduce((result, data) => res.concat(this.state.multipartData[data]));
+      const concatMultipartData = Object.keys(this.state.multipartData).reduce((result, data) => result.concat(this.state.multipartData[data]));
       const data = this.setParsedData(concatMultipartData);
       this.setData(data);
     }

--- a/src/util/account.js
+++ b/src/util/account.js
@@ -22,8 +22,8 @@ export function accountId({
   address,
   networkKey
 }) {
-  if (typeof address !== 'string' || address.length === 0 || !networkKey || !NETWORK_LIST[networkKey]) {
-    throw new Error(`Couldn't create an accountId. Address or networkKey missing, or network key was invalid.`);
+  if (!networkKey || !NETWORK_LIST[networkKey]) {
+    return `${NetworkProtocols.UNKNOWN}:${address}`;
   }
 
   const { ethereumChainId='', protocol, genesisHash='' } = NETWORK_LIST[networkKey];

--- a/src/util/account.js
+++ b/src/util/account.js
@@ -18,12 +18,10 @@
 
 import { NetworkProtocols, NETWORK_LIST, SubstrateNetworkKeys } from '../constants';
 
-export function accountId({
-  address,
-  networkKey
-}) {
-  if (!networkKey || !NETWORK_LIST[networkKey]) {
-    return `${NetworkProtocols.UNKNOWN}:${address}`;
+export function accountId({ address, networkKey }) {
+
+  if (typeof address !== 'string' || address.length === 0 || !networkKey || !NETWORK_LIST[networkKey]) {
+    throw new Error(`Couldn't create an accountId. Address or networkKey missing, or network key was invalid.`);
   }
 
   const { ethereumChainId='', protocol, genesisHash='' } = NETWORK_LIST[networkKey];

--- a/src/util/db.js
+++ b/src/util/db.js
@@ -38,7 +38,7 @@ export async function loadAccounts( version = 3 ) {
         accountMap.set(key, {...account});
       }
 
-      return accountMap
+      return accountMap;
   });
 }
 

--- a/src/util/db.js
+++ b/src/util/db.js
@@ -61,7 +61,7 @@ export const deleteAccount = async account =>
 
 export const saveAccount = account => 
   SecureStorage.setItem(
-    account.dbKey,
+    accountId(account),
     JSON.stringify(account, null, 0),
     accountsStore
   );

--- a/src/util/db.js
+++ b/src/util/db.js
@@ -30,11 +30,17 @@ export async function loadAccounts( version = 3 ) {
     keychainService: accountStoreVersion,
     sharedPreferencesName: accountStoreVersion
   };
+ 
+  return SecureStorage.getAllItems(accountsStore).then(accounts => {
+      // Object.values(accounts).map(account => JSON.parse(account))
+      let accountMap = new Map();
+      for (let [key, value] of Object.entries(accounts)) {
+        const account = JSON.parse(value)
+        accountMap.set(key, {...account, dbKey: key})
+      }
 
-  return SecureStorage.getAllItems(accountsStore)
-  // .then(accounts =>
-  //   Object.values(accounts).map(account => JSON.parse(account))
-  // );
+      return accountMap
+  });
 }
 
 const accountsStore = {

--- a/src/util/db.js
+++ b/src/util/db.js
@@ -32,7 +32,7 @@ export async function loadAccounts( version = 3 ) {
   };
  
   return SecureStorage.getAllItems(accountsStore).then(accounts => {
-      let accountMap = new Map();
+      const accountMap = new Map();
       for (let [key, value] of Object.entries(accounts)) {
         const account = JSON.parse(value)
         accountMap.set(key, {...account})

--- a/src/util/db.js
+++ b/src/util/db.js
@@ -31,9 +31,10 @@ export async function loadAccounts( version = 3 ) {
     sharedPreferencesName: accountStoreVersion
   };
 
-  return SecureStorage.getAllItems(accountsStore).then(accounts =>
-    Object.values(accounts).map(account => JSON.parse(account))
-  );
+  return SecureStorage.getAllItems(accountsStore)
+  // .then(accounts =>
+  //   Object.values(accounts).map(account => JSON.parse(account))
+  // );
 }
 
 const accountsStore = {
@@ -50,11 +51,11 @@ function txKey(hash) {
 }
 
 export const deleteAccount = async account =>
-  SecureStorage.deleteItem(accountId(account), accountsStore);
+  SecureStorage.deleteItem(account.dbKey, accountsStore);
 
 export const saveAccount = account => 
   SecureStorage.setItem(
-    accountId(account),
+    account.dbKey,
     JSON.stringify(account, null, 0),
     accountsStore
   );

--- a/src/util/db.js
+++ b/src/util/db.js
@@ -32,20 +32,11 @@ export async function loadAccounts( version = 3 ) {
   };
  
   return SecureStorage.getAllItems(accountsStore).then(accounts => {
-      //Object.values(accounts).map(account => JSON.parse(account))
-      // console.log('accounts db',accounts);
-      // let accountGood = {};
-      // for (let [key, value] of Object.entries(accounts)) {
-      //   const account = JSON.parse(value)
-      //   accountGood = {...accountGood, [key]:{...account, dbKey: key}}
-      // }
-
       let accountMap = new Map();
       for (let [key, value] of Object.entries(accounts)) {
         const account = JSON.parse(value)
-        accountMap.set(key, {...account, dbKey: key})
+        accountMap.set(key, {...account})
       }
-      // console.log('accountGood db',accountGood)
 
       return accountMap
   });
@@ -64,8 +55,8 @@ function txKey(hash) {
   return 'tx_' + hash;
 }
 
-export const deleteAccount = async account =>
-  SecureStorage.deleteItem(account.dbKey, accountsStore);
+export const deleteAccount = async accountKey =>
+  SecureStorage.deleteItem(accountKey, accountsStore);
 
 export const saveAccount = account => 
   SecureStorage.setItem(

--- a/src/util/db.js
+++ b/src/util/db.js
@@ -33,13 +33,22 @@ export async function loadAccounts( version = 3 ) {
  
   return SecureStorage.getAllItems(accountsStore).then(accounts => {
       // Object.values(accounts).map(account => JSON.parse(account))
-      let accountMap = new Map();
+
+      let accountGood = {};
       for (let [key, value] of Object.entries(accounts)) {
         const account = JSON.parse(value)
-        accountMap.set(key, {...account, dbKey: key})
+        accountGood = {...accountGood, [key]:{...account, dbKey: key}}
       }
 
-      return accountMap
+      // let accountMap = new Map();
+      // for (let [key, value] of Object.entries(accounts)) {
+      //   const account = JSON.parse(value)
+      //   accountMap.set(key, {...account, dbKey: key})
+      // }
+      // console.log('accounts db',accounts)
+      // console.log('accountGood db',accountGood)
+
+      return accountGood
   });
 }
 

--- a/src/util/db.js
+++ b/src/util/db.js
@@ -58,14 +58,12 @@ function txKey(hash) {
 export const deleteAccount = async accountKey =>
   SecureStorage.deleteItem(accountKey, accountsStore);
 
-export const saveAccount = account => 
+export const saveAccount = (accountKey, account) => 
   SecureStorage.setItem(
-    accountId(account),
+    accountKey,
     JSON.stringify(account, null, 0),
     accountsStore
   );
-
-export const saveAccounts = accounts => accounts.forEach(saveAccount);
 
 export async function saveTx(tx) {
   if (!tx.sender) {

--- a/src/util/db.js
+++ b/src/util/db.js
@@ -35,7 +35,7 @@ export async function loadAccounts( version = 3 ) {
       const accountMap = new Map();
       for (let [key, value] of Object.entries(accounts)) {
         const account = JSON.parse(value);
-        accountMap.set(key, {...account})
+        accountMap.set(key, {...account});
       }
 
       return accountMap

--- a/src/util/db.js
+++ b/src/util/db.js
@@ -32,23 +32,22 @@ export async function loadAccounts( version = 3 ) {
   };
  
   return SecureStorage.getAllItems(accountsStore).then(accounts => {
-      // Object.values(accounts).map(account => JSON.parse(account))
-
-      let accountGood = {};
-      for (let [key, value] of Object.entries(accounts)) {
-        const account = JSON.parse(value)
-        accountGood = {...accountGood, [key]:{...account, dbKey: key}}
-      }
-
-      // let accountMap = new Map();
+      //Object.values(accounts).map(account => JSON.parse(account))
+      // console.log('accounts db',accounts);
+      // let accountGood = {};
       // for (let [key, value] of Object.entries(accounts)) {
       //   const account = JSON.parse(value)
-      //   accountMap.set(key, {...account, dbKey: key})
+      //   accountGood = {...accountGood, [key]:{...account, dbKey: key}}
       // }
-      // console.log('accounts db',accounts)
+
+      let accountMap = new Map();
+      for (let [key, value] of Object.entries(accounts)) {
+        const account = JSON.parse(value)
+        accountMap.set(key, {...account, dbKey: key})
+      }
       // console.log('accountGood db',accountGood)
 
-      return accountGood
+      return accountMap
   });
 }
 

--- a/src/util/db.js
+++ b/src/util/db.js
@@ -34,7 +34,7 @@ export async function loadAccounts( version = 3 ) {
   return SecureStorage.getAllItems(accountsStore).then(accounts => {
       const accountMap = new Map();
       for (let [key, value] of Object.entries(accounts)) {
-        const account = JSON.parse(value)
+        const account = JSON.parse(value);
         accountMap.set(key, {...account})
       }
 


### PR DESCRIPTION
closes #389 

How to test:
- create a Kusama account (1)
- modify the genesisHash aka `networkKey` of Kusama in `src/constants.js`
- reload the App

Because the  genesisHash used to create (1) isn't known any more, we can't match the Kusama Network. Still this account can be seen, its backup retrieved with the pin and deleted.

edit:
This was quite a painful PR, trying to remove many weird things that were done. Now we use the same [key, value] mapping in the accountStore and in the db. This allows to show accounts which we have no corresponding `NetworkKey`. It also helps to seemlessly save or delete accounts (even if the network is not known) because the db and the store have the same keys.
 
This PR introduces the notion of `selectedKey` that corresponds to a `selectedAccount` (more broadly named `selected` in the app). I think it's quite straightforward, we should use this key as much as possible and only use `accountId()` when dealing with Data coming in (QR code scanning) or saving new accounts.

I tested the migration but please feel free to do it as well ([as explained here](https://github.com/paritytech/parity-signer/pull/352#issuecomment-527437669))

![image](https://user-images.githubusercontent.com/33178835/65086511-60072d80-d9b2-11e9-98d9-92c224e02006.png)
![image](https://user-images.githubusercontent.com/33178835/65086514-65fd0e80-d9b2-11e9-89fe-6e1327e0883c.png)
