### PR TITLE
chore: lock the version of eslint-babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,5 +77,8 @@
     "prettier": "1.18.2",
     "react-test-renderer": "16.9.0",
     "reactotron-react-native": "^3.6.5"
+  },
+  "resolutions": {
+    "@react-native-community/eslint-config/babel-eslint": "10.0.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1110,7 +1110,7 @@
   dependencies:
     "@typescript-eslint/eslint-plugin" "^1.5.0"
     "@typescript-eslint/parser" "^1.5.0"
-    babel-eslint "10.0.3"
+    babel-eslint "10.0.1"
     eslint-plugin-eslint-comments "^3.1.1"
     eslint-plugin-flowtype "2.50.3"
     eslint-plugin-jest "22.4.1"
@@ -1713,7 +1713,7 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-babel-eslint@10.0.3:
+babel-eslint@10.0.1, babel-eslint@10.0.3:
   version "10.0.3"
   resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.0.3.tgz#81a2c669be0f205e19462fed2482d33e4687a88a"
   integrity sha512-z3U7eMY6r/3f3/JB9mTsLjyxrv0Yb1zb8PCWCLpguxfCzBIZUwy23R1t/XKewP+8mEN2Ck8Dtr4q20z6ce6SoA==


### PR DESCRIPTION
### TLDR:

ESLint does not works as expected, this fix the `no-unused-var` error in "for.. in" of Javascript, and revert previous workaround.

### Long version:

Eslint evaluate `no-unused-var` for the keys in "for.. in" loop with eslint-babel: 10.0.1, which discussed [here](https://github.com/eslint/eslint/issues/12117).

So we have changed the dependency version, but this is still used in @react-native-community/eslint-config, and @react-native-community/eslint-config is rarely updated.

Though I have changed the code in `yarn.lock`, but every time we add new dependencies, remove dependencies, the lock file will be rewrite. It will further cause the original issue, it is just not the correct way to lock dependency's version.

So the correct way to do that is with yarn's [selective-version-resolutions](https://yarnpkg.com/lang/en/docs/selective-version-resolutions/) with a tiny modification on `package.json` file. That's what this PR about. **Also I suggest remove `package-lock.json` file if there is any**.