### PR TITLE
chore: Use Kusama cc2 genesis hash

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -17,7 +17,7 @@ export const EthereumNetworkKeys = Object.freeze({
 
 // genesisHash is used as Network key for Substrate networks
 export const SubstrateNetworkKeys = Object.freeze({
-  KUSAMA: '0x3fd7b9eb6a00376e5be61f01abb429ffb0b104be05eaff4d458da48fcd425baf', // https://polkascan.io/pre/kusama/block/0
+  KUSAMA: '0xe3777fa922cafbff200cadeaea1a76bd7898ad5b89f7848999058b50e715f636', // hhttps://polkascan.io/pre/kusama-cc2/block/0
   // SUBSTRATE_DEV: '0x4393a679e1830a487e8ae92733f089a80f3e24ba515b08dd8adb40fc6cedee8d', // substrate --dev commit ac6a2a783f0e1f4a814cf2add40275730cd41be1 hosted on wss://dev-node.substrate.dev .
 });
 
@@ -27,7 +27,7 @@ const substrateNetworkBase = {
     decimals: 12,
     genesisHash: SubstrateNetworkKeys.KUSAMA,
     prefix: 2,
-    title: 'Kusama',
+    title: 'Kusama CC2',
     unit: 'KSM'
   },
   // [SubstrateNetworkKeys.SUBSTRATE_DEV]: {

--- a/src/constants.js
+++ b/src/constants.js
@@ -17,7 +17,7 @@ export const EthereumNetworkKeys = Object.freeze({
 
 // genesisHash is used as Network key for Substrate networks
 export const SubstrateNetworkKeys = Object.freeze({
-  KUSAMA: '0xe3777fa922cafbff200cadeaea1a76bd7898ad5b89f7848999058b50e715f636', // hhttps://polkascan.io/pre/kusama-cc2/block/0
+  KUSAMA: '0xe3777fa922cafbff200cadeaea1a76bd7898ad5b89f7848999058b50e715f636', // https://polkascan.io/pre/kusama-cc2/block/0
   // SUBSTRATE_DEV: '0x4393a679e1830a487e8ae92733f089a80f3e24ba515b08dd8adb40fc6cedee8d', // substrate --dev commit ac6a2a783f0e1f4a814cf2add40275730cd41be1 hosted on wss://dev-node.substrate.dev .
 });
 


### PR DESCRIPTION
- uses the Kusama cc2 genesis hash (using polkascan or apps -> tools -> chain.getBlockHash(0))
"0xe3777fa922cafbff200cadeaea1a76bd7898ad5b89f7848999058b50e715f636"

Tested with apps, could sign the tx, got "error 1010", as expected since transfer aren't enabled.