### PR TITLE
fix: redirection for account with custom path

### DIFF
--- a/src/screens/PathDetails.js
+++ b/src/screens/PathDetails.js
@@ -28,6 +28,7 @@ import QrView from '../components/QrView';
 import {
 	getAddressWithPath,
 	getNetworkKey,
+	getNetworkKeyByPath,
 	getPathName,
 	getPathsWithSubstrateNetwork,
 	isSubstratePath
@@ -61,11 +62,15 @@ export function PathDetailsView({ accounts, navigation, path, networkKey }) {
 					await unlockSeedPhrase(navigation);
 					const deleteSucceed = await accounts.deletePath(path);
 					const paths = Array.from(accounts.state.currentIdentity.meta.keys());
-					const listedPaths = getPathsWithSubstrateNetwork(paths, networkKey);
+					const pathIndicatedNetworkKey = getNetworkKeyByPath(path);
+					const listedPaths = getPathsWithSubstrateNetwork(
+						paths,
+						pathIndicatedNetworkKey
+					);
 					const hasOtherPaths = listedPaths.length > 0;
 					if (deleteSucceed) {
 						isSubstratePath(path) && hasOtherPaths
-							? navigateToPathsList(navigation, networkKey)
+							? navigateToPathsList(navigation, pathIndicatedNetworkKey)
 							: navigation.navigate('AccountNetworkChooser');
 					} else {
 						alertPathDeletionError();


### PR DESCRIPTION
After delete an account with custom path, it should redirect to the custom paths list, but not the list of the fallback network like Kusama.

Reproduce: 
choose any account with custom path (it has Kusama network affliation) -> delete it -> Now it is navigate to kusama path list.

Screen recording (Check the screen after input the PIN): 

| before | after |
|---|---|
|![out mp4](https://user-images.githubusercontent.com/6014309/74146525-8cda0c80-4c01-11ea-9cc4-55308c88dd59.gif)|![out mp4](https://user-images.githubusercontent.com/6014309/74146588-aed38f00-4c01-11ea-91ef-77700d3d2e26.gif)|

