### PR TITLE
fix: remove version in "About" to fix CI

### DIFF
--- a/src/screens/About.js
+++ b/src/screens/About.js
@@ -20,7 +20,6 @@ import React from 'react';
 import { Linking, ScrollView, StyleSheet, Text, View } from 'react-native';
 import colors from '../colors';
 import fonts from '../fonts';
-import packageJson from '../../package.json';
 
 export default class About extends React.PureComponent {
 	static navigationOptions = {
@@ -31,7 +30,7 @@ export default class About extends React.PureComponent {
 	render() {
 		return (
 			<ScrollView style={styles.body} contentContainerStyle={{ padding: 20 }}>
-				<Text style={styles.title}>PARITY SIGNER ({packageJson.version})</Text>
+				<Text style={styles.title}>PARITY SIGNER</Text>
 				<View>
 					<Text style={styles.text}>
 						The Parity Signer mobile application is a secure air-gapped wallet

--- a/src/screens/AccountBackup.js
+++ b/src/screens/AccountBackup.js
@@ -111,7 +111,7 @@ class AccountBackupView extends React.PureComponent {
 				</View>
 				<TouchableItem
 					onPress={() => {
-						// only allow the copy of the recovery phrase in dev environment
+						// only allows the copy of the recovery phrase in dev environment
 						if (__DEV__) {
 							Alert.alert(
 								'Write this recovery phrase on paper',

--- a/src/screens/AccountBackup.js
+++ b/src/screens/AccountBackup.js
@@ -111,7 +111,7 @@ class AccountBackupView extends React.PureComponent {
 				</View>
 				<TouchableItem
 					onPress={() => {
-						// only allows the copy of the recovery phrase in dev environment
+						// only allow the copy of the recovery phrase in dev environment
 						if (__DEV__) {
 							Alert.alert(
 								'Write this recovery phrase on paper',


### PR DESCRIPTION
This code was just tiny little "nice to have" but it's responsible for one of the error that `./android/gradlew assembleRelease` throws when building an unsigned apk: 
> Error: package is not a valid resource name (reserved Java keyword)

This is solved by react-native `0.61` but for now I just want to see what the CI bumps into next.