### PR TITLE
ci: Revive android building

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,6 +13,12 @@ variables:
 
 default:
   cache:                           {}
+  retry:
+    max: 2
+    when:
+      - runner_system_failure
+      - unknown_failure
+      - api_failure
 
 workflow:
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,28 +20,44 @@ default:
       - unknown_failure
       - api_failure
 
-workflow:
-  rules:
-    - if: $CI_COMMIT_TAG
-    - if: $CI_COMMIT_BRANCH
+# workflow:
+  # rules:
+    # - if: $CI_COMMIT_TAG
+    # - if: $CI_COMMIT_BRANCH
 
-android-build-release:
-  stage:                           build
-  image:                           paritytech/signer-android-builder:latest
+android-build:
+  stage: build
+  image: paritytech/signer-android-builder:latest
   rules:
-    - if: $CI_PIPELINE_SOURCE == "web"
-    - if: $CI_PIPELINE_SOURCE == "schedule"
+      # TODO: Remove before merge with master
+    - if: $CI_COMMIT_REF_NAME == "mp-ci-revamp"
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/ # PRs
+  artifacts:
+    paths:
+      - android/app/build/outputs/apk/release/app-release-unsigned.apk
+  script:
+    - ./scripts/build.sh android
+    - cd android
+    - ./gradlew assembleRelease
+  tags:
+    - linux-docker
+
+android-build-and-sign:
+  stage: build
+  image: paritytech/signer-android-builder:latest
+  rules:
     - if: $CI_COMMIT_REF_NAME == "master"
       # TODO: Remove before merge with master
     - if: $CI_COMMIT_REF_NAME == "mp-ci-revamp"
-    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
-    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
   artifacts:
     paths:
       - signer-ci-build.apk
   script:
     - cat "$KEYSTORE_DATA" | base64 -d > /tmp/gitlab-ci.keystore
     - wc /tmp/gitlab-ci.keystore
-    - ./scripts/build-release.sh /tmp/gitlab-ci.keystore "$KEYSTORE_PASS"
+    - ./scripts/build.sh android
+    - cd android
+    - ./gradlew assembleRelease
+    - ./scripts/sign_android.sh /tmp/gitlab-ci.keystore "$KEYSTORE_PASS"
   tags:
     - linux-docker

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,7 @@ workflow:
 
 android-build-release:
   stage:                           build
-  image:                           paritytech/parity-signer:latest
+  image:                           paritytech/signer-android-builder:latest
   rules:
     - if: $CI_PIPELINE_SOURCE == "web"
     - if: $CI_PIPELINE_SOURCE == "schedule"
@@ -32,8 +32,8 @@ android-build-release:
     paths:
       - signer-app-release-signed.apk
   script:
-    - cat "$KEYSTORE_DATA" | base64 -d > /tmp/gitlab-ci.keystore
-    - wc /tmp/gitlab-ci.keystore
-    - ./scripts/build-release.sh /tmp/gitlab-ci.keystore "$KEYSTORE_ALIAS" "$KEYSTORE_PASS"
+    - scripts/build.sh android
+    - cd android; ./gradlew assembleRelease
+      # - ./scripts/build-release.sh /tmp/gitlab-ci.keystore "$KEYSTORE_ALIAS" "$KEYSTORE_PASS"
   tags:
     - linux-docker

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,8 +29,6 @@ android-build:
   stage: build
   image: paritytech/signer-android-builder:latest
   rules:
-      # TODO: Remove before merge with master
-    - if: $CI_COMMIT_REF_NAME == "mp-ci-revamp"
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/ # PRs
   artifacts:
     paths:
@@ -46,8 +44,6 @@ android-build-and-sign:
   image: paritytech/signer-android-builder:latest
   rules:
     - if: $CI_COMMIT_REF_NAME == "master"
-      # TODO: Remove before merge with master
-    - if: $CI_COMMIT_REF_NAME == "mp-ci-revamp"
   artifacts:
     paths:
       - signer-ci-build.apk

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,8 +32,8 @@ android-build-release:
     paths:
       - signer-app-release-signed.apk
   script:
