### PR TITLE
fix: remove kusama CC2 Network

### DIFF
--- a/src/components/DerivationNetworkSelector.tsx
+++ b/src/components/DerivationNetworkSelector.tsx
@@ -40,7 +40,7 @@ const ACCOUNT_NETWORK = 'Account Network';
 const Touchable: React.ComponentClass<TouchableNativeFeedbackProps> =
 	Platform.OS === 'android' ? TouchableNativeFeedback : TouchableOpacity;
 
-const excludedNetworks = [SubstrateNetworkKeys.KUSAMA_CC2];
+const excludedNetworks: string[] = [];
 if (!__DEV__) {
 	excludedNetworks.push(SubstrateNetworkKeys.SUBSTRATE_DEV);
 	excludedNetworks.push(SubstrateNetworkKeys.KUSAMA_DEV);

--- a/src/components/PathGroupCard.tsx
+++ b/src/components/PathGroupCard.tsx
@@ -34,7 +34,7 @@ import {
 	PathGroup
 } from 'types/identityTypes';
 import {
-	isSubstrateNetworkParams,
+	isUnknownNetworkParams,
 	SubstrateNetworkParams,
 	UnknownNetworkParams
 } from 'types/networkSpecsTypes';
@@ -98,8 +98,11 @@ export default function PathGroupCard({
 		}
 	};
 
+	const isUnknownNetwork = isUnknownNetworkParams(networkParams);
 	const headerTitle = removeSlash(pathGroup.title);
-	const headerCode = `//${networkParams.pathId}${pathGroup.title}`;
+	const headerCode = isUnknownNetwork
+		? pathGroup.title
+		: `//${networkParams.pathId}${pathGroup.title}`;
 	return (
 		<View key={`group${pathGroup.title}`} style={{ marginTop: 24 }}>
 			<Separator shadow={true} style={styles.separator} />
@@ -110,7 +113,7 @@ export default function PathGroupCard({
 						<Text style={fontStyles.t_codeS}>{headerCode}</Text>
 					</View>
 				</View>
-				{isSubstrateNetworkParams(networkParams) && (
+				{!isUnknownNetwork && (
 					<TouchableItem
 						onPress={(): any => addDerivationPath(true)}
 						style={styles.derivationButton}

--- a/src/constants/networkSpecs.ts
+++ b/src/constants/networkSpecs.ts
@@ -59,8 +59,6 @@ export const SubstrateNetworkKeys: Record<string, string> = Object.freeze({
 		'0x742a2ca70c2fda6cee4f8df98d64c4c670a052d9568058982dad9d5a7a135c5b', // https://polkascan.io/pre/edgeware/block/0
 	KULUPU: '0xf7a99d3cb92853d00d5275c971c132c074636256583fee53b3bbe60d7b8769ba',
 	KUSAMA: '0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe', // https://polkascan.io/pre/kusama-cc3/block/0
-	KUSAMA_CC2:
-		'0xe3777fa922cafbff200cadeaea1a76bd7898ad5b89f7848999058b50e715f636',
 	KUSAMA_DEV:
 		'0x5e9679182f658e148f33d3f760f11179977398bb3da8d1f0bf7b267fe6b3ebb0',
 	POLKADOT:
@@ -133,17 +131,6 @@ const substrateNetworkBase: Record<string, Partial<SubstrateNetworkParams>> = {
 		logo: require('res/img/logos/Kusama.png'),
 		order: 2,
 		pathId: 'kusama',
-		prefix: 2,
-		title: 'Kusama',
-		unit: 'KSM'
-	},
-	[SubstrateNetworkKeys.KUSAMA_CC2]: {
-		color: '#000',
-		decimals: 12,
-		genesisHash: SubstrateNetworkKeys.KUSAMA,
-		logo: require('res/img/logos/Kusama.png'),
-		order: 2,
-		pathId: 'kusama_CC2',
 		prefix: 2,
 		title: 'Kusama',
 		unit: 'KSM'

--- a/src/modules/network/utils.ts
+++ b/src/modules/network/utils.ts
@@ -34,10 +34,7 @@ export const filterSubstrateNetworks = (
 	networkList: Record<string, NetworkParams>,
 	extraFilter?: (networkKey: string, shouldExclude: boolean) => boolean
 ): Array<[string, NetworkParams]> => {
-	const excludedNetworks = [
-		UnknownNetworkKeys.UNKNOWN,
-		SubstrateNetworkKeys.KUSAMA_CC2
-	];
+	const excludedNetworks = [UnknownNetworkKeys.UNKNOWN];
 	if (!__DEV__) {
 		excludedNetworks.push(SubstrateNetworkKeys.SUBSTRATE_DEV);
 		excludedNetworks.push(SubstrateNetworkKeys.KUSAMA_DEV);
@@ -96,7 +93,7 @@ export function getCompleteSubstrateNetworkSpec(
 }
 
 export function defaultNetworkSpecs(): SubstrateNetworkParams[] {
-	const excludedNetworks = [SubstrateNetworkKeys.KUSAMA_CC2];
+	const excludedNetworks: string[] = [];
 	if (!__DEV__) {
 		excludedNetworks.push(SubstrateNetworkKeys.SUBSTRATE_DEV);
 		excludedNetworks.push(SubstrateNetworkKeys.KUSAMA_DEV);

--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -209,6 +209,5 @@ export async function getNetworkSpecs(): Promise<SubstrateNetworkParams[]> {
  */
 export async function saveDefaultNetworks(): Promise<void> {
 	const networkSpecsString = JSON.stringify(defaultNetworkSpecs());
-	console.log('networkSpecs to be stored is', networkSpecsString); //TODO to be removed
 	// AsyncStorage.setItem(networkSpecsStorageLabel, networkSpecsString);
 }

--- a/src/utils/identitiesUtils.ts
+++ b/src/utils/identitiesUtils.ts
@@ -181,11 +181,12 @@ export const getPathsWithSubstrateNetworkKey = (
 		let pathId;
 		if (!isSubstratePath(path)) return groupedPaths;
 		if (pathMeta.networkPathId !== undefined) {
-			pathId = pathMeta.networkPathId;
+			pathId = PATH_IDS_LIST.includes(pathMeta.networkPathId)
+				? pathMeta.networkPathId
+				: unknownNetworkPathId;
 		} else {
 			pathId = extractPathId(path);
 		}
-
 		if (pathId === targetPathId) {
 			groupedPaths.push(path);
 			return groupedPaths;
@@ -442,7 +443,6 @@ export const getMetadata = (networkKey: string): string => {
 		case SubstrateNetworkKeys.CENTRIFUGE_AMBER:
 			return centrifugeAmberMetadata;
 		case SubstrateNetworkKeys.KUSAMA:
-		case SubstrateNetworkKeys.KUSAMA_CC2:
 		case SubstrateNetworkKeys.KUSAMA_DEV:
 			return kusamaMetadata;
 		case SubstrateNetworkKeys.WESTEND:


### PR DESCRIPTION
close #539 

Currently the KUSAMA_CC2 Network related accounts will be grounped under `Unknown Network`.

![IMG_2B1D5649D205-1](https://user-images.githubusercontent.com/6014309/89912217-95cc8a80-dbf2-11ea-89b4-22df3211c183.jpeg)
