### PR TITLE
fix: use Metadata properly, not with the wrapped Metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@plugnet/util": "^1.1.100",
     "@plugnet/wasm-crypto-js": "^0.11.102",
     "@polkadot/api": "^0.98.0-beta.0",
-    "@polkadot/metadata": "^0.97.1",
     "@polkadot/reactnative-identicon": "^0.46.1",
     "@polkadot/types": "^0.98.0-beta.1",
     "@polkadot/util": "^1.7.1",

--- a/specs/util/decoders.spec.js
+++ b/specs/util/decoders.spec.js
@@ -19,9 +19,9 @@
 import {
 	createType,
 	GenericExtrinsicPayload,
+	Metadata,
 	TypeRegistry
 } from '@polkadot/types';
-import MetaData from '@polkadot/metadata';
 import Call from '@polkadot/types/primitive/Generic/Call';
 import { u8aConcat } from '@polkadot/util';
 import { checkAddress, decodeAddress } from '@polkadot/util-crypto';
@@ -46,7 +46,7 @@ const CRYPTO_SR25519 = new Uint8Array([0x01]);
 const CMD_SIGN_MORTAL = new Uint8Array([0]);
 const CMD_SIGN_MSG = new Uint8Array([3]);
 const registry = new TypeRegistry();
-new MetaData(registry, kusamaData);
+registry.setMetadata(new Metadata(registry, kusamaData));
 
 const KUSAMA_ADDRESS = 'FF42iLDmp7JLeySMjwWWtYQqfycJvsJFBYrySoMvtGfvAGs';
 const TEST_MESSAGE = 'THIS IS SPARTA!';

--- a/specs/util/units.spec.js
+++ b/specs/util/units.spec.js
@@ -16,16 +16,14 @@
 
 'use strict';
 
-import { TypeRegistry } from '@polkadot/types';
-import MetaData from '@polkadot/metadata';
+import { Metadata, TypeRegistry } from '@polkadot/types';
 import Call from '@polkadot/types/primitive/Generic/Call';
 import { formatBalance } from '@polkadot/util';
 
 import kusamaData from '../../src/util/static-kusama';
 import { fromWei } from '../../src/util/units';
 const registry = new TypeRegistry();
-
-new MetaData(registry, kusamaData);
+registry.setMetadata(new Metadata(registry, kusamaData));
 
 describe('units', () => {
 	describe('ethereum', () => {

--- a/src/components/PayloadDetailsCard.js
+++ b/src/components/PayloadDetailsCard.js
@@ -18,8 +18,7 @@
 
 'use strict';
 
-import { TypeRegistry } from '@polkadot/types';
-import MetaData from '@polkadot/metadata';
+import { TypeRegistry, Metadata } from '@polkadot/types';
 import Call from '@polkadot/types/primitive/Generic/Call';
 import { formatBalance } from '@polkadot/util';
 import { decodeAddress, encodeAddress } from '@polkadot/util-crypto';
@@ -60,14 +59,15 @@ export default class PayloadDetailsCard extends React.PureComponent {
 
 		let metadata;
 		if (isKusama) {
-			metadata = new MetaData(registry, kusamaMetadata);
-			// registry.setMetadata(metaData);
+			metadata = new Metadata(registry, kusamaMetadata);
+			registry.setMetadata(metadata);
 			formatBalance.setDefaults({
 				decimals: SUBSTRATE_NETWORK_LIST[SubstrateNetworkKeys.KUSAMA].decimals,
 				unit: SUBSTRATE_NETWORK_LIST[SubstrateNetworkKeys.KUSAMA].unit
 			});
 		} else if (__DEV__ && isSubstrateDev) {
-			metadata = new MetaData(registry, substrateDevMetadata);
+			metadata = new Metadata(registry, substrateDevMetadata);
+			registry.setMetadata(metadata);
 			formatBalance.setDefaults({
 				decimals:
 					SUBSTRATE_NETWORK_LIST[SubstrateNetworkKeys.SUBSTRATE_DEV].decimals,

--- a/yarn.lock
+++ b/yarn.lock
@@ -992,16 +992,6 @@
     "@polkadot/util" "^1.7.1"
     "@polkadot/util-crypto" "^1.7.1"
 
-"@polkadot/metadata@^0.97.1":
-  version "0.97.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/metadata/-/metadata-0.97.1.tgz#31c3ecdaa5afbd9ab896521e88504904d8c68bf1"
-  integrity sha512-RbU0aNi2VwGJ2U902d0vuCIjgeZRgE8G0MJm0kR6F0nR+Ya5iSRAdLx4J6hm4kMdu9wvVDK2eUOuXiCmNskJww==
-  dependencies:
-    "@babel/runtime" "^7.7.4"
-    "@polkadot/types" "^0.97.1"
-    "@polkadot/util" "^1.7.1"
-    "@polkadot/util-crypto" "^1.7.1"
-
 "@polkadot/metadata@^0.98.0-beta.1":
   version "0.98.0-beta.1"
   resolved "https://registry.yarnpkg.com/@polkadot/metadata/-/metadata-0.98.0-beta.1.tgz#3491cc376b0a466423315c4f18f1bc38853db0be"
@@ -1045,17 +1035,6 @@
     eventemitter3 "^4.0.0"
     isomorphic-fetch "^2.2.1"
     websocket "^1.0.30"
-
-"@polkadot/types@^0.97.1":
-  version "0.97.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-0.97.1.tgz#382bcc1ec392ebd8d1e6bccba3c80c395df4e4b9"
-  integrity sha512-0NkE8/d2m2BQSwvnfVAsEkTFs9l1R4ao15D8lAtJZeAe/B5ohs0rcg9bndK8PntGZZ5dUW+Xmy+JqnLCjLiPwQ==
-  dependencies:
-    "@babel/runtime" "^7.7.4"
-    "@polkadot/util" "^1.7.1"
-    "@polkadot/util-crypto" "^1.7.1"
-    "@types/memoizee" "^0.4.3"
-    memoizee "^0.4.14"
 
 "@polkadot/types@^0.98.0-beta.1":
   version "0.98.0-beta.1"


### PR DESCRIPTION
The `Decorated` class I imported from `@polkadot/metadata`, is actually for completely offline uage. (Or rather enables it). It is not actually metadata, it is a decorated version that wraps metadata. So it actually has a metadata getter as well.

It would be simple to just use `Metadata` from `@polkadot/types` instead, which also removes the additional dependecy of `@polkadot/metadata`

It mainly affect the decoding process, how to test:

1. run `yarn test`, all tests in `decoder.spec.js` should passed.
2. It should be possible to sign any extrinsics on CC3.