### PR TITLE
fix: seed reference destroy bug

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -134,8 +134,8 @@ android {
         minSdkVersion 18
         missingDimensionStrategy 'react-native-camera', 'general'
         targetSdkVersion 28
-        versionCode 4201
-        versionName "4.2.1"
+        versionCode 4202
+        versionName "4.2.2"
         ndk {
             abiFilters 'armeabi-v7a','arm64-v8a','x86','x86_64'
         }

--- a/ios/NativeSigner/Info.plist
+++ b/ios/NativeSigner/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.2.1</string>
+	<string>4.2.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>4201</string>
+	<string>4202</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "NativeSigner",
-  "version": "4.2.1-beta",
+  "version": "4.2.2-beta",
   "private": true,
   "license": "GPL-3.0",
   "engines": {

--- a/src/stores/SeedRefStore.tsx
+++ b/src/stores/SeedRefStore.tsx
@@ -34,7 +34,7 @@ export function SeedRefStore(props: any): React.ReactElement {
 					return Promise.resolve();
 				});
 				await Promise.all(promises);
-				seedRefs.clear();
+				setSeedRefs(new Map());
 			}
 			setAppState(nextAppState);
 		};


### PR DESCRIPTION
When clean the seed references, does not call the `setSeedRefs` function, which leads that the context do not update.

Also bump the version to v4.2.2