### PR TITLE
fix: new identity name input can't be focus

### DIFF
--- a/src/screens/IdentityNew.tsx
+++ b/src/screens/IdentityNew.tsx
@@ -172,7 +172,6 @@ function IdentityNew({
 				testID={testIDs.IdentityNew.nameInput}
 				value={accounts.getNewIdentity().name}
 				placeholder="Identity Name"
-				focus={false}
 			/>
 			{isRecover ? renderRecoverView() : renderCreateView()}
 		</KeyboardScrollView>


### PR DESCRIPTION
This is the fix according to user report:

> I had some issues yesterday with naming new identities. I could only type one letter at a time and then had to click again each time on the text field. it looked like the spelling/word recogintion didn't properly work. it was an iphone 5se installed fresh yesterday. 

Though I can't reproduce on my devices and simulators, but I think this line of code maybe lead to the incorrect behavouir.

