### PR TITLE
fix: Use kind-of >=6.0.3 everywhere

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
     "reactotron-react-native": "^3.6.5"
   },
   "resolutions": {
-    "@react-native-community/eslint-config/babel-eslint": "10.0.3"
+    "@react-native-community/eslint-config/babel-eslint": "10.0.3",
+    "kind-of": ">=6.0.3"
   },
   "detox": {
     "configurations": {


### PR DESCRIPTION
This repo's dependencies currently use [older versions](https://github.com/paritytech/parity-signer/blob/97651dcc2f78027aa83c3dc7834f6941e084c8a7/yarn.lock#L5138) of kind-of which have a possibly exploitable vulnerability ([original issue](https://github.com/jonschlinkert/kind-of/issues/30), [PR](https://github.com/jonschlinkert/kind-of/pull/31)).