### PR TITLE
fix: error with new recipient account

### DIFF
--- a/src/stores/ScannerStore.js
+++ b/src/stores/ScannerStore.js
@@ -384,7 +384,7 @@ export default class ScannerStore extends Container<ScannerState> {
 			(await accountsStore.getById({
 				address: recipientAddress,
 				networkKey
-			})) || emptyAccount(emptyAccount(recipientAddress, networkKey));
+			})) || emptyAccount(recipientAddress, networkKey);
 
 		// For Eth, always sign the keccak hash.
 		// For Substrate, only sign the blake2 hash if payload bytes length > 256 bytes (handled in decoder.js).


### PR DESCRIPTION
closes #496 .

It is not a problem with "this is sparta" account, it is a problem if recipent is not a recognized account in Ethereum.

### Reproduce problem:

Create any ethereum account, scan any transaction QR with an unrecognized destination address, error happens.

The bug affect so widely and is so obvious, I am feeling guilty for creating it, we will need to release a fix version soon.