### PR TITLE
fix: use keyboard scroll view for pin input screen

### DIFF
--- a/src/screens/AccountPin.js
+++ b/src/screens/AccountPin.js
@@ -121,7 +121,7 @@ class AccountPinView extends React.PureComponent {
 	render() {
 		const title = 'ACCOUNT PIN';
 		return (
-			<KeyboardScrollView style={styles.body}>
+			<KeyboardScrollView style={styles.body} extraHeight={120}>
 				<Background />
 				<Text style={styles.titleTop}>{title}</Text>
 				{this.showHintOrError()}
@@ -168,7 +168,7 @@ class PinInput extends Component {
 				multiline={false}
 				autoCorrect={false}
 				numberOfLines={1}
-				returnKeyType="next"
+				returnKeyType="done"
 				secureTextEntry
 				style={styles.pinInput}
 				{...this.props}

--- a/src/screens/AccountPin.js
+++ b/src/screens/AccountPin.js
@@ -26,7 +26,7 @@ import Background from '../components/Background';
 import Button from '../components/Button';
 import TextInput from '../components/TextInput';
 import AccountsStore from '../stores/AccountsStore';
-import KeyboardScrollView from "../components/KeyboardScrollView";
+import KeyboardScrollView from '../components/KeyboardScrollView';
 
 export default class AccountPin extends React.PureComponent {
 	render() {
@@ -168,7 +168,7 @@ class PinInput extends Component {
 				multiline={false}
 				autoCorrect={false}
 				numberOfLines={1}
-				returnKeyType="done"
+				returnKeyType="next"
 				secureTextEntry
 				style={styles.pinInput}
 				{...this.props}

--- a/src/screens/AccountPin.js
+++ b/src/screens/AccountPin.js
@@ -17,7 +17,7 @@
 'use strict';
 
 import React, { Component } from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text } from 'react-native';
 import { NavigationActions, StackActions } from 'react-navigation';
 import { Subscribe } from 'unstated';
 import colors from '../colors';
@@ -26,6 +26,7 @@ import Background from '../components/Background';
 import Button from '../components/Button';
 import TextInput from '../components/TextInput';
 import AccountsStore from '../stores/AccountsStore';
+import KeyboardScrollView from "../components/KeyboardScrollView";
 
 export default class AccountPin extends React.PureComponent {
 	render() {
@@ -120,7 +121,7 @@ class AccountPinView extends React.PureComponent {
 	render() {
 		const title = 'ACCOUNT PIN';
 		return (
-			<View style={styles.body}>
+			<KeyboardScrollView style={styles.body}>
 				<Background />
 				<Text style={styles.titleTop}>{title}</Text>
 				{this.showHintOrError()}
@@ -150,7 +151,7 @@ class AccountPinView extends React.PureComponent {
 					title="Done"
 					accessibilityLabel={'Done'}
 				/>
-			</View>
+			</KeyboardScrollView>
 		);
 	}
 }


### PR DESCRIPTION
fix #403  

screenshot on iPhone SE @laboon

Also click on the blank place will hide the keyboard.

![out](https://user-images.githubusercontent.com/6014309/66659898-8d0ecf00-ec44-11e9-8be0-144706e91bfb.gif)
