### PR TITLE
feat: create derive account button in account details

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -48,6 +48,7 @@ import AccountNew from './screens/AccountNew';
 import AccountPin from './screens/AccountPin';
 import AccountRecover from './screens/AccountRecover';
 import { AccountUnlock, AccountUnlockAndSign } from './screens/AccountUnlock';
+import DeriveNew from './screens/DeriveNew';
 import Loading from './screens/Loading';
 import MessageDetails from './screens/MessageDetails';
 import PrivacyPolicy from './screens/PrivacyPolicy';
@@ -203,6 +204,9 @@ const Screens = createStackNavigator(
 					},
 					AccountUnlockAndSign: {
 						screen: AccountUnlockAndSign
+					},
+					DeriveNew: {
+						screen: DeriveNew
 					},
 					MessageDetails: {
 						screen: MessageDetails

--- a/src/components/DerivationPathField.js
+++ b/src/components/DerivationPathField.js
@@ -24,8 +24,8 @@ import { parseDerivationPath } from '../util/suri';
 import TextInput from './TextInput';
 
 export default function DerivationPathField(props) {
-	const { onChange, styles, defaultPath } = props;
-	const [showAdvancedField, setShowAdvancedField] = useState(false);
+	const { onChange, styles, defaultPath, defaultExpand } = props;
+	const [showAdvancedField, setShowAdvancedField] = useState(defaultExpand);
 	const [isValidPath, setIsValidPath] = useState(true);
 	const [path, setPath] = useState(defaultPath);
 
@@ -35,20 +35,22 @@ export default function DerivationPathField(props) {
 
 	return (
 		<>
-			<TouchableOpacity
-				onPress={toggleShowAdvancedField}
-				style={{ diplay: 'flex' }}
-			>
-				<View style={{ justifyContent: 'center' }}>
-					<Text style={[styles.title, ownStyles.advancedText]}>
-						ADVANCED
-						<Icon
-							name={showAdvancedField ? 'arrow-drop-up' : 'arrow-drop-down'}
-							size={20}
-						/>
-					</Text>
-				</View>
-			</TouchableOpacity>
+			{!defaultExpand && (
+				<TouchableOpacity
+					onPress={toggleShowAdvancedField}
+					style={{ diplay: 'flex' }}
+				>
+					<View style={{ justifyContent: 'center' }}>
+						<Text style={[styles.title, ownStyles.advancedText]}>
+							ADVANCED
+							<Icon
+								name={showAdvancedField ? 'arrow-drop-up' : 'arrow-drop-down'}
+								size={20}
+							/>
+						</Text>
+					</View>
+				</TouchableOpacity>
+			)}
 			{showAdvancedField && (
 				<TextInput
 					onChangeText={text => {

--- a/src/components/DerivationPathField.js
+++ b/src/components/DerivationPathField.js
@@ -24,9 +24,10 @@ import { parseDerivationPath } from '../util/suri';
 import TextInput from './TextInput';
 
 export default function DerivationPathField(props) {
-	const { onChange, styles } = props;
+	const { onChange, styles, defaultPath } = props;
 	const [showAdvancedField, setShowAdvancedField] = useState(false);
 	const [isValidPath, setIsValidPath] = useState(true);
+	const [path, setPath] = useState(defaultPath);
 
 	const toggleShowAdvancedField = () => {
 		setShowAdvancedField(!showAdvancedField);
@@ -51,6 +52,7 @@ export default function DerivationPathField(props) {
 			{showAdvancedField && (
 				<TextInput
 					onChangeText={text => {
+						setPath(text);
 						try {
 							const derivationPath = parseDerivationPath(text);
 
@@ -70,6 +72,7 @@ export default function DerivationPathField(props) {
 							setIsValidPath(false);
 						}
 					}}
+					value={path}
 					placeholder="optional derivation path"
 					style={isValidPath ? ownStyles.validInput : ownStyles.invalidInput}
 				/>

--- a/src/screens/AccountBackup.js
+++ b/src/screens/AccountBackup.js
@@ -182,11 +182,6 @@ const styles = StyleSheet.create({
 		flexDirection: 'column',
 		padding: 20
 	},
-	bodyContainer: {
-		flex: 1,
-		flexDirection: 'column',
-		justifyContent: 'space-between'
-	},
 	bodyContent: {
 		paddingBottom: 40
 	},

--- a/src/screens/AccountBackup.js
+++ b/src/screens/AccountBackup.js
@@ -75,7 +75,7 @@ class AccountBackupView extends React.PureComponent {
 			accounts.lockAccount(selectedKey);
 		}
 
-		AppState.removeEventListener('change', this._handleAppStateChange);
+		AppState.removeEventListener('change', this.handleAppStateChange);
 	}
 
 	render() {

--- a/src/screens/AccountDetails.js
+++ b/src/screens/AccountDetails.js
@@ -150,7 +150,7 @@ This account can only be recovered with its associated recovery phrase.`,
 							menuItems={[
 								{ text: 'Edit', value: 'AccountEdit' },
 								{ text: 'Change Pin', value: 'AccountPin' },
-								{ value: 'DeriveNew', text: 'Derive More Keys'},
+								{ text: 'Derive More Keys', value: 'DeriveNew' },
 								{ text: 'View Recovery Phrase', value: 'AccountBackup' },
 								{
 									text: 'Delete',

--- a/src/screens/AccountDetails.js
+++ b/src/screens/AccountDetails.js
@@ -150,6 +150,7 @@ This account can only be recovered with its associated recovery phrase.`,
 							menuItems={[
 								{ text: 'Edit', value: 'AccountEdit' },
 								{ text: 'Change Pin', value: 'AccountPin' },
+								{ value: 'DeriveNew', text: 'Derive More Keys'},
 								{ text: 'View Recovery Phrase', value: 'AccountBackup' },
 								{
 									text: 'Delete',

--- a/src/screens/AccountNew.js
+++ b/src/screens/AccountNew.js
@@ -202,11 +202,6 @@ const styles = StyleSheet.create({
 		flex: 1,
 		overflow: 'hidden'
 	},
-	bodyContainer: {
-		flex: 1,
-		flexDirection: 'column',
-		justifyContent: 'space-between'
-	},
 	bottom: {
 		flexBasis: 50,
 		paddingBottom: 15

--- a/src/screens/AccountUnlock.js
+++ b/src/screens/AccountUnlock.js
@@ -69,6 +69,7 @@ export class AccountUnlock extends React.Component {
 	render() {
 		const { navigation } = this.props;
 		const next = navigation.getParam('next', 'AccountList');
+		const isAccountDerivation = navigation.getParam('isDerived');
 
 		return (
 			<Subscribe to={[AccountsStore]}>
@@ -76,6 +77,10 @@ export class AccountUnlock extends React.Component {
 					<AccountUnlockView
 						{...this.props}
 						checkPin={async pin => {
+							if (isAccountDerivation) {
+								await accounts.submitNew(pin);
+								return true;
+							}
 							return await accounts.unlockAccount(
 								accounts.getSelectedKey(),
 								pin

--- a/src/screens/DeriveNew.js
+++ b/src/screens/DeriveNew.js
@@ -1,0 +1,163 @@
+// Copyright 2015-2019 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+'use strict';
+
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { Subscribe } from 'unstated';
+
+import colors from '../colors';
+import AccountIconChooser from '../components/AccountIconChooser';
+import Background from '../components/Background';
+import Button from '../components/Button';
+import DerivationPathField from '../components/DerivationPathField'
+import KeyboardScrollView from '../components/KeyboardScrollView';
+import NetworkButton from '../components/NetworkButton';
+import TextInput from '../components/TextInput';
+import { NETWORK_LIST, NetworkProtocols } from '../constants';
+import fonts from '../fonts';
+import AccountsStore from '../stores/AccountsStore';
+import { empty, validateSeed } from '../util/account';
+import {constructSURI} from '../util/suri';
+
+export default class AccountNew extends React.Component {
+	static navigationOptions = {
+		title: 'New Account',
+		headerBackTitle: 'Back'
+	};
+	render() {
+		return (
+			<Subscribe to={[AccountsStore]}>
+				{accounts => <AccountNewView {...this.props} accounts={accounts} />}
+			</Subscribe>
+		);
+	}
+}
+
+class AccountNewView extends React.Component {
+
+	constructor(props) {
+		super(props);
+
+		this.state = {
+			derivationPassword: '',
+			derivationPath: '',
+			isDerivationPathValid: true,
+			selectedAccount: undefined,
+			selectedNetwork: undefined,
+		};
+	}
+
+	componentDidMount(): void {
+		const { accounts } = this.props;
+		accounts.updateNew(accounts.getSelected());
+	}
+
+	componentWillUnmount = function() {
+		// called when the user goes back, or finishes the whole process
+		this.props.accounts.updateNew(empty());
+	};
+
+	render() {
+		const { accounts, navigation } = this.props;
+		const { derivationPassword, derivationPath, isDerivationPathValid } = this.state;
+		const selectedAccount = accounts.getSelected();
+		const {address, name, seed, seedPhrase, validBip39Seed, networkKey} = selectedAccount;
+
+		if (!selectedAccount) {
+			return null;
+		}
+
+		return (
+			<View style={styles.body}>
+				<KeyboardScrollView style={{ padding: 20 }}>
+					<Background />
+					<View style={styles.top}>
+						<Text style={styles.titleTop}>DERIVE ACCOUNT</Text>
+						<Text style={styles.title}>NAME</Text>
+						<TextInput
+							onChangeText={name => accounts.updateNew({ name })}
+							value={name}
+							placeholder="Enter a new account name"
+						/>
+						<DerivationPathField
+							onChange = { ({derivationPassword, derivationPath, isDerivationPathValid}) => {
+								this.setState({ derivationPath, derivationPassword, isDerivationPathValid });
+							}}
+							styles={styles}
+						/>
+					</View>
+					<View style={styles.bottom}>
+						<Text style={styles.hintText}>
+							Next, you will be asked to backup your account, get a pen and some paper.
+						</Text>
+						<Button
+							buttonStyles={styles.nextStep}
+							title="Next Step"
+							disabled={!validateSeed(seed, validBip39Seed).valid || !isDerivationPathValid}
+							onPress={() => {
+								validateSeed(seed, validBip39Seed).valid &&
+								navigation.navigate('AccountBackup', {
+									isNew: true,
+									isWelcome: navigation.getParam('isWelcome')
+								});
+							}}
+						/>
+					</View>
+				</KeyboardScrollView>
+			</View>
+		);
+	}
+}
+
+const styles = StyleSheet.create({
+	body: {
+		backgroundColor: colors.bg,
+		flex: 1,
+		overflow: 'hidden'
+	},
+	top: {
+		flex: 1
+	},
+	bottom: {
+		flexBasis: 50,
+		paddingBottom: 15
+	},
+	title: {
+		fontFamily: fonts.bold,
+		color: colors.bg_text_sec,
+		fontSize: 18,
+		paddingBottom: 20
+	},
+	titleTop: {
+		color: colors.bg_text_sec,
+		fontFamily: fonts.bold,
+		fontSize: 24,
+		paddingBottom: 20,
+		textAlign: 'center'
+	},
+	hintText: {
+		fontFamily: fonts.bold,
+		textAlign: 'center',
+		paddingTop: 20,
+		color: colors.bg_text_sec,
+		fontSize: 12
+	},
+	nextStep: {
+		marginTop: 15
+	}
+});

--- a/src/screens/DeriveNew.js
+++ b/src/screens/DeriveNew.js
@@ -17,7 +17,7 @@
 'use strict';
 
 import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { AppState, StyleSheet, Text, View } from 'react-native';
 import { Subscribe } from 'unstated';
 
 import colors from '../colors';
@@ -50,6 +50,7 @@ export default class DeriveNew extends React.Component {
 class DeriveNewView extends React.Component {
 	constructor(props) {
 		super(props);
+		this.handleAppStateChange = this.handleAppStateChange.bind(this);
 		const { accounts } = this.props;
 		const { seedPhrase, derivationPath, networkKey } = accounts.getSelected();
 		accounts.updateNew({ derivationPath, networkKey, seedPhrase });
@@ -59,9 +60,27 @@ class DeriveNewView extends React.Component {
 		};
 	}
 
-	componentWillUnmount = function() {
+	componentDidMount() {
+		AppState.addEventListener('change', this.handleAppStateChange);
+	}
+
+	componentWillUnmount() {
 		// called when the user goes back, or finishes the whole process
+		const { accounts } = this.props;
+		const selectedKey = accounts.getSelectedKey();
+
+		if (selectedKey) {
+			accounts.lockAccount(selectedKey);
+		}
+
 		this.props.accounts.updateNew(empty());
+		AppState.removeEventListener('change', this.handleAppStateChange);
+	}
+
+	handleAppStateChange = nextAppState => {
+		if (nextAppState === 'inactive') {
+			this.props.navigation.goBack();
+		}
 	};
 
 	render() {

--- a/src/screens/DeriveNew.js
+++ b/src/screens/DeriveNew.js
@@ -102,10 +102,13 @@ class DeriveNewView extends React.Component {
 						<Text style={styles.titleTop}>DERIVE ACCOUNT</Text>
 						<Text style={styles.title}>NAME</Text>
 						<TextInput
-							onChangeText={newName => accounts.updateNew({ newName })}
+							onChangeText={newName => accounts.updateNew({ name: newName })}
 							value={name}
 							placeholder="Enter a new account name"
 						/>
+						<Text style={[styles.title, { paddingTop: 20 }]}>
+							DERIVATION PATH
+						</Text>
 						<DerivationPathField
 							onChange={async ({
 								derivationPassword,
@@ -131,6 +134,7 @@ class DeriveNewView extends React.Component {
 									isDerivationPathValid
 								});
 							}}
+							defaultExpand={true}
 							defaultPath={accounts.getSelected().derivationPath}
 							styles={styles}
 						/>


### PR DESCRIPTION
First functional PR for #404 

In account detail screen, create a `derive account` button for root identity (Account without derivation path).

User may create derived account from the seed.