-    - scripts/build.sh android
-    - cd android; ./gradlew assembleRelease
-      # - ./scripts/build-release.sh /tmp/gitlab-ci.keystore "$KEYSTORE_ALIAS" "$KEYSTORE_PASS"
+    - cat "$KEYSTORE_DATA" | base64 -d > /tmp/gitlab-ci.keystore
+    - wc /tmp/gitlab-ci.keystore
+    - ./scripts/build-release.sh /tmp/gitlab-ci.keystore "$KEYSTORE_PASS"
   tags:
     - linux-docker

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,8 +37,7 @@ android-build:
       - android/app/build/outputs/apk/release/app-release-unsigned.apk
   script:
     - ./scripts/build.sh android
-    - cd android
-    - ./gradlew assembleRelease
+    - cd android; ./gradlew assembleRelease
   tags:
     - linux-docker
 
@@ -56,8 +55,7 @@ android-build-and-sign:
     - cat "$KEYSTORE_DATA" | base64 -d > /tmp/gitlab-ci.keystore
     - wc /tmp/gitlab-ci.keystore
     - ./scripts/build.sh android
-    - cd android
-    - ./gradlew assembleRelease
+    - cd android; ./gradlew assembleRelease; cd ..
     - ./scripts/sign_android.sh /tmp/gitlab-ci.keystore "$KEYSTORE_PASS"
   tags:
     - linux-docker

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,6 +32,8 @@ android-build-release:
     - if: $CI_PIPELINE_SOURCE == "web"
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME == "master"
+      # TODO: Remove before merge with master
+    - if: $CI_COMMIT_REF_NAME == "mp-ci-revamp"
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,7 +38,7 @@ android-build-release:
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
   artifacts:
     paths:
-      - signer-app-release-signed.apk
+      - signer-ci-build.apk
   script:
     - cat "$KEYSTORE_DATA" | base64 -d > /tmp/gitlab-ci.keystore
     - wc /tmp/gitlab-ci.keystore

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,25 +1,17 @@
-FROM rust
+FROM bitriseio/android-ndk:latest
 MAINTAINER Parity Technologies <admin@parity.io>
 
 WORKDIR /build
 
-RUN su -c 'curl -sL https://deb.nodesource.com/setup_14.x | bash -'
-RUN apt-get update -y; apt-get install -y openjdk-11-jdk-headless wget curl unzip zipalign nodejs
-RUN curl https://dl.google.com/android/repository/commandlinetools-linux-6858069_latest.zip > /tmp/cli-tools.zip
-RUN unzip /tmp/cli-tools.zip -d /opt
-RUN yes | ANDROID_SDK_ROOT=/opt/cmdline-tools/bin/ /opt/cmdline-tools/bin/sdkmanager --licenses --sdk_root=/opt/cmdline-tools/bin/
-RUN npm install -g react-native-cli yarn
-RUN curl https://dl.google.com/android/repository/android-ndk-r21e-linux-x86_64.zip > /tmp/ndk.zip
-RUN unzip /tmp/ndk.zip -d /opt
-ENV NDK_HOME /opt/android-ndk-r21e/
-ENV ANDROID_SDK_ROOT /opt/cmdline-tools/bin/
+ENV RUSTUP_HOME=/usr/local/rustup
+ENV CARGO_HOME=/usr/local/cargo
+ENV PATH=/usr/local/cargo/bin:$PATH
 
-WORKDIR /tmp/scripts
+RUN apt-get -y update; apt-get -y install default-jdk
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV NDK_HOME=/opt/android-ndk
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/
+
 COPY scripts /tmp/scripts/
 RUN bash /tmp/scripts/init.sh
-WORKDIR /build
 
