### PR TITLE
fix: loading error

### DIFF
--- a/src/screens/Loading.js
+++ b/src/screens/Loading.js
@@ -75,14 +75,14 @@ export default class Loading extends React.PureComponent {
 		const oldAccounts_v2 = await loadAccounts(2);
 		const oldAccounts = [...oldAccounts_v1, ...oldAccounts_v2];
 		const accounts = oldAccounts.map(([_, value]) => {
-			let result = {};
 			if (value.chainId) {
 				// The networkKey for Ethereum accounts is the chain id
-				result = { ...value, networkKey: value.chainId, recovered: true };
+				const result = { ...value, networkKey: value.chainId, recovered: true };
 				delete result.chainId;
 				delete result.networkType;
+				return result;
 			}
-			return result;
+			return value;
 		});
 
 		accounts.forEach(account => {


### PR DESCRIPTION
Not sure when this part of loading code is changed.
Description:
If there is substrate code in the keychain, after reinstall, will have accountID generate error. It is because that migration ignored substrate account here.
related to #412 

Reproduce bug (only on iOS): 
Install the app, create one substrate account on KUSAMA, delete app, install again, now the first screen will see the error screen. 


