### PR TITLE
fix: Header and upgrade gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,7 +14,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath('com.android.tools.build:gradle:3.4.2')
+        classpath('com.android.tools.build:gradle:3.5.1')
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/src/App.js
+++ b/src/App.js
@@ -99,7 +99,7 @@ const globalStackNavigationOptions = {
 	},
 	headerTintColor: colors.card_bg,
 	headerTitleStyle: {
-		// display: 'none'
+		display: 'none'
 	}
 };
 


### PR DESCRIPTION
- closes #447 
- update gradle to 3.5.1 (Android Studio kept asking me to)

The header brings back the usual behavior on Android of not having any header title. Please make sure that it looks ok on iphone (the home as well as the other screens).