### PR TITLE
chore: fix navigation after path deletion

### DIFF
--- a/src/screens/PathDetails.js
+++ b/src/screens/PathDetails.js
@@ -30,6 +30,7 @@ import {
 	getIdentityName,
 	getNetworkKeyByPath,
 	getPathName,
+	getPathsWithSubstrateNetwork,
 	isSubstratePath
 } from '../util/identitiesUtils';
 import { defaultNetworkKey, UnknownNetworkKeys } from '../constants';
@@ -61,8 +62,11 @@ export function PathDetailsView({ accounts, navigation, path, networkKey }) {
 			alertDeleteAccount('this key pairs', async () => {
 				await unlockSeedPhrase(navigation);
 				const deleteSucceed = await accounts.deletePath(path);
+				const paths = Array.from(accounts.state.currentIdentity.meta.keys());
+				const listedPaths = getPathsWithSubstrateNetwork(paths, networkKey);
+				const hasOtherPaths = listedPaths.length > 0;
 				if (deleteSucceed) {
-					isSubstratePath(path) && !isRootPath
+					isSubstratePath(path) && !isRootPath && hasOtherPaths
 						? navigateToPathsList(navigation, networkKey)
 						: navigation.navigate('AccountNetworkChooser');
 				} else {


### PR DESCRIPTION
After delete all the paths in one of the Substrate network, it will still navigate back to the path list of this network. It would be better to navigate back to the network chooser screen.

|Before Fix| After Fix|
|---|---|
|![beforeDelete](https://user-images.githubusercontent.com/6014309/71717177-7a590000-2e17-11ea-867e-37a1f76e7e76.gif)|![afterDelete](https://user-images.githubusercontent.com/6014309/71717085-30701a00-2e17-11ea-8ca1-2e6ed87ee65c.gif)|


