### PR TITLE
test: add test arguments for e2e test

### DIFF
--- a/android/app/src/main/java/io/parity/signer/MainActivity.java
+++ b/android/app/src/main/java/io/parity/signer/MainActivity.java
@@ -26,7 +26,6 @@ public class MainActivity extends ReactActivity {
             getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE,
                                        WindowManager.LayoutParams.FLAG_SECURE);
         }
-
     }
 
     @Override
@@ -35,6 +34,14 @@ public class MainActivity extends ReactActivity {
             @Override
             protected ReactRootView createRootView() {
             return new RNGestureHandlerEnabledRootView(MainActivity.this);
+            }
+
+            @Override
+            protected Bundle getLaunchOptions() {
+                Bundle bundle = new Bundle();
+                Bundle argumentsBundle = MainActivity.this.getIntent().getBundleExtra("launchArgs");
+                bundle.putBundle("launchArgs", argumentsBundle);
+                return bundle;
             }
         };
     }

--- a/ios/NativeSigner/AppDelegate.m
+++ b/ios/NativeSigner/AppDelegate.m
@@ -17,9 +17,12 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
   RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
+  NSArray<NSString *> *arguments = [[NSProcessInfo processInfo] arguments];
+  NSDictionary *initialProps = [NSDictionary dictionaryWithObject: arguments forKey: @"launchArgs"];
+  
   RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
                                                    moduleName:@"NativeSigner"
-                                            initialProperties:nil];
+                                            initialProperties:initialProps];
 
   rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
 

--- a/src/App.js
+++ b/src/App.js
@@ -21,7 +21,7 @@ import '../shim';
 import '@polkadot/types/injector';
 
 import React, { Component } from 'react';
-import { StatusBar, YellowBox } from 'react-native';
+import { Platform, StatusBar, YellowBox } from 'react-native';
 import {
 	createAppContainer,
 	createStackNavigator,
@@ -58,9 +58,23 @@ import SignedTx from './screens/SignedTx';
 import TermsAndConditions from './screens/TermsAndConditions';
 import TxDetails from './screens/TxDetails';
 
+const getLaunchArgs = props => {
+	if (Platform.OS === 'ios') {
+		if (props.launchArgs && props.launchArgs.includes('-detoxServer')) {
+			global.inTest = true;
+		}
+	} else {
+		if (props.launchArgs && props.launchArgs.hasOwnProperty('detoxServer')) {
+			global.inTest = true;
+		}
+	}
+	global.inTest = false;
+};
+
 export default class App extends Component {
-	constructor() {
+	constructor(props) {
 		super();
+		getLaunchArgs(props);
 		if (__DEV__) {
 			YellowBox.ignoreWarnings([
 				'Warning: componentWillReceiveProps',


### PR DESCRIPTION
Create the bindings for launchArgs, which could be useful now to detect the detox e2e environment and set mock methods.

### iOS
The launchArgs in ios would be an array with following strings ( It wouldn't be empty, at least contain the path): 
<img width="557" alt="Screen Shot 2019-11-09 at 11 45 39" src="https://user-images.githubusercontent.com/6014309/68528397-82eaf980-02f2-11ea-8d45-208b43fa4f6f.png">
<img width="824" alt="Screen Shot 2019-11-09 at 13 14 40" src="https://user-images.githubusercontent.com/6014309/68528436-f7be3380-02f2-11ea-9621-814a4119cd3f.png">

### Android
The launchArgs in Android is an object, return null if there is no args:
<img width="1093" alt="Screen Shot 2019-11-09 at 12 18 50" src="https://user-images.githubusercontent.com/6014309/68528410-ab72f380-02f2-11ea-8d36-22523c5ebcde.png">

### Usage
We could cal `global.inTest` to check if it is a test runtime.
