### PR TITLE
fix: pin input text and return button

### DIFF
--- a/e2e/e2eUtils.js
+++ b/e2e/e2eUtils.js
@@ -43,6 +43,17 @@ export const testInput = async (inputId, inputText) => {
 	await element(by.id(inputId)).tapReturnKey();
 };
 
+export const testInputWithDone = async (inputId, inputText) => {
+	await element(by.id(inputId)).typeText(inputText);
+	if (device.getPlatform() === 'ios') {
+		await element(by.label('Done'))
+			.atIndex(0)
+			.tap();
+	} else {
+		await element(by.id(inputId)).tapReturnKey();
+	}
+};
+
 export const testScrollAndTap = async (buttonId, screenId) => {
 	await waitFor(element(by.id(buttonId)))
 		.toBeVisible()
@@ -52,6 +63,5 @@ export const testScrollAndTap = async (buttonId, screenId) => {
 };
 
 export const testUnlockPin = async pinCode => {
-	await testInput(IdentityPin.unlockPinInput, pinCode);
-	await testTap(IdentityPin.unlockPinButton);
+	await testInputWithDone(IdentityPin.unlockPinInput, pinCode);
 };

--- a/e2e/identityManipulation.spec.js
+++ b/e2e/identityManipulation.spec.js
@@ -21,6 +21,7 @@ import {
 	tapBack,
 	testExist,
 	testInput,
+	testInputWithDone,
 	testNotExist,
 	testNotVisible,
 	testScrollAndTap,
@@ -55,8 +56,7 @@ const mockSeedPhrase =
 
 const testSetUpDefaultPath = async () => {
 	await testInput(IdentityPin.setPin, pinCode);
-	await testInput(IdentityPin.confirmPin, pinCode);
-	await testTap(IdentityPin.submitButton);
+	await testInputWithDone(IdentityPin.confirmPin, pinCode);
 	await testVisible(AccountNetworkChooser.chooserScreen);
 	await testScrollAndTap(
 		substrateNetworkButtonIndex,

--- a/e2e/identityManipulation.spec.js
+++ b/e2e/identityManipulation.spec.js
@@ -87,17 +87,16 @@ describe('Load test', async () => {
 	it('recover a identity with seed phrase', async () => {
 		await testTap(AccountNetworkChooser.recoverButton);
 		await testVisible(IdentityNew.seedInput);
-		await element(by.id(IdentityNew.seedInput)).typeText(mockSeedPhrase);
 		await testInput(IdentityNew.nameInput, mockIdentityName);
-		await testTap(IdentityNew.recoverButton);
+		await element(by.id(IdentityNew.seedInput)).typeText(mockSeedPhrase);
+		await element(by.id(IdentityNew.seedInput)).tapReturnKey();
 		await testSetUpDefaultPath();
 	});
 
 	it('derive a new key', async () => {
 		await testTap(PathsList.deriveButton);
-		await testInput(PathDerivation.nameInput, 'first one');
 		await testInput(PathDerivation.pathInput, defaultPath);
-		await testTap(PathDerivation.deriveButton);
+		await testInput(PathDerivation.nameInput, 'first one');
 		await testUnlockPin(pinCode);
 		await testExist(PathsList.pathCard + `//kusama${defaultPath}`);
 	});
@@ -128,9 +127,8 @@ describe('Load test', async () => {
 			testIDs.AccountNetworkChooser.addCustomNetworkButton,
 			testIDs.AccountNetworkChooser.chooserScreen
 		);
-		await testInput(PathDerivation.nameInput, 'custom network');
 		await testInput(PathDerivation.pathInput, customPath);
-		await testTap(PathDerivation.deriveButton);
+		await testInput(PathDerivation.nameInput, 'custom network');
 		await testUnlockPin(pinCode);
 		await testExist(PathsList.pathCard + customPath);
 	});

--- a/src/screens/IdentityNew.js
+++ b/src/screens/IdentityNew.js
@@ -104,8 +104,10 @@ function IdentityNew({ accounts, navigation }) {
 		<>
 			<AccountSeed
 				testID={testIDs.IdentityNew.seedInput}
-				valid={isSeedValid.valid}
 				onChangeText={onSeedTextInput}
+				onSubmitEditing={onRecoverConfirm}
+				returnKeyType="done"
+				valid={isSeedValid.valid}
 				value={seedPhrase}
 			/>
 			<View style={styles.btnBox}>

--- a/src/screens/IdentityPin.js
+++ b/src/screens/IdentityPin.js
@@ -81,11 +81,13 @@ function IdentityPin({ navigation, accounts }) {
 
 	const showHintOrError = () => {
 		if (state.pinTooShort) {
-			return ' Your pin must be at least 6 digits long!';
+			return t.pinTooShortHint;
 		} else if (state.pinMismatch) {
-			return isUnlock ? ' Pin code is wrong!' : " Pin codes don't match!";
+			return isUnlock
+				? t.pinMisMatchHint.pinUnlock
+				: t.pinMisMatchHint.pinCreation;
 		}
-		return ' Choose a PIN code with 6 or more digits';
+		return isUnlock ? t.subtitle.pinUnlock : t.subtitle.pinCreation;
 	};
 
 	const onPinInputChange = (stateName, pinInput) => {
@@ -102,12 +104,12 @@ function IdentityPin({ navigation, accounts }) {
 		isUnlock ? (
 			<>
 				<ScreenHeading
-					title={'Unlock Identity'}
+					title={t.title.pinUnlock}
 					error={state.pinMismatch || state.pinTooShort}
 					subtitle={showHintOrError()}
 				/>
 				<PinInput
-					label="PIN"
+					label={t.pinLabel}
 					autoFocus
 					testID={testIDs.IdentityPin.unlockPinInput}
 					returnKeyType="done"
@@ -115,7 +117,7 @@ function IdentityPin({ navigation, accounts }) {
 					value={state.pin}
 				/>
 				<ButtonMainAction
-					title={'Done'}
+					title={t.doneButton.pinUnlock}
 					bottom={false}
 					onPress={testPin}
 					testID={testIDs.IdentityPin.unlockPinButton}
@@ -124,13 +126,13 @@ function IdentityPin({ navigation, accounts }) {
 		) : (
 			<>
 				<ScreenHeading
-					title={'Set Identity PIN'}
+					title={t.title.pinCreation}
 					subtitle={showHintOrError()}
 					error={state.pinMismatch || state.pinTooShort}
 				/>
 
 				<PinInput
-					label="PIN"
+					label={t.pinLabel}
 					autoFocus
 					testID={testIDs.IdentityPin.setPin}
 					returnKeyType="next"
@@ -142,7 +144,7 @@ function IdentityPin({ navigation, accounts }) {
 					value={state.pin}
 				/>
 				<PinInput
-					label="Confirm PIN"
+					label={t.pinConfirmLabel}
 					returnKeyType="done"
 					testID={testIDs.IdentityPin.confirmPin}
 					focus={state.focusConfirmation}
@@ -152,7 +154,7 @@ function IdentityPin({ navigation, accounts }) {
 					value={state.confirmation}
 				/>
 				<ButtonMainAction
-					title={'Done'}
+					title={t.doneButton.pinCreation}
 					bottom={false}
 					onPress={submit}
 					testID={testIDs.IdentityPin.submitButton}
@@ -190,6 +192,28 @@ function PinInput(props) {
 		/>
 	);
 }
+
+const t = {
+	doneButton: {
+		pinCreation: 'DONE',
+		pinUnlock: 'UNLOCK'
+	},
+	pinConfirmLabel: 'Confirm PIN',
+	pinLabel: 'PIN',
+	pinMisMatchHint: {
+		pinCreation: "Pin codes don't match!",
+		pinUnlock: 'Pin code is wrong!'
+	},
+	pinTooShortHint: 'Your pin must be at least 6 digits long!',
+	subtitle: {
+		pinCreation: 'Choose a PIN code with 6 or more digits',
+		pinUnlock: 'Unlock the identity to use the seed'
+	},
+	title: {
+		pinCreation: 'Set Identity PIN',
+		pinUnlock: 'Unlock Identity'
+	}
+};
 
 const styles = StyleSheet.create({
 	body: {

--- a/src/screens/IdentityPin.js
+++ b/src/screens/IdentityPin.js
@@ -114,6 +114,7 @@ function IdentityPin({ navigation, accounts }) {
 					testID={testIDs.IdentityPin.unlockPinInput}
 					returnKeyType="done"
 					onChangeText={pin => onPinInputChange('pin', pin)}
+					onSubmitEditing={testPin}
 					value={state.pin}
 				/>
 				<ButtonMainAction
@@ -152,6 +153,7 @@ function IdentityPin({ navigation, accounts }) {
 						onPinInputChange('confirmation', confirmation)
 					}
 					value={state.confirmation}
+					onSubmitEditing={submit}
 				/>
 				<ButtonMainAction
 					title={t.doneButton.pinCreation}

--- a/src/screens/PathDerivation.js
+++ b/src/screens/PathDerivation.js
@@ -16,7 +16,7 @@
 
 'use strict';
 
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { withNavigation } from 'react-navigation';
 import { withAccountStore } from '../util/HOC';
 import { Platform, StyleSheet, Text, View } from 'react-native';
@@ -43,6 +43,7 @@ function PathDerivation({ accounts, navigation }) {
 	const [derivationPath, setDerivationPath] = useState('');
 	const [keyPairsName, setKeyPairsName] = useState('');
 	const [isPathValid, setIsPathValid] = useState(true);
+	const pathNameInput = useRef(null);
 	const inheritNetworkKey = navigation.getParam('networkKey');
 	const isCustomPath = inheritNetworkKey === undefined;
 	const networkKey = inheritNetworkKey || getNetworkKeyByPath(derivationPath);
@@ -80,21 +81,26 @@ function PathDerivation({ accounts, navigation }) {
 			<KeyboardScrollView extraHeight={Platform.OS === 'ios' ? 250 : 180}>
 				{!isPathValid && <Text>Invalid Path</Text>}
 				<TextInput
-					autoCorrect={false}
 					autoCompleteType="off"
+					autoCorrect={false}
 					label="Path"
-					placeholder="//hard/soft"
-					value={derivationPath}
-					testID={testIDs.PathDerivation.pathInput}
 					onChangeText={setDerivationPath}
+					onSubmitEditing={() => pathNameInput.current.focus()}
+					placeholder="//hard/soft"
+					returnKeyType="next"
+					testID={testIDs.PathDerivation.pathInput}
+					value={derivationPath}
 				/>
 				<TextInput
-					autoCorrect={false}
 					autoCompleteType="off"
+					autoCorrect={false}
 					label="Display Name"
+					onChangeText={keyParisName => setKeyPairsName(keyParisName)}
+					onSubmitEditing={onPathDerivation}
+					ref={pathNameInput}
+					returnKeyType="done"
 					testID={testIDs.PathDerivation.nameInput}
 					value={keyPairsName}
-					onChangeText={keyParisName => setKeyPairsName(keyParisName)}
 				/>
 				<Separator style={{ height: 0 }} />
 				<PathCard
@@ -108,7 +114,7 @@ function PathDerivation({ accounts, navigation }) {
 					style={{ marginTop: 8 }}
 					title="Derive Address"
 					testID={testIDs.PathDerivation.deriveButton}
-					onPress={() => onPathDerivation()}
+					onPress={onPathDerivation}
 				/>
 			</KeyboardScrollView>
 		</View>


### PR DESCRIPTION
closes #518 , #519

## Unlock pin Input Text
4a30916 : is for #518, now the text is changed, and all the text in `IdentityNew` is ordered into a object/map called `t`.

<img width="784" alt="Screen Shot 2020-01-08 at 20 09 49" src="https://user-images.githubusercontent.com/6014309/72008634-88ae7e00-3254-11ea-8914-ec9e0a3703cd.png">

## Return button in text input component

The other three commits are for #519 , the main fix is in dc8d65e , which add `onSubmitEditing` for TextInput Component. Other two commits is mainly for e2e tests.
The unfunctioned button is not only in Android but also in iOS, now I have address all the return button in both platforms:
1. in path derivation process, path input and account name input.
2. in pin unlock screen, pin input
3. in pin creation screen, pin input
4. in path recovery screen, seed input

## How to test:
for above 1 and 2, try create any path from a Kusama network:
 
![out](https://user-images.githubusercontent.com/6014309/72008989-42a5ea00-3255-11ea-8373-6824539fe8c5.gif)

for above 3 and 4, try recovery an identity with any seed:

|android|ios|
|---|---|
|![out_android](https://user-images.githubusercontent.com/6014309/72009195-b47e3380-3255-11ea-905e-ac12d4ca26d5.gif)|![out](https://user-images.githubusercontent.com/6014309/72009217-bea03200-3255-11ea-95b4-a1c6fb892134.gif)|




