### PR TITLE
docs: temporary readme redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,27 +22,26 @@ Switching to airplane mode suffices in many cases.
 
 # !!! Parity Signer is being refactored from the ground up !!!
 
-The legacy app is still **safe to use and fully functional** and this release is published 
+The legacy app is still **fully functional** and is published 
 on the app stores. The source and documentation in the `./docs` directory for these are 
 available in release branches (see below). 
 
 [The legacy documentation for the published app is here](https://github.com/paritytech/parity-signer/tree/legacy-4.6.2/docs)
 
-**NOTE: The `./docs` directory in this branch is under ***heavy development and is not updated for**
-**the refactor at this time.**
+**NOTE: The `./docs` directory in this branch is under heavy development and is not updated for
+the refactor at this time.**
 
 ==========================================================
 
 ### Legacy versions
 
-Published versions for use are available at following branches:
+Published version for use is available at following branch:
 
 - [Last public release with React Native](https://github.com/paritytech/parity-signer/tree/legacy-4.5.3)
+
+> Other unreleased development versions of this app could be useful for reference.
+
 - [Non-ascii characters fix and some transaction parsing](https://github.com/paritytech/parity-signer/tree/legacy-4.6.2)
-
-> Older versions of this app could be useful for reference, but **they are not safe for use**
-> to store keys in production.
-
 - [Metadata types import and message parsing in RN](https://github.com/paritytech/parity-signer/tree/legacy-metadataRN)
 - [Rust backend with RN frontend](https://github.com/paritytech/parity-signer/tree/legacy-rust)
 


### PR DESCRIPTION
Until we have proper documentation, people should be guided to old docs