### PR TITLE
fix: scanning block and e2e

### DIFF
--- a/src/modules/sign/screens/QrScanner.tsx
+++ b/src/modules/sign/screens/QrScanner.tsx
@@ -52,10 +52,10 @@ export function Scanner({
 		totalFramesCount: 0
 	});
 	useEffect((): (() => void) => {
-		const unsubscribeFocus = navigation.addListener(
-			'focus',
-			scannerStore.setReady.bind(scannerStore)
-		);
+		const unsubscribeFocus = navigation.addListener('focus', () => {
+			setLastFrame(null);
+			scannerStore.setReady();
+		});
 		const unsubscribeBlur = navigation.addListener(
 			'blur',
 			scannerStore.setBusy.bind(scannerStore)

--- a/test/e2e/injections.ts
+++ b/test/e2e/injections.ts
@@ -73,6 +73,7 @@ export const onMockBarCodeRead = async (
 ): Promise<void> => {
 	const scanRequest = scanRequestDataMap[txRequest];
 	if (typeof scanRequest === 'string') {
+		await timeout(200);
 		await onBarCodeRead(buildSignRequest(scanRequest));
 	} else if (Array.isArray(scanRequest)) {
 		for (const rawData of scanRequest as string[]) {
@@ -80,6 +81,7 @@ export const onMockBarCodeRead = async (
 			await onBarCodeRead(buildSignRequest(rawData));
 		}
 	} else if (typeof scanRequest === 'object') {
+		await timeout(200);
 		await onBarCodeRead(
 			buildSignRequest(scanRequest.rawData, scanRequest.data)
 		);


### PR DESCRIPTION
Actually this pr add the missing commits for #603 

After scanning and in the pin input screen, is user press back, the next scan will not triggered if qr is not changed, this prevent the error

Also add the timeout for e2e scan test, which enable the screen to do the cleanup and transition with correct workflow 