### PR TITLE
test: Add integration(e2e) test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js: 8
 
 cache:
   directories:
-    - node_modules
+  - node_modules
 
 install:
   - yarn

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,44 @@
 ---
-language: node_js
-node_js:
-  - 8
 
-cache:
-  directories:
-  - node_modules
+matrix:
+  include:
+  - language: objective-c
+    osx_image: xcode8.3
 
-install:
-  - yarn
+    branches:
+      only:
+        - master
 
-script:
-  - yarn run lint
-  - yarn run test
+    env:
+      global:
+        - NODE_VERSION=stable
+
+    install:
+      - brew tap wix/brew
+      - brew install applesimutils
+      - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash
+      - export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+      - nvm install $NODE_VERSION
+      - nvm use $NODE_VERSION
+      - nvm alias default $NODE_VERSION
+
+      - npm install -g react-native-cli
+      - npm install -g detox-cli
+
+    script:
+      - detox build --configuration ios.sim.release
+      - detox test --configuration ios.sim.release --cleanup
+
+  - language: node_js
+    node_js: 8
+
+    cache:
+      directories:
+        - node_modules
+
+    install:
+      - yarn
+
+    script:
+      - yarn run lint
+      - yarn run test

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,23 +11,24 @@ matrix:
 
     env:
       global:
-        - NODE_VERSION=stable
+        - NODE_VERSION = 8
 
     install:
       - brew tap wix/brew
       - brew install applesimutils
       - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash
       - export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
-      - nvm install $NODE_VERSION
-      - nvm use $NODE_VERSION
-      - nvm alias default $NODE_VERSION
-
+      - nvm install 8
+      - nvm use 8
+      - nvm alias default 8
+      - npm install -g yarn
       - npm install -g react-native-cli
       - npm install -g detox-cli
+      - yarn
 
     script:
-      - detox build --configuration ios.sim.release
-      - detox test --configuration ios.sim.release --cleanup
+      - detox build -c ios.sim.release
+      - detox test -c ios.sim.release
 
   - language: node_js
     node_js: 8

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 matrix:
   include:
   - language: objective-c
-    osx_image: xcode8.3
+    osx_image: xcode10.3
 
     branches:
       only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,81 +1,96 @@
 ---
+language: node_js
+node_js: 8
 
-matrix:
-  include:
-  - language: objective-c
-    osx_image: xcode10.3
+cache:
+  directories:
+    - node_modules
 
-    branches:
-      only:
-        - master
+install:
+  - yarn
 
-    cache:
-      directories:
-        - node_modules
+script:
+  - yarn run lint
+  - yarn run test
 
-    install:
-      - brew tap wix/brew
-      - brew install applesimutils
-      - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash
-      - export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
-      - nvm install 8
-      - nvm use 8
-      - nvm alias default 8
-      - npm install -g yarn
-      - npm install -g react-native-cli
-      - npm install -g detox-cli
-      - gem install xcpretty
-      - yarn
+# TODO complete following part to Integrate E2E test
 
-    script:
-      - detox build -c ios.sim.release
-      - detox test -c ios.sim.release
-
-  - language: android
-#    env:
-#      - REACT_NATIVE_VERSION=0.59.4
-    android:
-      components:
-        - tools
-        - platform-tools
-        - build-tools-28.0.3
-        - android-28
-        - extra-google-google_play_services
-        - extra-google-m2repository
-        - extra-android-m2repository
-#        - sys-img-x86-android-26
-        - sys-img-x86-android-28
-
-    cache:
-      directories:
-        - node_modules
-
-    install:
-      - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash
-      - export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
-      - nvm install 8
-      - nvm use 8
-      - nvm alias default 8
-      - npm install -g yarn
-      - npm install -g react-native-cli
-      - npm install -g detox-cli
-      - yes | sdkmanager "build-tools;28.0.3"
-      - yarn
-
-    script:
-      - detox build -c android.emu.release
-      - detox test -c android.emu.release
-
-  - language: node_js
-    node_js: 8
-
-    cache:
-      directories:
-        - node_modules
-
-    install:
-      - yarn
-
-    script:
-      - yarn run lint
-      - yarn run test
+#matrix:
+#  include:
+#  - language: objective-c
+#    osx_image: xcode10.3
+#
+#    branches:
+#      only:
+#        - master
+#
+#    cache:
+#      directories:
+#        - node_modules
+#
+#    install:
+#      - brew tap wix/brew
+#      - brew install applesimutils
+#      - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash
+#      - export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+#      - nvm install 8
+#      - nvm use 8
+#      - nvm alias default 8
+#      - npm install -g yarn
+#      - npm install -g react-native-cli
+#      - npm install -g detox-cli
+#      - gem install xcpretty
+#      - yarn
+#
+#    script:
+#      - detox build -c ios.sim.release
+#      - detox test -c ios.sim.release
+#
+#  - language: android
+##    env:
+##      - REACT_NATIVE_VERSION=0.59.4
+#    android:
+#      components:
+#        - tools
+#        - platform-tools
+#        - build-tools-28.0.3
+#        - android-28
+#        - extra-google-google_play_services
+#        - extra-google-m2repository
+#        - extra-android-m2repository
+##        - sys-img-x86-android-26
+#        - sys-img-x86-android-28
+#
+#    cache:
+#      directories:
+#        - node_modules
+#
+#    install:
+#      - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash
+#      - export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+#      - nvm install 8
+#      - nvm use 8
+#      - nvm alias default 8
+#      - npm install -g yarn
+#      - npm install -g react-native-cli
+#      - npm install -g detox-cli
+#      - yes | sdkmanager "build-tools;28.0.3"
+#      - yarn
+#
+#    script:
+#      - detox build -c android.emu.release
+#      - detox test -c android.emu.release
+#
+#  - language: node_js
+#    node_js: 8
+#
+#    cache:
+#      directories:
+#        - node_modules
+#
+#    install:
+#      - yarn
+#
+#    script:
+#      - yarn run lint
+#      - yarn run test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ matrix:
       only:
         - master
 
-    env:
-      global:
-        - NODE_VERSION = 8
+    cache:
+      directories:
+        - node_modules
 
     install:
       - brew tap wix/brew
@@ -30,6 +30,41 @@ matrix:
     script:
       - detox build -c ios.sim.release
       - detox test -c ios.sim.release
+
+  - language: android
+#    env:
+#      - REACT_NATIVE_VERSION=0.59.4
+    android:
+      components:
+        - tools
+        - platform-tools
+        - build-tools-28.0.3
+        - android-28
+        - extra-google-google_play_services
+        - extra-google-m2repository
+        - extra-android-m2repository
+#        - sys-img-x86-android-26
+        - sys-img-x86-android-28
+
+    cache:
+      directories:
+        - node_modules
+
+    install:
+      - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash
+      - export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+      - nvm install 8
+      - nvm use 8
+      - nvm alias default 8
+      - npm install -g yarn
+      - npm install -g react-native-cli
+      - npm install -g detox-cli
+      - yes | sdkmanager "build-tools;28.0.3"
+      - yarn
+
+    script:
+      - detox build -c android.emu.release
+      - detox test -c android.emu.release
 
   - language: node_js
     node_js: 8

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ script:
 #
 #  - language: android
 ##    env:
