### PR TITLE
ci: Add retry failed CI jobs twice

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,6 +13,12 @@ variables:
 
 default:
   cache:                           {}
+  retry:
+    max: 2
+    when:
+      - runner_system_failure
+      - unknown_failure
+      - api_failure
 
 workflow:
   rules:


### PR DESCRIPTION
This PR add pipeline functionality to retry CI jobs twice in case if it failed due to following reasons: 
```
      - runner_system_failure
      - unknown_failure
      - api_failure
```