### PR TITLE
fix: prevent back on network choser android

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
         "build": "yarn xcbuild:debug",
         "type": "ios.simulator",
         "device": {
-          "type": "iPhone 11"
+          "type": "iPhone 8"
         }
       },
       "ios.sim.release": {
@@ -133,7 +133,7 @@
         "build": "yarn xcbuild:githubActions",
         "type": "ios.simulator",
         "device": {
-          "os": "iOS 13.3",
+          "os": "iOS 13.4",
           "type": "iPhone 8"
         }
       },

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
         "build": "yarn xcbuild:debug",
         "type": "ios.simulator",
         "device": {
-          "type": "iPhone 8"
+          "type": "iPhone 11"
         }
       },
       "ios.sim.release": {

--- a/src/modules/main/components/NetworkSelector.tsx
+++ b/src/modules/main/components/NetworkSelector.tsx
@@ -15,7 +15,8 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 import React, { useState } from 'react';
-import { ScrollView } from 'react-native';
+import { BackHandler, ScrollView } from 'react-native';
+import { useFocusEffect } from '@react-navigation/native';
 
 import { NetworkCard } from 'components/AccountCard';
 import { SafeAreaViewContainer } from 'components/SafeAreaContainer';
@@ -67,6 +68,25 @@ export default function NetworkSelector({
 	const [shouldShowMoreNetworks, setShouldShowMoreNetworks] = useState(false);
 	const { identities, currentIdentity } = accounts.state;
 	const seedRefHooks = useSeedRef(currentIdentity!.encryptedSeed);
+
+	// catch android back button and prevent exiting the app
+	useFocusEffect(
+		React.useCallback((): any => {
+			const handleBackButton = (): boolean => {
+				if (shouldShowMoreNetworks) {
+					setShouldShowMoreNetworks(false);
+					return true;
+				} else {
+					return false;
+				}
+			};
+			const backHandler = BackHandler.addEventListener(
+				'hardwareBackPress',
+				handleBackButton
+			);
+			return (): void => backHandler.remove();
+		}, [shouldShowMoreNetworks])
+	);
 
 	const sortNetworkKeys = (
 		[, params1]: [any, NetworkParams],


### PR DESCRIPTION
closes #542 

As `BackHandler` only existed in andriod, and on iOS swipe back won't lead user to quit app.

So this PR only focus on Android.

The test result should be the same as descripted in the issue's expected screen record.