-# cleanup
-RUN apt-get autoremove -y
-RUN apt-get clean -y
-RUN rm -rf /tmp/* /var/tmp/*

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,25 +1,56 @@
-# Base on Bitrise but prune everything we don't want
-FROM bitriseio/android-ndk:latest
+# This dockerfile is based on Bitrise but with a lot of extra cruft we don't need removed
+FROM ubuntu:focal
 MAINTAINER Parity Technologies <admin@parity.io>
 
-WORKDIR /build
+ENV ANDROID_SDK_ROOT /opt/android-sdk-linux
+ENV ANDROID_HOME /opt/android-sdk-linux
+ENV NDK_HOME /opt/android-ndk
+ENV ANDROID_NDK_VERSION r22
+ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64/
+
+RUN apt-get -y update && apt-get -y install default-jdk wget unzip curl clang
+
+# SDK setup is taken from https://github.com/bitrise-io/android/blob/master/Dockerfile
+# NDK setup is taken from https://github.com/bitrise-io/android-ndk/blob/master/Dockerfile
+
+RUN cd /opt \
+    && wget -q https://dl.google.com/android/repository/commandlinetools-linux-6858069_latest.zip -O android-commandline-tools.zip \
+    && mkdir -p ${ANDROID_SDK_ROOT}/cmdline-tools \
+    && unzip -q android-commandline-tools.zip -d /tmp/ \
+    && mv /tmp/cmdline-tools/ ${ANDROID_SDK_ROOT}/cmdline-tools/latest \
+    && rm android-commandline-tools.zip && ls -la ${ANDROID_SDK_ROOT}/cmdline-tools/latest/
+
+ENV PATH ${PATH}:${ANDROID_SDK_ROOT}/platform-tools:${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin
+
+RUN mkdir /opt/android-ndk-tmp && \
+    cd /opt/android-ndk-tmp && \
+    wget -q https://dl.google.com/android/repository/android-ndk-${ANDROID_NDK_VERSION}-linux-x86_64.zip && \
+# uncompress
+    unzip -q android-ndk-${ANDROID_NDK_VERSION}-linux-x86_64.zip && \
+# move to its final location
+    mv ./android-ndk-${ANDROID_NDK_VERSION} ${NDK_HOME} && \
+# remove temp dir
+    cd ${NDK_HOME} && \
+    rm -rf /opt/android-ndk-tmp
+
+# add to PATH
+ENV PATH ${PATH}:${NDK_HOME}
+
+# rust stuff
 
 ENV RUSTUP_HOME=/usr/local/rustup
 ENV CARGO_HOME=/usr/local/cargo
 ENV PATH=/usr/local/cargo/bin:$PATH
 
-RUN apt-get -y update; apt-get -y install default-jdk
+WORKDIR /build
+
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-ENV NDK_HOME=/opt/android-ndk
-ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/
 
 COPY scripts /tmp/scripts/
 RUN bash /tmp/scripts/init.sh
 
 # Cleanup
-RUN rm -rf /opt/android-sdk/system-images; \
-    rm -rf /opt/android-sdk/build-tools/*; \
-    rm -rf /tmp/scripts ;\
-    apt-get autoremote -y ; \
+RUN rm -rf /tmp/scripts ;\
+    apt-get autoremove -y ; \
     apt-get clean ; \
     rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,4 @@
+# Base on Bitrise but prune everything we don't want
 FROM bitriseio/android-ndk:latest
 MAINTAINER Parity Technologies <admin@parity.io>
 
@@ -15,3 +16,10 @@ ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/
 COPY scripts /tmp/scripts/
 RUN bash /tmp/scripts/init.sh
 
+# Cleanup
+RUN rm -rf /opt/android-sdk/system-images; \
+    rm -rf /opt/android-sdk/build-tools/*; \
+    rm -rf /tmp/scripts ;\
+    apt-get autoremote -y ; \
+    apt-get clean ; \
+    rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,6 +22,10 @@ RUN cd /opt \
 
 ENV PATH ${PATH}:${ANDROID_SDK_ROOT}/platform-tools:${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin
 
+RUN yes | sdkmanager --licenses
+# We need at least one set of build-tools installed for apksigner
+RUN yes | sdkmanager "build-tools;30.0.3"
+
 RUN mkdir /opt/android-ndk-tmp && \
     cd /opt/android-ndk-tmp && \
     wget -q https://dl.google.com/android/repository/android-ndk-${ANDROID_NDK_VERSION}-linux-x86_64.zip && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Parity Technologies <admin@parity.io>
 ENV ANDROID_SDK_ROOT /opt/android-sdk-linux
 ENV ANDROID_HOME /opt/android-sdk-linux
 ENV NDK_HOME /opt/android-ndk
-ENV ANDROID_NDK_VERSION r22
+ENV ANDROID_NDK_VERSION r23b
 ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64/
 
 RUN apt-get -y update && apt-get -y install default-jdk wget unzip curl clang
@@ -28,9 +28,9 @@ RUN yes | sdkmanager "build-tools;30.0.3"
 
 RUN mkdir /opt/android-ndk-tmp && \
     cd /opt/android-ndk-tmp && \
-    wget -q https://dl.google.com/android/repository/android-ndk-${ANDROID_NDK_VERSION}-linux-x86_64.zip && \
+    wget -q https://dl.google.com/android/repository/android-ndk-${ANDROID_NDK_VERSION}-linux.zip && \
 # uncompress
-    unzip -q android-ndk-${ANDROID_NDK_VERSION}-linux-x86_64.zip && \
+    unzip -q android-ndk-${ANDROID_NDK_VERSION}-linux.zip && \
 # move to its final location
     mv ./android-ndk-${ANDROID_NDK_VERSION} ${NDK_HOME} && \
 # remove temp dir

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -17,5 +17,6 @@ pushd "$(dirname "${0}")"/../android
   echo "[+] Running Gradle"
   ./gradlew assembleRelease
   echo "[+] Build complete! Signing bundle"
-  "$ANDROID_BUILD_TOOLS_PATH/apksigner" sign --ks "$keystore" --key-pass "env:$keypass" app/build/outputs/apk/release/app-release-unsigned.apk
+  "$ANDROID_BUILD_TOOLS_PATH/apksigner" sign --ks "$keystore" --ks-pass "pass:$keypass" app/build/outputs/apk/release/app-release-unsigned.apk
+  cp app/build/outputs/apk/release/app-release-unsigned.apk ../signer-ci-build.apk
 popd

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -3,6 +3,8 @@
 keystore="$(readlink -f "$1")"
 keypass="$2"
 
+cat "$keypass" | wc
+
 # Get latest android-sdk-linux version for apksigner path
 ANDROID_BUILD_TOOLS_PATH=$(find /opt/android-sdk-linux/build-tools/ -maxdepth 1 -type d | sort -V | tail -n 1)
 

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -3,8 +3,6 @@
 keystore="$(readlink -f "$1")"
 keypass="$2"
 
-cat "$keypass" | wc
-
 # Get latest android-sdk-linux version for apksigner path
 ANDROID_BUILD_TOOLS_PATH=$(find /opt/android-sdk-linux/build-tools/ -maxdepth 1 -type d | sort -V | tail -n 1)
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -64,6 +64,7 @@ if [ "$1" == "android" ]
     done
 
     rm -rf ../../android/app/src/main/assets/Database/*
+    mkdir -p ../../android/app/src/main/assets/Database/
     cp -R ../database/database_cold_release/* ../../android/app/src/main/assets/Database/
 fi
 

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source ./variables.sh
+source "$(dirname "${0}")/variables.sh"
 
 cargo install cargo-lipo
 

--- a/scripts/sign_android.sh
+++ b/scripts/sign_android.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 keystore="$(readlink -f "$1")"
 keypass="$2"
@@ -6,17 +7,8 @@ keypass="$2"
 # Get latest android-sdk-linux version for apksigner path
 ANDROID_BUILD_TOOLS_PATH=$(find /opt/android-sdk-linux/build-tools/ -maxdepth 1 -type d | sort -V | tail -n 1)
 
-set -e
-
-# Build rust lib
-pushd "$(dirname "${0}")"/..
-  ./scripts/build.sh android
-popd
-
 pushd "$(dirname "${0}")"/../android
-  echo "[+] Running Gradle"
-  ./gradlew assembleRelease
-  echo "[+] Build complete! Signing bundle"
+  echo "[+] Signing bundle"
   "$ANDROID_BUILD_TOOLS_PATH/apksigner" sign --ks "$keystore" --ks-pass "pass:$keypass" app/build/outputs/apk/release/app-release-unsigned.apk
   cp app/build/outputs/apk/release/app-release-unsigned.apk ../signer-ci-build.apk
 popd

--- a/scripts/sign_metadata.sh
+++ b/scripts/sign_metadata.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+chain="$1"
+spec_version="$2"
+
+rust_dir="$(dirname "${0}")/../rust/generate_message"
+pushd "$rust_dir" || exit 1
+  cargo run restore_defaults
+  cargo run load_metadata -a
+  cargo run show -database
+  echo "[+] Generating UNSIGNED metadata APNG for $chain spec_version $spec_version..."
+  cargo run make -qr -crypto none -msgtype load_metadata -payload "sign_me_load_metadata_${chain}V${spec_version}"
+popd || exit 1


### PR DESCRIPTION
This adds/fixes Gitlab building of the android component of the project. It creates two CI jobs; one that just builds the project (not tremendously useful) and another that builds it *and* signs it, producing an APK that can actually be installed. The latter only runs on merging with master, due to needing to access protected variables in Gitlab