### PR TITLE
fix: add whitespace after tapping the suggestion text

### DIFF
--- a/src/components/AccountSeed.js
+++ b/src/components/AccountSeed.js
@@ -112,7 +112,7 @@ export default class AccountSeed extends Component {
 						<TouchableItem
 							key={i}
 							onPress={e => {
-								let phrase = left.concat(suggestion, right).join(' ');
+								let phrase = left.concat(suggestion, right).join(' ').trimEnd();
 								const is24words = phrase.split(' ').length === 24;
 								if (!is24words) phrase += ' ';
 								this.props.onChangeText(phrase);

--- a/src/components/AccountSeed.js
+++ b/src/components/AccountSeed.js
@@ -112,7 +112,10 @@ export default class AccountSeed extends Component {
 						<TouchableItem
 							key={i}
 							onPress={e => {
-								let phrase = left.concat(suggestion, right).join(' ').trimEnd();
+								let phrase = left
+									.concat(suggestion, right)
+									.join(' ')
+									.trimEnd();
 								const is24words = phrase.split(' ').length === 24;
 								if (!is24words) phrase += ' ';
 								this.props.onChangeText(phrase);

--- a/src/components/AccountSeed.js
+++ b/src/components/AccountSeed.js
@@ -112,8 +112,9 @@ export default class AccountSeed extends Component {
 						<TouchableItem
 							key={i}
 							onPress={e => {
-								const phrase = left.concat(suggestion, right).join(' ');
-
+								let phrase = left.concat(suggestion, right).join(' ');
+								const is24words = phrase.split(' ').length === 24;
+								if (!is24words) phrase += ' ';
 								this.props.onChangeText(phrase);
 							}}
 						>

--- a/src/screens/IdentityNew.js
+++ b/src/screens/IdentityNew.js
@@ -62,7 +62,7 @@ function IdentityNew({ accounts, navigation }) {
 	const onSeedTextInput = inputSeedPhrase => {
 		setSeedPhrase(inputSeedPhrase);
 		const addressGeneration = () =>
-			brainWalletAddress(inputSeedPhrase)
+			brainWalletAddress(inputSeedPhrase.trimEnd())
 				.then(({ bip39 }) => {
 					setIsSeedValid(validateSeed(inputSeedPhrase, bip39));
 				})
@@ -74,7 +74,11 @@ function IdentityNew({ accounts, navigation }) {
 	const onRecoverIdentity = async () => {
 		const pin = await setPin(navigation);
 		try {
-			await accounts.saveNewIdentity(seedPhrase, pin);
+			if (isSeedValid.bip39) {
+				await accounts.saveNewIdentity(seedPhrase.trimEnd(), pin);
+			} else {
+				await accounts.saveNewIdentity(seedPhrase, pin);
+			}
 			setSeedPhrase('');
 			navigateToNewIdentityNetwork(navigation);
 		} catch (e) {

--- a/src/util/account.js
+++ b/src/util/account.js
@@ -78,7 +78,7 @@ export function validateSeed(seed, validBip39Seed) {
 		};
 	}
 
-	const words = validBip39Seed ? seed.trimEnd().split('') : seed.split(' ');
+	const words = validBip39Seed ? seed.trimEnd().split(' ') : seed.split(' ');
 
 	for (let word of words) {
 		if (word === '') {

--- a/src/util/account.js
+++ b/src/util/account.js
@@ -72,17 +72,19 @@ export function validateSeed(seed, validBip39Seed) {
 	if (!seed || seed.length === 0) {
 		return {
 			accountRecoveryAllowed: false,
+			bip39: false,
 			reason: 'A seed phrase is required.',
 			valid: false
 		};
 	}
 
-	const words = seed.split(' ');
+	const words = validBip39Seed ? seed.trimEnd().split('') : seed.split(' ');
 
 	for (let word of words) {
 		if (word === '') {
 			return {
 				accountRecoveryAllowed: true,
+				bip39: false,
 				reason: 'Extra whitespace found.',
 				valid: false
 			};
@@ -92,6 +94,7 @@ export function validateSeed(seed, validBip39Seed) {
 	if (!validBip39Seed) {
 		return {
 			accountRecoveryAllowed: true,
+			bip39: false,
 			reason:
 				'This recovery phrase is not a valid BIP39 seed, will be treated as a legacy Parity brain wallet.',
 			valid: false
@@ -99,6 +102,7 @@ export function validateSeed(seed, validBip39Seed) {
 	}
 
 	return {
+		bip39: true,
 		reason: null,
 		valid: true
 	};


### PR DESCRIPTION
close #529 .

Now after tapping the suggestion text, the trailing space will be automatically added.

And for a 24 words recovery phrase, it will not add the whitespace to the end.

But for a 12, 15, 18, or 21 words (They should all be possible to be recovered), the trailing whitespace is still added, but after tapping the "Recover Identity" button and input PIN, it will automatically be trimmed.

Test cases:
1. tapping any suggestion word, a whitespace should follow.
2. move the cursor to middle, and add another suggestion word, no extra trailing whitespace in the end should be added.
3. After input bip39 mnemonic phrase, the box border should not be red though there is a trailing whitespace.
4. after  input bip39 mnemonic phrase and recovered the identity, the recover phrase should not include any trailing whitespace, they should be removed during recovery process.
5. After input 24 bip39 words, there should be no more traling whitespaces added.