-##      - REACT_NATIVE_VERSION=0.59.4
+##      - REACT_NATIVE_VERSION=0.60.5
 #    android:
 #      components:
 #        - tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ matrix:
       - npm install -g yarn
       - npm install -g react-native-cli
       - npm install -g detox-cli
+      - gem install xcpretty
       - yarn
 
     script:

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Parity Signer is integrated with [Detox](https://github.com/wix/Detox) E2E testi
 First make sure `detox-cli` is installed as global dependency with
 
 ```
-npm install -g detox-cli
+yarn global add detox-cli
 ```
 
 ##### Complete Test

--- a/README.md
+++ b/README.md
@@ -128,7 +128,10 @@ yarn global add detox-cli
 ```
 
 ##### Complete Test
-just run `yarn e2e:ios` or `yarn e2e:android`.
+
+1. run react native server with `yarn start`
+
+2. run `yarn e2e:ios` or `yarn e2e:android`.
 
 ##### Develop and Test
 Details please refer to Detox official [Documentation](https://github.com/wix/Detox/blob/master/docs/Guide.DevelopingWhileWritingTests.md)
@@ -149,7 +152,7 @@ If you want to use another specific device than defined in the configuration, ad
 yarn test-e2e:android --device-name Pixel_2_API_28
 ```
 
-On Android please replace `ios` with `android`, currently Detox's Android 0.60.x support is in progress, need to run `yarn start` to start a react-native server before testing. If there is an error, try build it again with `yarn build-e2e:android`
+On Android please replace `ios` with `android`, currently Detox's Android 0.60.x support is in progress, if there is an error, try build it again with `yarn build-e2e:android`
 
 ### Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -147,8 +147,9 @@ Re-run tests without re-installing the app
 yarn test-e2e:ios --reuse
 ```
 
-If you want to use another specific device than defined in the configuration, add `--device-name` flag (on Android API version is needed), for example:
+If you want to use another specific emulator/simulator than defined in the configuration, add `--device-name` flag (on Android API version is needed), for example:
 ```
+yarn test-e2e:ios --device-name iPhone X
 yarn test-e2e:android --device-name Pixel_2_API_28
 ```
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Corresponding data:
 
 #### Integration Test
 
-Parity Signer is integrated with [Detox](https://github.com/wix/Detox) E2E testing. And Detox has very detailed [documentation](https://github.com/wix/Detox/blob/master/docs/README.md).
+Parity Signer is integrated with [Detox](https://github.com/wix/Detox) E2E testing. Detox has very detailed [documentation](https://github.com/wix/Detox/blob/master/docs/README.md).
 
 First make sure `detox-cli` is installed as global dependency with
 
@@ -134,7 +134,7 @@ yarn global add detox-cli
 2. run `yarn e2e:ios` or `yarn e2e:android`.
 
 ##### Develop and Test
-Details please refer to Detox official [Documentation](https://github.com/wix/Detox/blob/master/docs/Guide.DevelopingWhileWritingTests.md)
+Details please refer to Detox official guide [here](https://github.com/wix/Detox/blob/master/docs/Guide.DevelopingWhileWritingTests.md)
 
 Once you have run `yarn ios` you do not need to build it, just run:
 ```shell
@@ -147,13 +147,13 @@ Re-run tests without re-installing the app
 yarn test-e2e:ios --reuse
 ```
 
-If you want to use another specific emulator/simulator than defined in the configuration, add `--device-name` flag (on Android API version is needed), for example:
+If you want to use another specific emulator/simulator than those defined in the configuration, add `--device-name` flag (on Android API version is needed), for example:
 ```
 yarn test-e2e:ios --device-name iPhone X
 yarn test-e2e:android --device-name Pixel_2_API_28
 ```
 
-On Android please replace `ios` with `android`, currently Detox's Android 0.60.x support is in progress, if there is an error, try build it again with `yarn build-e2e:android`
+On Android please replace `ios` with `android`, currently Detox's Android 0.60.x support is in progress, if there is an error, try to build it again with `yarn build-e2e:android`
 
 ### Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,13 @@ Re-run tests without re-installing the app
 ```
 yarn test-e2e:ios --reuse
 ```
-On Android is same, just replace `ios` with `android`, since Detox's Android support is in progress, when there is an error just build it again with `yarn build-e2e:android`
+
+If you want to use another specific device than defined in the configuration, add `--device-name` flag (on Android API version is needed), for example:
+```
+yarn test-e2e:android --device-name Pixel_2_API_28
+```
+
+On Android please replace `ios` with `android`, currently Detox's Android 0.60.x support is in progress, need to run `yarn start` to start a react-native server before testing. If there is an error, try build it again with `yarn build-e2e:android`
 
 ### Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ Corresponding data:
 
 Parity Signer is integrated with [Detox](https://github.com/wix/Detox) E2E testing. And Detox has very detailed [documentation](https://github.com/wix/Detox/blob/master/docs/README.md).
 
+First make sure `detox-cli` is installed as global dependency with
+
+```
+npm install -g detox-cli
+```
+
 To just test it, you may run `yarn e2e:ios` or `yarn e2e:android`.
 
 To test it during the develop, once you have run `yarn ios` you do not need to build it, just run:

--- a/README.md
+++ b/README.md
@@ -127,18 +127,23 @@ First make sure `detox-cli` is installed as global dependency with
 npm install -g detox-cli
 ```
 
-To just test it, you may run `yarn e2e:ios` or `yarn e2e:android`.
+##### Complete Test
+just run `yarn e2e:ios` or `yarn e2e:android`.
 
-To test it during the develop, once you have run `yarn ios` you do not need to build it, just run:
+##### Develop and Test
+Details please refer to Detox official [Documentation](https://github.com/wix/Detox/blob/master/docs/Guide.DevelopingWhileWritingTests.md)
+
+Once you have run `yarn ios` you do not need to build it, just run:
 ```shell
 yarn test-e2e:ios
 ```
+This command will open another simulator with the pre-defined configurations.
 
 Re-run tests without re-installing the app
 ```
 yarn test-e2e:ios --reuse
 ```
-On Android is same, just replace `ios` with `android`.
+On Android is same, just replace `ios` with `android`, since Detox's Android support is in progress, when there is an error just build it again with `yarn build-e2e:android`
 
 ### Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,23 @@ Corresponding data:
 }
 ```
 
+#### Integration Test
+
+Parity Signer is integrated with [Detox](https://github.com/wix/Detox) E2E testing. And Detox has very detailed [documentation](https://github.com/wix/Detox/blob/master/docs/README.md).
+
+To just test it, you may run `yarn e2e:ios` or `yarn e2e:android`.
+
+To test it during the develop, once you have run `yarn ios` you do not need to build it, just run:
+```shell
+yarn test-e2e:ios
+```
+
+Re-run tests without re-installing the app
+```
+yarn test-e2e:ios --reuse
+```
+On Android is same, just replace `ios` with `android`.
+
 ### Troubleshooting
 
 #### `No dimension set for key window` on Android < 5.0

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -98,7 +98,8 @@ def enableSeparateBuildPerCPUArchitecture = false
 def enableProguardInReleaseBuilds = false
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -107,7 +108,7 @@ android {
 
     defaultConfig {
         applicationId "io.parity.signer"
-        minSdkVersion 16
+        minSdkVersion 18
         missingDimensionStrategy 'react-native-camera', 'general'
         targetSdkVersion 28
         versionCode 309
@@ -119,6 +120,8 @@ android {
             pickFirst 'lib/x86_64/libjsc.so'
             pickFirst 'lib/arm64-v8a/libjsc.so'
         }
+        testBuildType System.getProperty('testBuildType', 'debug')  // This will later be used to control the test apk build type
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     signingConfigs {
         release {
@@ -146,6 +149,8 @@ android {
         release {
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+            // Detox-specific additions to pro-guard
+            // proguardFile "${rootProject.projectDir}/../node_modules/detox/android/detox/proguard-rules-app.pro"
         }
     }
     // applicationVariants are e.g. debug, release
@@ -178,6 +183,16 @@ dependencies {
         implementation 'org.webkit:android-jsc-intl:+'
     } else {
         implementation 'org.webkit:android-jsc:+'
+    }
+    androidTestImplementation('com.wix:detox:+') { transitive = true }
+    androidTestImplementation 'junit:junit:4.12'
+}
+
+configurations.all {
+    resolutionStrategy {
+        //  the line below is required for Detox since version 14.5.0;
+        //  it should removed as soon as the project compiles without it
+        force 'androidx.annotation:annotation:1.0.0'
     }
 }
 

--- a/android/app/src/androidTest/java/io/parity/signer/DetoxTest.java
+++ b/android/app/src/androidTest/java/io/parity/signer/DetoxTest.java
@@ -1,0 +1,24 @@
+package io.parity.signer;
+
+import com.wix.detox.Detox;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+import androidx.test.rule.ActivityTestRule;
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class DetoxTest {
+
+    @Rule
+    public ActivityTestRule<MainActivity> mActivityRule = new ActivityTestRule<>(MainActivity.class, false, false);
+
+    @Test
+    public void runDetoxTests() {
+        Detox.runTests(mActivityRule);
+    }
+}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,19 +3,19 @@
 buildscript {
    ext {
         buildToolsVersion = "28.0.3"
-        minSdkVersion = 16
+        minSdkVersion = 18
         compileSdkVersion = 28
         targetSdkVersion = 28
         supportLibVersion = "28.0.0"
+        kotlinVersion = '1.3.41'
     }
-
     repositories {
         google()
         jcenter()
     }
     dependencies {
         classpath('com.android.tools.build:gradle:3.4.2')
-
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -35,6 +35,10 @@ allprojects {
             // Android JSC is installed from npm
             url("$rootDir/../node_modules/jsc-android/dist")
         }
+        maven {
+            // All of Detox' artifacts are provided via the npm module
+            url "$rootDir/../node_modules/detox/Detox-android"
+        }
     }
 }
 
@@ -44,6 +48,14 @@ subprojects {
             if (details.requested.group == 'com.android.support'
                 && !details.requested.name.contains('multidex') ) {
             details.useVersion "28.0.3"
+            }
+        }
+    }
+    afterEvaluate {project ->
+        if (project.hasProperty("android")) {
+            android {
+                compileSdkVersion 28
+                buildToolsVersion "28.0.3"
             }
         }
     }

--- a/e2e/config.json
+++ b/e2e/config.json
@@ -1,0 +1,6 @@
+{
+    "setupFilesAfterEnv": ["./init.js"],
+    "testEnvironment": "node",
+    "reporters": ["detox/runners/jest/streamlineReporter"],
+    "verbose": true
+}

--- a/e2e/firstTest.spec.js
+++ b/e2e/firstTest.spec.js
@@ -1,15 +1,15 @@
-import testIds from "./testIds";
+import testIDs from "./testIDs";
 
 describe('Example', () => {
   beforeEach(async () => {
-    // await device.reloadReactNative();
+    await device.reloadReactNative();
   });
 
   it('should have account list screen', async () => {
-    await expect(element(by.id(testIds.TacScreen.tacView))).toBeVisible();
-    await element(by.id(testIds.TacScreen.agreePrivacyButton)).tap();
-    await element(by.id(testIds.TacScreen.agreeTacButton)).tap();
-    await element(by.id(testIds.TacScreen.nextButton)).tap();
-    await expect(element(by.id(testIds.AccountListScreen.accountList))).toBeVisible();
+    await expect(element(by.id(testIDs.TacScreen.tacView))).toBeVisible();
+    await element(by.id(testIDs.TacScreen.agreePrivacyButton)).tap();
+    await element(by.id(testIDs.TacScreen.agreeTacButton)).tap();
+    await element(by.id(testIDs.TacScreen.nextButton)).tap();
+    await expect(element(by.id(testIDs.AccountListScreen.accountList))).toBeVisible();
   });
 });

--- a/e2e/firstTest.spec.js
+++ b/e2e/firstTest.spec.js
@@ -1,10 +1,6 @@
 import testIDs from "./testIDs";
 
 describe('Load test', () => {
-  beforeEach(async () => {
-    await device.reloadReactNative();
-  });
-
   it('should have account list screen', async () => {
     await expect(element(by.id(testIDs.TacScreen.tacView))).toBeVisible();
     await element(by.id(testIDs.TacScreen.agreePrivacyButton)).tap();

--- a/e2e/firstTest.spec.js
+++ b/e2e/firstTest.spec.js
@@ -1,6 +1,6 @@
 import testIDs from "./testIDs";
 
-describe('Example', () => {
+describe('Load test', () => {
   beforeEach(async () => {
     await device.reloadReactNative();
   });

--- a/e2e/firstTest.spec.js
+++ b/e2e/firstTest.spec.js
@@ -1,0 +1,15 @@
+import testIds from "./testIds";
+
+describe('Example', () => {
+  beforeEach(async () => {
+    // await device.reloadReactNative();
+  });
+
+  it('should have account list screen', async () => {
+    await expect(element(by.id(testIds.TacScreen.tacView))).toBeVisible();
+    await element(by.id(testIds.TacScreen.agreePrivacyButton)).tap();
+    await element(by.id(testIds.TacScreen.agreeTacButton)).tap();
+    await element(by.id(testIds.TacScreen.nextButton)).tap();
+    await expect(element(by.id(testIds.AccountListScreen.accountList))).toBeVisible();
+  });
+});

--- a/e2e/init.js
+++ b/e2e/init.js
@@ -1,0 +1,25 @@
+const detox = require('detox');
+const config = require('../package.json').detox;
+const adapter = require('detox/runners/jest/adapter');
+const specReporter = require('detox/runners/jest/specReporter');
+
+// Set the default timeout
+jest.setTimeout(120000);
+jasmine.getEnv().addReporter(adapter);
+
+// This takes care of generating status logs on a per-spec basis. By default, jest only reports at file-level.
+// This is strictly optional.
+jasmine.getEnv().addReporter(specReporter);
+
+beforeAll(async () => {
+  await detox.init(config);
+});
+
+beforeEach(async () => {
+  await adapter.beforeEach();
+});
+
+afterAll(async () => {
+  await adapter.afterAll();
+  await detox.cleanup();
+});

--- a/e2e/testIDs.js
+++ b/e2e/testIDs.js
@@ -1,0 +1,13 @@
+const testIDs = {
+	TacScreen: {
+		tacView: 'tac_view',
+		agreeTacButton: 'tac_agree',
+		agreePrivacyButton: 'tac_privacy',
+		nextButton: 'tac_next'
+	},
+	AccountListScreen: {
+		accountList: 'accountList',
+	}
+};
+
+export default testIDs;

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
       },
       "ios.sim.release": {
         "binaryPath": "ios/build/NativeSigner/Build/Products/Release-iphonesimulator/NativeSigner.app",
-        "build": "xcodebuild -project ios/NativeSigner.xcodeproj -scheme NativeSigner -configuration Release -sdk iphonesimulator -derivedDataPath ios/build",
+        "build": "xcodebuild -project ios/NativeSigner.xcodeproj -scheme NativeSigner -configuration Release -sdk iphonesimulator -derivedDataPath ios/build -UseModernBuildSystem=NO",
         "type": "ios.simulator",
         "device": {
           "type": "iPhone 6 SE"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "ios": "yarn run build-rust-ios && react-native run-ios",
     "lint": "npx eslint ./src/ --ext .js,.jsx",
     "lint:fix": "npx eslint ./src/ --ext .js,.jsx --fix",
-    "postinstall": "npx jetify",
+    "postinstall": "npx jetify && ./scripts/fix-rn-camera-path.sh ./node_modules/react-native-camera/ios/RNCamera.xcodeproj/project.pbxproj",
     "start": "NODE_OPTIONS=--max_old_space_size=8192 react-native start",
     "test": "jest",
     "build-e2e:android": "detox build -c android.emu.debug",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,15 @@
         "build": "xcodebuild -project ios/NativeSigner.xcodeproj -scheme NativeSigner -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build",
         "type": "ios.simulator",
         "device": {
-          "type": "iPhone X"
+          "type": "iPhone 6 SE"
+        }
+      },
+      "ios.sim.release": {
+        "binaryPath": "ios/build/NativeSigner/Build/Products/Release-iphonesimulator/NativeSigner.app",
+        "build": "xcodebuild -project ios/NativeSigner.xcodeproj -scheme NativeSigner -configuration Release -sdk iphonesimulator -derivedDataPath ios/build",
+        "type": "ios.simulator",
+        "device": {
+          "type": "iPhone 6 SE"
         }
       },
       "android.emu.debug": {

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
       },
       "ios.sim.release": {
         "binaryPath": "ios/build/NativeSigner/Build/Products/Release-iphonesimulator/NativeSigner.app",
-        "build": "xcodebuild -project ios/NativeSigner.xcodeproj -scheme NativeSigner -configuration Release -sdk iphonesimulator -derivedDataPath ios/build -UseModernBuildSystem=NO",
+        "build": "xcodebuild -project ios/NativeSigner.xcodeproj -scheme NativeSigner -configuration Release -sdk iphonesimulator -derivedDataPath ios/build -UseModernBuildSystem=NO | xcpretty && exit ${PIPESTATUS[0]}",
         "type": "ios.simulator",
         "device": {
           "type": "iPhone 6 SE"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "ios": "yarn run build-rust-ios && react-native run-ios",
     "lint": "npx eslint ./src/ --ext .js,.jsx",
     "lint:fix": "npx eslint ./src/ --ext .js,.jsx --fix",
-    "postinstall": "npx jetify && ./scripts/fix-rn-camera-path.sh ./node_modules/react-native-camera/ios/RNCamera.xcodeproj/project.pbxproj",
+    "postinstall": "npx jetify && chmod +x ./scripts/fix-rn-camera-path.sh && ./scripts/fix-rn-camera-path.sh ./node_modules/react-native-camera/ios/RNCamera.xcodeproj/project.pbxproj",
     "start": "NODE_OPTIONS=--max_old_space_size=8192 react-native start",
     "test": "jest",
     "build-e2e:android": "detox build -c android.emu.debug",
@@ -112,7 +112,7 @@
         "build": "cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release && cd ..",
         "type": "android.emulator",
         "device": {
-          "avdName": "Nexus_5X_API_28"
+          "avdName": "Pixel_2_API_28"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "configurations": {
       "ios.sim.debug": {
         "binaryPath": "ios/build/NativeSigner/Build/Products/Debug-iphonesimulator/NativeSigner.app",
-        "build": "xcodebuild -project ios/NativeSigner.xcodeproj -scheme NativeSigner -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build",
+        "build": "xcodebuild -project ios/NativeSigner.xcodeproj -scheme NativeSigner -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build/NativeSigner",
         "type": "ios.simulator",
         "device": {
           "type": "iPhone SE"
@@ -100,7 +100,7 @@
       },
       "ios.sim.release": {
         "binaryPath": "ios/build/NativeSigner/Build/Products/Release-iphonesimulator/NativeSigner.app",
-        "build": "xcodebuild -project ios/NativeSigner.xcodeproj -scheme NativeSigner -configuration Release -sdk iphonesimulator -derivedDataPath ios/build -UseModernBuildSystem=NO | xcpretty -t && exit ${PIPESTATUS[0]}",
+        "build": "xcodebuild -project ios/NativeSigner.xcodeproj -scheme NativeSigner -configuration Release -sdk iphonesimulator -derivedDataPath ios/build/NativeSigner -UseModernBuildSystem=NO | xcpretty -t && exit ${PIPESTATUS[0]}",
         "type": "ios.simulator",
         "device": {
           "type": "iPhone SE"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,13 @@
     "lint:fix": "npx eslint ./src/ --ext .js,.jsx --fix",
     "postinstall": "npx jetify",
     "start": "NODE_OPTIONS=--max_old_space_size=8192 react-native start",
-    "test": "jest"
+    "test": "jest",
+    "build-e2e:android": "detox build -c android.emu.debug",
+    "test-e2e:android": "detox test -c android.emu.debug",
+    "e2e:android": "yarn run build-e2e:android && yarn run test-e2e:android",
+    "build-e2e:ios": "detox build -c ios.sim.debug",
+    "test-e2e:ios": "detox test -c ios.sim.debug",
+    "e2e:ios": "yarn run build-e2e:ios && yarn run test-e2e:ios"
   },
   "husky": {
     "hooks": {
@@ -90,6 +96,23 @@
         "type": "ios.simulator",
         "device": {
           "type": "iPhone X"
+        }
+      },
+      "android.emu.debug": {
+        "binaryPath": "android/app/build/outputs/apk/debug/app-debug.apk",
+        "build":
+        "cd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug && cd ..",
+        "type": "android.emulator",
+        "device": {
+          "avdName": "Pixel_2_API_28"
+        }
+      },
+      "android.emu.release": {
+        "binaryPath": "android/app/build/outputs/apk/release/app-release.apk",
+        "build": "cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release && cd ..",
+        "type": "android.emulator",
+        "device": {
+          "avdName": "Nexus_5X_API_28"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "babel-eslint": "10.0.3",
     "babel-jest": "^24.9.0",
     "babel-plugin-rewrite-require": "^1.14.5",
+    "detox": "^14.5.0",
     "eslint": "^6.3.0",
     "eslint-config-prettier": "^6.2.0",
     "eslint-plugin-prettier": "^3.1.0",
@@ -80,5 +81,19 @@
   },
   "resolutions": {
     "@react-native-community/eslint-config/babel-eslint": "10.0.3"
+  },
+  "detox": {
+    "configurations": {
+      "ios.sim.debug": {
+        "binaryPath": "ios/build/NativeSigner/Build/Products/Debug-iphonesimulator/NativeSigner.app",
+        "build": "xcodebuild -project ios/NativeSigner.xcodeproj -scheme NativeSigner -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build",
+        "type": "ios.simulator",
+        "device": {
+          "type": "iPhone X"
+        }
+      }
+    },
+    "runner-config": "e2e/config.json",
+    "test-runner": "jest"
   }
 }

--- a/package.json
+++ b/package.json
@@ -95,15 +95,15 @@
         "build": "xcodebuild -project ios/NativeSigner.xcodeproj -scheme NativeSigner -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build",
         "type": "ios.simulator",
         "device": {
-          "type": "iPhone 6 SE"
+          "type": "iPhone SE"
         }
       },
       "ios.sim.release": {
         "binaryPath": "ios/build/NativeSigner/Build/Products/Release-iphonesimulator/NativeSigner.app",
-        "build": "xcodebuild -project ios/NativeSigner.xcodeproj -scheme NativeSigner -configuration Release -sdk iphonesimulator -derivedDataPath ios/build -UseModernBuildSystem=NO | xcpretty && exit ${PIPESTATUS[0]}",
+        "build": "xcodebuild -project ios/NativeSigner.xcodeproj -scheme NativeSigner -configuration Release -sdk iphonesimulator -derivedDataPath ios/build -UseModernBuildSystem=NO | xcpretty -t && exit ${PIPESTATUS[0]}",
         "type": "ios.simulator",
         "device": {
-          "type": "iPhone 6 SE"
+          "type": "iPhone SE"
         }
       },
       "android.emu.debug": {
@@ -112,7 +112,7 @@
         "cd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug && cd ..",
         "type": "android.emulator",
         "device": {
-          "avdName": "Pixel_2_API_28"
+          "avdName": "Nexus_5_API_28"
         }
       },
       "android.emu.release": {
@@ -120,7 +120,7 @@
         "build": "cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release && cd ..",
         "type": "android.emulator",
         "device": {
-          "avdName": "Pixel_2_API_28"
+          "avdName": "Nexus_5_API_28"
         }
       }
     },

--- a/scripts/fix-rn-camera-path.sh
+++ b/scripts/fix-rn-camera-path.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# fix-rncamera-search-paths.sh
+#
+# Fix Frameworks/Headers Search Path build settings in react-native-camera/ios Xcode project
+# First argument is path to RNCamera xcode project file, e.g.:
+#   ./node_modules/react-native-camera/ios/RNCamera.xcodeproj/project.pbxproj
+#
+
+SRC_FILE="$1"
+
+if [ ! -f ${SRC_FILE} ]; then
+    echo "Error: RNCamera xcodeproj not found at path: ${SRC_FILE}"
+    echo "Skipping fix"
+    exit 0
+fi
+
+perl -i -p0e 's/FRAMEWORK_SEARCH_PATHS = (.*?);/FRAMEWORK_SEARCH_PATHS = "\$(SRCROOT)\/..\/..\/..\/ios\/Pods\/Headers\/**\/**";/gs' ${SRC_FILE}
+
+perl -i -p0e 's/HEADER_SEARCH_PATHS = (.*?);/HEADER_SEARCH_PATHS = "\$(SRCROOT)\/..\/..\/react-native\/React\/**";/gs' ${SRC_FILE}
+
+perl -i -p0e 's/LIBRARY_SEARCH_PATHS = (.*?);/LIBRARY_SEARCH_PATHS = "\$(SRCROOT)\/..\/..\/..\/ios\/Pods\/Headers\/**\/**";/gs' ${SRC_FILE}
+
+echo "Fixed RNCamera xcodeproj at path: ${SRC_FILE}"

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -46,7 +46,14 @@ export default class Button extends React.PureComponent<{
 	};
 
 	render() {
-		const { onPress, title, disabled, textStyles, buttonStyles } = this.props;
+		const {
+			onPress,
+			title,
+			disabled,
+			textStyles,
+			buttonStyles,
+			testID
+		} = this.props;
 
 		const finalTextStyles = [styles.text, textStyles];
 		const finalButtonStyles = [styles.button, buttonStyles];
@@ -63,6 +70,7 @@ export default class Button extends React.PureComponent<{
 				accessibilityComponentType="button"
 				disabled={disabled}
 				onPress={onPress}
+				testID={testID}
 			>
 				<View style={finalButtonStyles}>
 					<Text style={finalTextStyles} disabled={disabled}>

--- a/src/screens/AccountList.js
+++ b/src/screens/AccountList.js
@@ -28,6 +28,7 @@ import Button from '../components/Button';
 import PopupMenu from '../components/PopupMenu';
 import fonts from '../fonts';
 import AccountsStore from '../stores/AccountsStore';
+import testIDs from '../../e2e/testIDs';
 
 export default class AccountList extends React.PureComponent {
 	static navigationOptions = {
@@ -89,7 +90,7 @@ class AccountListView extends React.PureComponent {
 		const { navigate } = navigation;
 
 		return (
-			<View style={styles.body}>
+			<View style={styles.body} testID={testIDs.AccountListScreen.accountList}>
 				<Background />
 				<View style={styles.header}>
 					<Text style={styles.title}>ACCOUNTS</Text>

--- a/src/screens/TermsAndConditions.js
+++ b/src/screens/TermsAndConditions.js
@@ -26,6 +26,7 @@ import Button from '../components/Button';
 import Markdown from '../components/Markdown';
 import TouchableItem from '../components/TouchableItem';
 import { saveToCAndPPConfirmation } from '../util/db';
+import testIDs from '../../e2e/testIDs';
 
 export default class TermsAndConditions extends React.PureComponent {
 	static navigationOptions = {
@@ -42,12 +43,13 @@ export default class TermsAndConditions extends React.PureComponent {
 		const { navigation } = this.props;
 		const { tocAgreement, ppAgreement } = this.state;
 		return (
-			<View style={styles.body}>
+			<View style={styles.body} testID={testIDs.TacScreen.tacView}>
 				<ScrollView contentContainerStyle={{}}>
 					<Markdown>{toc}</Markdown>
 				</ScrollView>
 
 				<TouchableItem
+					testID={testIDs.TacScreen.agreeTacButton}
 					style={{
 						alignItems: 'center',
 						flexDirection: 'row'
@@ -75,6 +77,7 @@ export default class TermsAndConditions extends React.PureComponent {
 					}}
 				>
 					<Icon
+						testID={testIDs.TacScreen.agreePrivacyButton}
 						name={ppAgreement ? 'checkbox-marked' : 'checkbox-blank-outline'}
 						style={[styles.text, { fontSize: 30 }]}
 					/>
@@ -94,6 +97,7 @@ export default class TermsAndConditions extends React.PureComponent {
 
 				<Button
 					buttonStyles={{ height: 60, marginTop: 10 }}
+					testID={testIDs.TacScreen.nextButton}
 					title="Next"
 					disabled={!ppAgreement || !tocAgreement}
 					onPress={async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -46,6 +46,26 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
+"@babel/core@^7.4.5":
+  version "7.6.4"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.6.4.tgz#6ebd9fe00925f6c3e177bb726a188b5f578088ff"
+  integrity sha512-Rm0HGw101GY8FTzpWSyRbki/jzq+/PkNQJ+nSulrdY6gFGOsNseCqD6KHRYe2E+EdzuBdr2pxCp6s4Uk6eJ+XQ==
+  dependencies:
+    "@babel/code-frame" "^7.5.5"
+    "@babel/generator" "^7.6.4"
+    "@babel/helpers" "^7.6.2"
+    "@babel/parser" "^7.6.4"
+    "@babel/template" "^7.6.0"
+    "@babel/traverse" "^7.6.3"
+    "@babel/types" "^7.6.3"
+    convert-source-map "^1.1.0"
+    debug "^4.1.0"
+    json5 "^2.1.0"
+    lodash "^4.17.13"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
 "@babel/generator@^7.0.0", "@babel/generator@^7.4.0", "@babel/generator@^7.6.0":
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.6.0.tgz#e2c21efbfd3293ad819a2359b448f002bfdfda56"
@@ -56,6 +76,16 @@
     lodash "^4.17.13"
     source-map "^0.5.0"
     trim-right "^1.0.1"
+
+"@babel/generator@^7.6.3", "@babel/generator@^7.6.4":
+  version "7.6.4"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.6.4.tgz#a4f8437287bf9671b07f483b76e3bb731bc97671"
+  integrity sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==
+  dependencies:
+    "@babel/types" "^7.6.3"
+    jsesc "^2.5.1"
+    lodash "^4.17.13"
+    source-map "^0.5.0"
 
 "@babel/helper-annotate-as-pure@^7.0.0":
   version "7.0.0"
@@ -241,6 +271,15 @@
     "@babel/traverse" "^7.6.0"
     "@babel/types" "^7.6.0"
 
+"@babel/helpers@^7.6.2":
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.6.2.tgz#681ffe489ea4dcc55f23ce469e58e59c1c045153"
+  integrity sha512-3/bAUL8zZxYs1cdX2ilEE0WobqbCmKWr/889lf2SS0PpDcpEIY8pb1CCyz0pEcX3pEb+MCbks1jIokz2xLtGTA==
+  dependencies:
+    "@babel/template" "^7.6.0"
+    "@babel/traverse" "^7.6.2"
+    "@babel/types" "^7.6.0"
+
 "@babel/highlight@^7.0.0":
   version "7.5.0"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.5.0.tgz#56d11312bd9248fa619591d02472be6e8cb32540"
@@ -254,6 +293,11 @@
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.6.0.tgz#3e05d0647432a8326cb28d0de03895ae5a57f39b"
   integrity sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ==
+
+"@babel/parser@^7.6.3", "@babel/parser@^7.6.4":
+  version "7.6.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.6.4.tgz#cb9b36a7482110282d5cb6dd424ec9262b473d81"
+  integrity sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==
 
 "@babel/plugin-external-helpers@^7.0.0":
   version "7.2.0"
@@ -663,10 +707,34 @@
     globals "^11.1.0"
     lodash "^4.17.13"
 
+"@babel/traverse@^7.6.2", "@babel/traverse@^7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.6.3.tgz#66d7dba146b086703c0fb10dd588b7364cec47f9"
+  integrity sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==
+  dependencies:
+    "@babel/code-frame" "^7.5.5"
+    "@babel/generator" "^7.6.3"
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-split-export-declaration" "^7.4.4"
+    "@babel/parser" "^7.6.3"
+    "@babel/types" "^7.6.3"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.13"
+
 "@babel/types@^7.0.0", "@babel/types@^7.2.0", "@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.5.5", "@babel/types@^7.6.0":
   version "7.6.1"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.6.1.tgz#53abf3308add3ac2a2884d539151c57c4b3ac648"
   integrity sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.6.3.tgz#3f07d96f854f98e2fbd45c64b0cb942d11e8ba09"
+  integrity sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.13"
@@ -1904,6 +1972,11 @@ blakejs@^1.1.0:
   resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.1.0.tgz#69df92ef953aa88ca51a32df6ab1c54a155fc7a5"
   integrity sha1-ad+S75U6qIylGjLfarHFShVfx6U=
 
+bluebird@3.5.x:
+  version "3.5.5"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.5.tgz#a8d0afd73251effbbd5fe384a77d73003c17a71f"
+  integrity sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==
+
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.11.8, bn.js@^4.4.0:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
@@ -2079,6 +2152,24 @@ builtin-status-codes@^3.0.0:
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
   integrity sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=
 
+bunyan-debug-stream@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/bunyan-debug-stream/-/bunyan-debug-stream-1.1.1.tgz#4740a00b7d5c2d9d1b714925ab0802516040813e"
+  integrity sha512-jJbQ1gXUL6vMmZVdbaTFK1v1sGa7axLrSQQwkB6HU9HCPTzsw2HsKcPHm1vgXZlEck/4IvEuRwg/9+083YelCg==
+  dependencies:
+    colors "^1.0.3"
+    exception-formatter "^1.0.4"
+
+bunyan@^1.8.12:
+  version "1.8.12"
+  resolved "https://registry.yarnpkg.com/bunyan/-/bunyan-1.8.12.tgz#f150f0f6748abdd72aeae84f04403be2ef113797"
+  integrity sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=
+  optionalDependencies:
+    dtrace-provider "~0.8"
+    moment "^2.10.6"
+    mv "~2"
+    safe-json-stringify "~1"
+
 bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
@@ -2180,6 +2271,15 @@ check-error@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
   integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
+
+child-process-promise@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/child-process-promise/-/child-process-promise-2.2.1.tgz#4730a11ef610fad450b8f223c79d31d7bdad8074"
+  integrity sha1-RzChHvYQ+tRQuPIjx50x172tgHQ=
+  dependencies:
+    cross-spawn "^4.0.2"
+    node-version "^1.0.0"
+    promise-polyfill "^6.0.1"
 
 chokidar@^2.1.8:
   version "2.1.8"
@@ -2337,6 +2437,11 @@ colorette@^1.0.7:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.1.0.tgz#1f943e5a357fac10b4e0f5aaef3b14cdc1af6ec7"
   integrity sha512-6S062WDQUXi6hOfkO/sBPVwE5ASXY4G2+b4atvhJfSsuUUhIaUKlkjLe9692Ipyt5/a+IPF5aVTu3V5gvXq5cg==
+
+colors@^1.0.3:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
+  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
 
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.8"
@@ -2508,6 +2613,14 @@ create-react-context@^0.1.5:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.1.6.tgz#0f425931d907741127acc6e31acb4f9015dd9fdc"
   integrity sha512-eCnYYEUEc5i32LHwpE/W7NlddOB9oHwsPaWtWzYtflNkkwa3IfindIcoXdVWs12zCbwaMCavKNu84EXogVIWHw==
+
+cross-spawn@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
+  integrity sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=
+  dependencies:
+    lru-cache "^4.0.1"
+    which "^1.2.9"
 
 cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
@@ -2745,6 +2858,33 @@ detect-newline@^2.1.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
   integrity sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=
 
+detox@^14.5.0:
+  version "14.5.0"
+  resolved "https://registry.yarnpkg.com/detox/-/detox-14.5.0.tgz#cc96b41a2b76a029ef26be861fb04f69fe70c965"
+  integrity sha512-6LH/Aw/0pnf5llCY5rZICxVK1uoAmV+OZzGPQogpE3ZqxPkViFkg/SHsQqOn1M1Iswia7SzfSgu2KfKMNFXvRA==
+  dependencies:
+    "@babel/core" "^7.4.5"
+    bunyan "^1.8.12"
+    bunyan-debug-stream "^1.1.0"
+    chalk "^2.4.2"
+    child-process-promise "^2.2.0"
+    fs-extra "^4.0.2"
+    funpermaproxy "^1.0.1"
+    get-port "^2.1.0"
+    ini "^1.3.4"
+    lodash "^4.17.5"
+    minimist "^1.2.0"
+    proper-lockfile "^3.0.2"
+    sanitize-filename "^1.6.1"
+    shell-utils "^1.0.9"
+    tail "^2.0.0"
+    telnet-client "0.15.3"
+    tempfile "^2.0.0"
+    which "^1.3.1"
+    ws "^3.3.1"
+    yargs "^13.0.0"
+    yargs-parser "^13.0.0"
+
 diff-sequences@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.9.0.tgz#5715d6244e2aa65f48bba0bc972db0b0b11e95b5"
@@ -2824,6 +2964,13 @@ drbg.js@^1.0.1:
     browserify-aes "^1.0.6"
     create-hash "^1.1.2"
     create-hmac "^1.1.4"
+
+dtrace-provider@~0.8:
+  version "0.8.8"
+  resolved "https://registry.yarnpkg.com/dtrace-provider/-/dtrace-provider-0.8.8.tgz#2996d5490c37e1347be263b423ed7b297fb0d97e"
+  integrity sha512-b7Z7cNtHPhH9EJhNNbbeqTcXB8LGFFZhq1PGgEvpeHlzd36bhbdTWoE/Ba/YguqpBSlAPKnARWhVlhunCMwfxg==
+  dependencies:
+    nan "^2.14.0"
 
 ecc-jsbn@~0.1.1:
   version "0.1.2"
@@ -3215,6 +3362,13 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
 
+exception-formatter@^1.0.4:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/exception-formatter/-/exception-formatter-1.0.7.tgz#3291616b86fceabefa97aee6a4708032c6e3b96d"
+  integrity sha512-zV45vEsjytJrwfGq6X9qd1Ll56cW4NC2mhCO6lqwMk4ZpA1fZ6C3UiaQM/X7if+7wZFmCgss3ahp9B/uVFuLRw==
+  dependencies:
+    colors "^1.0.3"
+
 exec-sh@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.3.2.tgz#6738de2eb7c8e671d0366aea0b0db8c6f7d7391b"
@@ -3557,6 +3711,15 @@ fs-extra@^1.0.0:
     jsonfile "^2.1.0"
     klaw "^1.0.0"
 
+fs-extra@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
+  integrity sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-extra@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
@@ -3601,6 +3764,11 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
+funpermaproxy@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/funpermaproxy/-/funpermaproxy-1.0.1.tgz#4650e69b7c334d9717c06beba9b339cc08ac3335"
+  integrity sha512-9pEzs5vnNtR7ZGihly98w/mQ7blsvl68Wj30ZCDAXy7qDN4CWLLjdfjtH/P2m6whsnaJkw15hysCNHMXue+wdA==
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
@@ -3629,6 +3797,13 @@ get-func-name@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
   integrity sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=
+
+get-port@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/get-port/-/get-port-2.1.0.tgz#8783f9dcebd1eea495a334e1a6a251e78887ab1a"
+  integrity sha1-h4P53OvR7qSVozThpqJR54iHqxo=
+  dependencies:
+    pinkie-promise "^2.0.0"
 
 get-stdin@^6.0.0:
   version "6.0.0"
@@ -3678,6 +3853,17 @@ glob-parent@^5.0.0:
   integrity sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==
   dependencies:
     is-glob "^4.0.1"
+
+glob@^6.0.1:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
+  integrity sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=
+  dependencies:
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "2 || 3"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
 
 glob@^7.0.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
   version "7.1.4"
@@ -3978,7 +4164,7 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ini@~1.3.0:
+ini@^1.3.4, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
@@ -4978,7 +5164,7 @@ lodash.unescape@4.0.1:
   resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
   integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
 
-lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.5, lodash@^4.3.0, lodash@^4.6.1:
+lodash@4.x.x, lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.5, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -5493,7 +5679,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-minimatch@^3.0.4:
+"minimatch@2 || 3", minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -5543,14 +5729,14 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@^0.5.0, mkdirp@^0.5.1:
+mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
 
-moment@^2.24.0:
+moment@^2.10.6, moment@^2.24.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
@@ -5586,6 +5772,15 @@ mute-stream@0.0.7:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
+mv@~2:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/mv/-/mv-2.1.1.tgz#ae6ce0d6f6d5e0a4f7d893798d03c1ea9559b6a2"
+  integrity sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=
+  dependencies:
+    mkdirp "~0.5.1"
+    ncp "~2.0.0"
+    rimraf "~2.4.0"
+
 nan@^2.12.1, nan@^2.14.0:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
@@ -5612,6 +5807,11 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+
+ncp@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
+  integrity sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=
 
 needle@^2.2.1:
   version "2.4.0"
@@ -5731,6 +5931,11 @@ node-pre-gyp@^0.12.0:
     rimraf "^2.6.1"
     semver "^5.3.0"
     tar "^4"
+
+node-version@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/node-version/-/node-version-1.2.0.tgz#34fde3ffa8e1149bd323983479dda620e1b5060d"
+  integrity sha512-ma6oU4Sk0qOoKEAymVoTvk8EdXEobdS7m/mAGhDJ8Rouugho48crHBORAmy5BoOcv8wraPM6xumapQp5hl4iIQ==
 
 nopt@^4.0.1:
   version "4.0.1"
@@ -6255,6 +6460,18 @@ pify@^4.0.1:
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
 
+pinkie-promise@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
+  integrity sha1-ITXW36ejWMBprJsXh3YogihFD/o=
+  dependencies:
+    pinkie "^2.0.0"
+
+pinkie@^2.0.0:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
+  integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
+
 pirates@^4.0.0, pirates@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.1.tgz#643a92caf894566f91b2b986d2c66950a8e2fb87"
@@ -6365,6 +6582,11 @@ progress@^2.0.0:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
+promise-polyfill@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-6.1.0.tgz#dfa96943ea9c121fca4de9b5868cb39d3472e057"
+  integrity sha1-36lpQ+qcEh/KTem1hoyznTRy4Fc=
+
 promise@^7.1.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
@@ -6393,6 +6615,15 @@ propagate@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
   integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
+
+proper-lockfile@^3.0.2:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/proper-lockfile/-/proper-lockfile-3.2.0.tgz#89ca420eea1d55d38ca552578851460067bcda66"
+  integrity sha512-iMghHHXv2bsxl6NchhEaFck8tvX3F9cknEEh1SUpguUOBjN7PAAW9BLzmbc1g/mCD1gY3EE2EABBHPJfFdHFmA==
+  dependencies:
+    graceful-fs "^4.1.11"
+    retry "^0.12.0"
+    signal-exit "^3.0.2"
 
 pseudomap@^1.0.2:
   version "1.0.2"
@@ -7034,6 +7265,11 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
+retry@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
+  integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
+
 rimraf@2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
@@ -7052,6 +7288,13 @@ rimraf@~2.2.6:
   version "2.2.8"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
   integrity sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=
+
+rimraf@~2.4.0:
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.4.5.tgz#ee710ce5d93a8fdb856fb5ea8ff0e2d75934b2da"
+  integrity sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=
+  dependencies:
+    glob "^6.0.1"
 
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
@@ -7119,6 +7362,11 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, 
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
   integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
 
+safe-json-stringify@~1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz#356e44bc98f1f93ce45df14bcd7c01cda86e0afd"
+  integrity sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==
+
 safe-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e"
@@ -7145,6 +7393,13 @@ sane@^4.0.3:
     micromatch "^3.1.4"
     minimist "^1.1.1"
     walker "~1.0.5"
+
+sanitize-filename@^1.6.1:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/sanitize-filename/-/sanitize-filename-1.6.3.tgz#755ebd752045931977e30b2025d340d7c9090378"
+  integrity sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==
+  dependencies:
+    truncate-utf8-bytes "^1.0.0"
 
 sax@^1.2.1, sax@^1.2.4:
   version "1.2.4"
@@ -7294,6 +7549,13 @@ shell-quote@^1.6.1:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
   integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
+
+shell-utils@^1.0.9:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/shell-utils/-/shell-utils-1.0.10.tgz#7fe7b8084f5d6d21323d941267013bc38aed063e"
+  integrity sha512-p1xuqhj3jgcXiV8wGoF1eL/NOvapN9tyGDoObqKwvZTUZn7fIzK75swLTEHfGa7sObeN9vxFplHw/zgYUYRTsg==
+  dependencies:
+    lodash "4.x.x"
 
 shellwords@^0.1.1:
   version "0.1.1"
@@ -7667,6 +7929,11 @@ table@^5.2.3:
     slice-ansi "^2.1.0"
     string-width "^3.0.0"
 
+tail@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/tail/-/tail-2.0.3.tgz#37567adc4624a70b35f1d146c3376fa3d6ef7c04"
+  integrity sha512-s9NOGkLqqiDEtBttQZI7acLS8ycYK5sTlDwNjGnpXG9c8AWj0cfAtwEIzo/hVRMMiC5EYz+bXaJWC1u1u0GPpQ==
+
 tar@^4:
   version "4.4.10"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.10.tgz#946b2810b9a5e0b26140cf78bea6b0b0d689eba1"
@@ -7680,6 +7947,18 @@ tar@^4:
     safe-buffer "^5.1.2"
     yallist "^3.0.3"
 
+telnet-client@0.15.3:
+  version "0.15.3"
+  resolved "https://registry.yarnpkg.com/telnet-client/-/telnet-client-0.15.3.tgz#99ec754e4acf6fa51dc69898f574df3c2550712e"
+  integrity sha512-GSfdzQV0BKIYsmeXq7bJFJ2wHeJud6icaIxCUf6QCGQUD6R0BBGbT1+yLDhq67JRdgRpwyPwUbV7JxFeRrZomQ==
+  dependencies:
+    bluebird "3.5.x"
+
+temp-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-1.0.0.tgz#0a7c0ea26d3a39afa7e0ebea9c1fc0bc4daa011d"
+  integrity sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=
+
 temp@0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/temp/-/temp-0.8.3.tgz#e0c6bc4d26b903124410e4fed81103014dfc1f59"
@@ -7687,6 +7966,14 @@ temp@0.8.3:
   dependencies:
     os-tmpdir "^1.0.0"
     rimraf "~2.2.6"
+
+tempfile@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tempfile/-/tempfile-2.0.0.tgz#6b0446856a9b1114d1856ffcbe509cccb0977265"
+  integrity sha1-awRGhWqbERTRhW/8vlCczLCXcmU=
+  dependencies:
+    temp-dir "^1.0.0"
+    uuid "^3.0.1"
 
 test-exclude@^5.2.3:
   version "5.2.3"
@@ -7820,6 +8107,13 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
+
+truncate-utf8-bytes@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz#405923909592d56f78a5818434b0b78489ca5f2b"
+  integrity sha1-QFkjkJWS1W94pYGENLC3hInKXys=
+  dependencies:
+    utf8-byte-length "^1.0.1"
 
 tslib@^1.8.1, tslib@^1.9.0:
   version "1.10.0"
@@ -8023,6 +8317,11 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
+utf8-byte-length@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz#f45f150c4c66eee968186505ab93fcbb8ad6bf61"
+  integrity sha1-9F8VDExm7uloGGUFq5P8u4rWv2E=
+
 util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
@@ -8055,7 +8354,7 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@^3.3.2:
+uuid@^3.0.1, uuid@^3.3.2:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
   integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
@@ -8173,7 +8472,7 @@ which-module@^2.0.0:
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
-which@^1.2.9, which@^1.3.0:
+which@^1.2.9, which@^1.3.0, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
@@ -8348,7 +8647,7 @@ yargs-parser@^11.1.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^13.1.1:
+yargs-parser@^13.0.0, yargs-parser@^13.1.1:
   version "13.1.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.1.tgz#d26058532aa06d365fe091f6a1fc06b2f7e5eca0"
   integrity sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==
@@ -8381,7 +8680,7 @@ yargs@^12.0.5:
     y18n "^3.2.1 || ^4.0.0"
     yargs-parser "^11.1.1"
 
-yargs@^13.2.2, yargs@^13.3.0:
+yargs@^13.0.0, yargs@^13.2.2, yargs@^13.3.0:
   version "13.3.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.0.tgz#4c657a55e07e5f2cf947f8a366567c04a0dedc83"
   integrity sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==


### PR DESCRIPTION
This is the configuration part of #326 which enable us to run CI locally.

For test it locally you need install `detox-cli` as global npm dependency. it has conflict with local `detox` dependency so that we could not add it locally and start with `npx`

```
npm install -g detox-cli
```

After testing with Cavy and Detox, I find Detox is a better choice for us, since we want to develop the test and the origin code base at the same time. And the only complex part of Detox is the configuration part, to use it we do not to use High Order Component, but just with an `testID` on the component. It is more powerful and It is in active development by Wix team.

There are some comparison articles like [Detox vs Appium](https://medium.com/reactive-hub/detox-vs-appium-ui-tests-in-react-native-2d07bf1e244f) or [Detox vs Cavy](https://github.com/pixielabs/cavy/wiki/Detox-comparison)

c37c6e4 : fixes a recursive path problem caused by react-native-camera when build test on iOS, discussion [here](https://github.com/react-native-community/react-native-camera/issues/1407#issuecomment-435702383)

### Test Demo
| iOS       | Android  |
| ------------- |:-------------:|
|![out](https://user-images.githubusercontent.com/6014309/67159360-a64e0480-f343-11e9-9a82-660ca353a1e0.gif)|![out_android](https://user-images.githubusercontent.com/6014309/67159357-9d5d3300-f343-11e9-8f5a-daf76dbb71eb.gif)|

### Further steps
After a lot of attempts trying to add the integration test on Travis CI, I keep get the failing test because the build process failed without variant configurations like Rust environment or Android NKD. This will need helps from other people who is experienced with setting Travis CI test environment, and I would like to suggest **now we do the CI test locally, and work on Travis CI integration in another PR**, to prevent blocking current development work.