### PR TITLE
chore: upgrade to RN 0.61.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "node-libs-react-native": "^1.0.3",
     "prop-types": "^15.6.1",
     "react": "^16.9.0",
-    "react-native": "0.60.5",
+    "react-native": "0.61.2",
     "react-native-camera": "^3.4.0",
     "react-native-gesture-handler": "^1.4.1",
     "react-native-keyboard-aware-scroll-view": "^0.9.1",

--- a/src/util/native.js
+++ b/src/util/native.js
@@ -16,8 +16,10 @@
 
 'use strict';
 
-import { EthkeyBridge } from 'NativeModules';
+import { NaitveModules } from 'react-native';
 import { checksummedAddress } from './checksum';
+
+const { EthkeyBridge } = NaitveModules;
 
 /**
  * Turn an address string tagged with either 'legacy:' or 'bip39:' prefix

--- a/src/util/native.js
+++ b/src/util/native.js
@@ -16,10 +16,10 @@
 
 'use strict';
 
-import { NaitveModules } from 'react-native';
+import { NativeModules } from 'react-native';
 import { checksummedAddress } from './checksum';
 
-const { EthkeyBridge } = NaitveModules;
+const { EthkeyBridge } = NativeModules;
 
 /**
  * Turn an address string tagged with either 'legacy:' or 'bip39:' prefix


### PR DESCRIPTION
I couldn't perform a successful e2e test on substrate development using `apps`. Because of the recent changes in Kusama I believe. I was able to perform an e2e test (transaction) on an older version of `apps` using the `dev-node`.
Ethereum Tx and signing were successfully tested as well.