### PR TITLE
fix: display soft derivation custom path

### DIFF
--- a/specs/util/identitiesUtils.spec.js
+++ b/specs/util/identitiesUtils.spec.js
@@ -29,120 +29,104 @@ import {
 	UnknownNetworkKeys
 } from '../../src/constants';
 
-const addressFunding1 = 'address1',
-	addressFunding2 = 'address2',
-	addressSoft = 'address3',
-	addressPolkadot = 'address5',
-	addressStaking = 'address4',
-	addressEthereum = 'address6',
-	addressDefault = 'addressDefault',
-	addressKusamaRoot = 'addressKusamaRoot',
-	addressRoot = 'addressRoot',
-	addressCustom = 'addressCustom',
-	paths = [
-		'//kusama//default',
-		'//kusama//funding/1',
-		'//kusama/softKey1',
-		'//kusama//funding/2',
-		'//kusama//staking/1',
-		'//polkadot//default',
-		'1',
-		'//kusama',
-		'',
-		'//custom'
-	],
-	kusamaPaths = [
-		'//kusama//default',
-		'//kusama//funding/1',
-		'//kusama/softKey1',
-		'//kusama//funding/2',
-		'//kusama//staking/1',
-		'//kusama'
-	],
-	metaCustom = {
-		address: addressCustom,
-		createdAt: 1571068850409,
-		name: 'custom Path',
-		updatedAt: 1571068850409
-	},
-	metaDefault = {
-		address: addressDefault,
-		createdAt: 1571068850409,
+const raw = [
+	{
+		address: 'addressDefault',
+		expectName: 'default',
+		isKusamaPath: true,
 		name: '',
-		updatedAt: 1571078850509
+		path: '//kusama//default'
 	},
-	metaFunding1 = {
-		address: addressFunding1,
-		createdAt: 1571068850409,
+	{
+		address: 'address1',
+		expectName: 'funding account1',
+		isKusamaPath: true,
 		name: 'funding account1',
-		updatedAt: 1571078850509
+		path: '//kusama//funding/1'
 	},
-	metaFunding2 = {
-		address: addressFunding2,
-		createdAt: 1571068850409,
+	{
+		address: 'address3',
+		expectName: 'softKey1',
+		isKusamaPath: true,
 		name: '',
-		updatedAt: 1571078850509
+		path: '//kusama/softKey1'
 	},
-	metaStaking = {
-		address: addressStaking,
-		createdAt: 1571068850409,
+	{
+		address: 'address2',
+		expectName: 'funding2',
+		isKusamaPath: true,
 		name: '',
-		updatedAt: 1571078850509
+		path: '//kusama//funding/2'
 	},
-	metaPolkadot = {
-		address: addressPolkadot,
-		createdAt: 1573142786972,
-		name: 'PolkadotFirst',
-		updatedAt: 1573142786972
-	},
-	metaEthereum = {
-		address: addressEthereum,
-		createdAt: 1573142786972,
-		name: 'Eth account',
-		updatedAt: 1573142786972
-	},
-	metaKusamaRoot = {
-		address: addressKusamaRoot,
-		createdAt: 1573142786972,
+	{
+		address: 'address4',
+		expectName: 'staking1',
+		isKusamaPath: true,
 		name: '',
-		updatedAt: 1573142786972
+		path: '//kusama//staking/1'
 	},
-	metaRoot = {
-		address: addressRoot,
-		createdAt: 1573142786972,
+	{
+		address: 'address5',
+		expectName: 'default',
 		name: '',
-		updatedAt: 1573142786972
+		path: '//polkadot//default'
 	},
-	metaSoftKey = {
-		address: addressSoft,
-		createdAt: 1573142786972,
+	{
+		address: 'address6',
+		expectName: 'No name',
 		name: '',
+		path: '1'
+	},
+	{
+		address: 'addressKusamaRoot',
+		expectName: 'kusama',
+		isKusamaPath: true,
+		name: '',
+		path: '//kusama'
+	},
+	{
+		address: 'addressRoot',
+		expectName: '',
+		name: '',
+		path: ''
+	},
+	{
+		address: 'addressCustom',
+		expectName: 'CustomName',
+		name: 'CustomName',
+		path: '//custom'
+	},
+	{
+		address: 'addressKusamaSoft',
+		expectName: 'kusama',
+		name: '',
+		path: '/kusama'
+	},
+	{
+		address: 'softAddress',
+		expectName: '1',
+		name: '',
+		path: '/kusama/1'
+	}
+];
+const expectNames = raw.map(v => v.expectName);
+const paths = raw.map(v => v.path);
+const kusamaPaths = raw.filter(v => v.isKusamaPath).map(v => v.path);
+const metaMap = raw.reduce((acc, v) => {
+	const meta = {
+		address: v.address,
+		createdAt: 1573142786972,
+		name: v.name,
 		updatedAt: 1573142786972
 	};
-const addressesMap = new Map([
-	[addressDefault, paths[0]],
-	[addressFunding1, paths[1]],
-	[addressSoft, paths[2]],
-	[addressFunding2, paths[3]],
-	[addressStaking, paths[4]],
-	[addressPolkadot, paths[5]],
-	[addressEthereum, paths[6]],
-	[addressKusamaRoot, paths[7]],
-	[addressRoot, paths[8]],
-	[addressCustom, paths[9]]
-]);
-const metaMap = new Map([
-	[paths[0], metaDefault],
-	[paths[1], metaFunding1],
-	[paths[2], metaSoftKey],
-	[paths[3], metaStaking],
-	[paths[4], metaFunding2],
-	[paths[5], metaPolkadot],
-	[paths[6], metaEthereum],
-	[paths[7], metaKusamaRoot],
-	[paths[8], metaRoot],
-	[paths[9], metaCustom]
-]);
+	acc.set(v.path, meta);
+	return acc;
+}, new Map());
+const addressesMap = raw.reduce((acc, v) => {
+	acc.set(v.address, v.path);
+	return acc;
+}, new Map());
+
 const testIdentities = [
 	{
 		addresses: addressesMap,
@@ -190,7 +174,13 @@ describe('IdentitiesUtils', () => {
 	});
 
 	it('regroup the unknown paths', () => {
-		const unKnownPaths = ['//polkadot//default', '', '//custom'];
+		const unKnownPaths = [
+			'//polkadot//default',
+			'',
+			'//custom',
+			'/kusama',
+			'/kusama/1'
+		];
 		const groupResult = groupPaths(unKnownPaths);
 		expect(groupResult).toEqual([
 			{
@@ -200,23 +190,19 @@ describe('IdentitiesUtils', () => {
 			{
 				paths: ['//custom'],
 				title: 'custom'
+			},
+			{
+				paths: ['/kusama'],
+				title: 'kusama'
+			},
+			{
+				paths: ['/kusama/1'],
+				title: '/1'
 			}
 		]);
 	});
 
 	it('get the path name', () => {
-		const expectNames = [
-			'default',
-			'funding account1',
-			'softKey1',
-			'funding2',
-			'staking1',
-			'PolkadotFirst',
-			'Eth account',
-			'',
-			'',
-			'custom Path'
-		];
 		paths.forEach((path, index) => {
 			const name = getPathName(path, testIdentities[0]);
 			expect(name).toEqual(expectNames[index]);

--- a/specs/util/identitiesUtils.spec.js
+++ b/specs/util/identitiesUtils.spec.js
@@ -107,6 +107,12 @@ const raw = [
 		expectName: '1',
 		name: '',
 		path: '/kusama/1'
+	},
+	{
+		address: 'softAddress2',
+		expectName: '1',
+		name: '',
+		path: '/polkadot/1'
 	}
 ];
 const expectNames = raw.map(v => v.expectName);
@@ -179,25 +185,26 @@ describe('IdentitiesUtils', () => {
 			'',
 			'//custom',
 			'/kusama',
-			'/kusama/1'
+			'/kusama/1',
+			'/polkadot/1'
 		];
 		const groupResult = groupPaths(unKnownPaths);
 		expect(groupResult).toEqual([
 			{
 				paths: ['//polkadot//default'],
-				title: '//default'
+				title: '//polkadot'
 			},
 			{
 				paths: ['//custom'],
-				title: 'custom'
+				title: '//custom'
 			},
 			{
-				paths: ['/kusama'],
-				title: 'kusama'
+				paths: ['/polkadot/1'],
+				title: '/polkadot'
 			},
 			{
-				paths: ['/kusama/1'],
-				title: '/1'
+				paths: ['/kusama', '/kusama/1'],
+				title: '/kusama'
 			}
 		]);
 	});

--- a/src/screens/PathsList.js
+++ b/src/screens/PathsList.js
@@ -95,7 +95,7 @@ function PathsList({ accounts, navigation }) {
 					rootPath,
 					seedPhrase,
 					networkKey,
-					`${networkParams.title} Root`
+					''
 				);
 				if (derivationSucceed) {
 					navigateToPathDetails(navigation, networkKey, rootPath);

--- a/src/util/identitiesUtils.js
+++ b/src/util/identitiesUtils.js
@@ -206,12 +206,11 @@ export const getPathName = (path, lookUpIdentity) => {
 };
 
 /**
- * This function grouped paths list into a list with different groups, for a better display.
- * The group will based :
- * on their second subpath if it is a known network, for example, '//staking' of '//kusama//staking/0'
- * on their first subpath if it is an unknown network, for example, '/random' of '/random//derivation/1'
- * examples please refer to the path group test suit in identitiesUtils.spec.js
- */
+ * This function decides how to group the list of derivation paths in the display based on the following rules.
+ * If the network is unknown: group by the first subpath, e.g. '/random' of '/random//derivation/1'
+ * If the network is known: group by the second subpath, e.g. '//staking' of '//kusama//staking/0'
+ * Please refer to identitiesUtils.spec.js for more examples.
+ **/
 export const groupPaths = paths => {
 	const insertPathIntoGroup = (matchingPath, fullPath, pathGroup) => {
 		const groupName = matchingPath.match(pathsRegex.firstPath)[0];

--- a/src/util/identitiesUtils.js
+++ b/src/util/identitiesUtils.js
@@ -37,12 +37,13 @@ const extractPathId = path => {
 
 export const extractSubPathName = path => {
 	const pathFragments = path.match(pathsRegex.allPath);
-	if (!pathFragments || pathFragments.length <= 1) return '';
+	if (!pathFragments || pathFragments.length === 0) return '';
+	if (pathFragments.length === 1) return removeSlash(pathFragments[0]);
 	return removeSlash(pathFragments.slice(1).join(''));
 };
 
 export const isSubstratePath = path =>
-	path.split('//')[1] !== undefined || path === '';
+	path.match(pathsRegex.allPath) != null || path === '';
 
 export const isEthereumAccountId = v => v.indexOf('ethereum:') === 0;
 
@@ -209,19 +210,19 @@ export const groupPaths = paths => {
 		if (path === '') {
 			return groupedPath;
 		}
-		const pathId = extractPathId(path) || '';
-		const isRootPath = removeSlash(path) === pathId;
+		const rootPath = path.match(pathsRegex.firstPath)[0];
+		const isRootPath = path === rootPath;
 		if (isRootPath) {
 			const isUnknownRootPath = Object.values(NETWORK_LIST).every(
-				v => v.pathId !== pathId
+				v => `//${v.pathId}` !== rootPath
 			);
 			if (isUnknownRootPath) {
-				groupedPath.push({ paths: [path], title: pathId });
+				groupedPath.push({ paths: [path], title: removeSlash(rootPath) });
 			}
 			return groupedPath;
 		}
 
-		const subPath = path.slice(pathId.length + 2);
+		const subPath = path.slice(rootPath.length);
 
 		const groupName = subPath.match(pathsRegex.firstPath)[0];
 

--- a/src/util/identitiesUtils.js
+++ b/src/util/identitiesUtils.js
@@ -43,7 +43,7 @@ export const extractSubPathName = path => {
 };
 
 export const isSubstratePath = path =>
-	path.match(pathsRegex.allPath) != null || path === '';
+	path.match(pathsRegex.allPath) !== null || path === '';
 
 export const isEthereumAccountId = v => v.indexOf('ethereum:') === 0;
 
@@ -205,6 +205,13 @@ export const getPathName = (path, lookUpIdentity) => {
 	return extractSubPathName(path);
 };
 
+/**
+ * This function grouped paths list into a list with different groups, for a better display.
+ * The group will based :
+ * on their second subpath if it is a known network, for example, '//staking' of '//kusama//staking/0'
+ * on their first subpath if it is an unknown network, for example, '/random' of '/random//derivation/1'
+ * examples please refer to the path group test suit in identitiesUtils.spec.js
+ */
 export const groupPaths = paths => {
 	const insertPathIntoGroup = (matchingPath, fullPath, pathGroup) => {
 		const groupName = matchingPath.match(pathsRegex.firstPath)[0];
@@ -218,7 +225,7 @@ export const groupPaths = paths => {
 		}
 	};
 
-	const unSortedPaths = paths.reduce((groupedPath, path) => {
+	const groupedPaths = paths.reduce((groupedPath, path) => {
 		if (path === '') {
 			return groupedPath;
 		}
@@ -240,5 +247,5 @@ export const groupPaths = paths => {
 
 		return groupedPath;
 	}, []);
-	return unSortedPaths.sort((a, b) => a.paths.length - b.paths.length);
+	return groupedPaths.sort((a, b) => a.paths.length - b.paths.length);
 };

--- a/src/util/identitiesUtils.js
+++ b/src/util/identitiesUtils.js
@@ -206,33 +206,38 @@ export const getPathName = (path, lookUpIdentity) => {
 };
 
 export const groupPaths = paths => {
+	const insertPathIntoGroup = (matchingPath, fullPath, pathGroup) => {
+		const groupName = matchingPath.match(pathsRegex.firstPath)[0];
+
+		const existedItem = pathGroup.find(p => p.title === groupName);
+		if (existedItem) {
+			existedItem.paths.push(fullPath);
+			existedItem.paths.sort();
+		} else {
+			pathGroup.push({ paths: [fullPath], title: groupName });
+		}
+	};
+
 	const unSortedPaths = paths.reduce((groupedPath, path) => {
 		if (path === '') {
 			return groupedPath;
 		}
 		const rootPath = path.match(pathsRegex.firstPath)[0];
-		const isRootPath = path === rootPath;
-		if (isRootPath) {
-			const isUnknownRootPath = Object.values(NETWORK_LIST).every(
-				v => `//${v.pathId}` !== rootPath
-			);
-			if (isUnknownRootPath) {
-				groupedPath.push({ paths: [path], title: removeSlash(rootPath) });
-			}
+
+		const isUnknownRootPath = Object.values(NETWORK_LIST).every(
+			v => `//${v.pathId}` !== rootPath
+		);
+		if (isUnknownRootPath) {
+			insertPathIntoGroup(path, path, groupedPath);
 			return groupedPath;
 		}
 
+		const isRootPath = path === rootPath;
+		if (isRootPath) return groupedPath;
+
 		const subPath = path.slice(rootPath.length);
+		insertPathIntoGroup(subPath, path, groupedPath);
 
-		const groupName = subPath.match(pathsRegex.firstPath)[0];
-
-		const existedItem = groupedPath.find(p => p.title === groupName);
-		if (existedItem) {
-			existedItem.paths.push(path);
-			existedItem.paths.sort();
-		} else {
-			groupedPath.push({ paths: [path], title: groupName });
-		}
 		return groupedPath;
 	}, []);
 	return unSortedPaths.sort((a, b) => a.paths.length - b.paths.length);

--- a/src/util/regex.js
+++ b/src/util/regex.js
@@ -19,7 +19,7 @@
 export const pathsRegex = {
 	allPath: /(\/|\/\/)[\w-.]+(?=(\/?))/g,
 	firstPath: /(\/|\/\/)[\w-.]+(?=(\/)?)/,
-	networkPath: /(\/|\/\/)[\w-.]+(?=(\/)?)/,
+	networkPath: /(\/\/)[\w-.]+(?=(\/)?)/,
 	validateDerivedPath: /^(\/\/?[\w-.]+)*$/
 };
 


### PR DESCRIPTION
close #522 

The bug is caused by the incorrect sorting function in `identitiesUtils.js`

Fix the bug and refactor the test suit in `identitiesUtils.spec.js`, which make it easy to add more cases.

Also now the unknown paths will be grouped by the first catch group of path.

In the following example  `/soft/path`, `/soft/222`, `/soft/333` will be grouped together under `/soft`

Signing tested successfully on iOS.

![out](https://user-images.githubusercontent.com/6014309/72243478-57370900-35ec-11ea-85fa-a6027908037f.gif)
