### PR TITLE
chore: improve parsing message error

### DIFF
--- a/src/modules/sign/strings.ts
+++ b/src/modules/sign/strings.ts
@@ -7,6 +7,8 @@ const strings = {
 	ERROR_NO_SENDER_FOUND: 'There is no related account in the app',
 	ERROR_NO_SENDER_IDENTITY: 'There is no related identity in the app',
 	ERROR_TITLE: 'Unable to parse QR data',
+	ERROR_WRONG_RAW:
+		'Frames number is too big, the QR seems not to be a recognized extrinsic raw data',
 	INFO_ETH_TX: 'You are about to send the following amount',
 	INFO_MULTI_PART:
 		'You are about to send the following extrinsic. We will sign the hash of the payload as it is oversized.',

--- a/src/utils/decoders.ts
+++ b/src/utils/decoders.ts
@@ -110,7 +110,7 @@ export async function constructDataFromBytes(
 	const frameInfo = hexStripPrefix(u8aToHex(bytes.slice(0, 5)));
 	const frameCount = parseInt(frameInfo.substr(2, 4), 16);
 	const isMultipart = frameCount > 1; // for simplicity, even single frame payloads are marked as multipart.
-	if (frameCount > 100) throw new Error(strings.ERROR_WRONG_RAW);
+	if (frameCount > 50) throw new Error(strings.ERROR_WRONG_RAW);
 	const currentFrame = parseInt(frameInfo.substr(6, 4), 16);
 	const uosAfterFrames = hexStripPrefix(u8aToHex(bytes.slice(5)));
 

--- a/src/utils/decoders.ts
+++ b/src/utils/decoders.ts
@@ -110,6 +110,7 @@ export async function constructDataFromBytes(
 	const frameInfo = hexStripPrefix(u8aToHex(bytes.slice(0, 5)));
 	const frameCount = parseInt(frameInfo.substr(2, 4), 16);
 	const isMultipart = frameCount > 1; // for simplicity, even single frame payloads are marked as multipart.
+	if (frameCount > 100) throw new Error(strings.ERROR_WRONG_RAW);
 	const currentFrame = parseInt(frameInfo.substr(6, 4), 16);
 	const uosAfterFrames = hexStripPrefix(u8aToHex(bytes.slice(5)));
 


### PR DESCRIPTION
When parsing the random string, it is sometimes is parsed as a multi frames qr code, this walkaround prevent this behavior somehow.