### PR TITLE
fix: extra height, focus, suggestions in text input

### DIFF
--- a/src/components/AccountSeed.js
+++ b/src/components/AccountSeed.js
@@ -133,12 +133,13 @@ export default class AccountSeed extends Component {
 		return (
 			<View>
 				<TextInput
-					autoFocus
 					style={[fontStyles.t_seed, styles.input, invalidStyles]}
 					multiline
 					autoCorrect={false}
 					autoCompleteType="off"
 					autoCapitalize="none"
+					returnKeyType="done"
+					blurOnSubmit={true}
 					textAlignVertical="top"
 					onSelectionChange={this.handleCursorPosition}
 					{...this.props}

--- a/src/components/ButtonNewDerivation.js
+++ b/src/components/ButtonNewDerivation.js
@@ -58,6 +58,7 @@ const styles = StyleSheet.create({
 	},
 	text: {
 		letterSpacing: -0.4,
-		opacity: 0.4
+		opacity: 0.4,
+		textAlign: 'center'
 	}
 });

--- a/src/screens/IdentityNew.js
+++ b/src/screens/IdentityNew.js
@@ -17,7 +17,7 @@
 'use strict';
 
 import React, { useEffect, useState } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 import { withNavigation } from 'react-navigation';
 
 import Button from '../components/Button';
@@ -145,7 +145,10 @@ function IdentityNew({ accounts, navigation }) {
 	);
 
 	return (
-		<KeyboardScrollView style={styles.body}>
+		<KeyboardScrollView
+			style={styles.body}
+			extraHeight={Platform.OS === 'ios' ? 210 : 120}
+		>
 			<ScreenHeading title={'New Identity'} />
 			<TextInput
 				onChangeText={updateName}

--- a/src/screens/IdentityPin.js
+++ b/src/screens/IdentityPin.js
@@ -163,7 +163,7 @@ function IdentityPin({ navigation, accounts }) {
 	return (
 		<KeyboardScrollView
 			style={styles.body}
-			extraHeight={120}
+			extraHeight={200}
 			testID={testIDs.IdentityPin.scrollScreen}
 		>
 			<Background />

--- a/src/screens/PathDerivation.js
+++ b/src/screens/PathDerivation.js
@@ -19,7 +19,7 @@
 import React, { useState } from 'react';
 import { withNavigation } from 'react-navigation';
 import { withAccountStore } from '../util/HOC';
-import { StyleSheet, Text, View } from 'react-native';
+import { Platform, StyleSheet, Text, View } from 'react-native';
 import TextInput from '../components/TextInput';
 import ButtonMainAction from '../components/ButtonMainAction';
 import { validateDerivedPath } from '../util/identitiesUtils';
@@ -74,17 +74,20 @@ function PathDerivation({ accounts, navigation }) {
 				subtitle={existedNetworkPath}
 				subtitleIcon={true}
 			/>
-			<KeyboardScrollView>
+			<KeyboardScrollView extraHeight={Platform.OS === 'ios' ? 250 : 180}>
 				{!isPathValid && <Text>Invalid Path</Text>}
 				<TextInput
+					autoCorrect={false}
+					autoCompleteType="off"
 					label="Path"
 					placeholder="//hard/soft"
-					autoFocus
 					value={derivationPath}
 					testID={testIDs.PathDerivation.pathInput}
 					onChangeText={setDerivationPath}
 				/>
 				<TextInput
+					autoCorrect={false}
+					autoCompleteType="off"
 					label="Display Name"
 					testID={testIDs.PathDerivation.nameInput}
 					value={keyPairsName}


### PR DESCRIPTION
closes #485 

Imporve text input on Identity New, Identity Pin and Path Derivation screen.

* remove autofocus for Identity New and Path Derivation screen.
* remove suggestions when creating path  and when recovering identity
* adjust extra height for keyboard scroll view which enble showing confirm button on small screen devices. (Basically, for every KeyboardScrollView, the `extraHeight` need to be specified to enble scroll up the screen for focused text input)

|Android|Ios|
|---|---|
|![out](https://user-images.githubusercontent.com/6014309/71217740-0a973100-22bf-11ea-9f98-6380c542bef9.gif)|![out_ios](https://user-images.githubusercontent.com/6014309/71217743-0ec34e80-22bf-11ea-95fb-0ead0cb378c9.gif)


### How to test
On a small screen device, try the text input in the following screens
* recover identity with seed.
* generate new seed.
* unlock account with pin.

