### PR TITLE
chore: reset current identity in async way

### DIFF
--- a/src/components/IdentitiesSwitch.tsx
+++ b/src/components/IdentitiesSwitch.tsx
@@ -92,10 +92,10 @@ function IdentitiesSwitch({
 		}
 	};
 
-	const onLegacyListClicked = async (): Promise<void> => {
-		await accounts.resetCurrentIdentity();
+	const onLegacyListClicked = (): void => {
 		setVisible(false);
 		navigateToLegacyAccountList(navigation);
+		accounts.resetCurrentIdentity();
 	};
 
 	const renderIdentityOptions = (identity: Identity): React.ReactElement => {


### PR DESCRIPTION
This PR add minor improvement, which do not need to reset currentIdentity before going to legacy account list.