### PR TITLE
fix: ios: seed collision check fix

### DIFF
--- a/ios/NativeSigner/Models/Navigator.swift
+++ b/ios/NativeSigner/Models/Navigator.swift
@@ -156,7 +156,7 @@ struct ActionResult: Decodable {
 enum SignerScreen: Decodable {
     case Scan
     case Keys(MKeys)
-    case Settings(MVerifierDetails)
+    case Settings(MVerifierDetails?)
     case Log(MLog)
     case LogDetails(MLogDetails)
     case Transaction(MTransaction)

--- a/ios/NativeSigner/Models/RustNative.swift
+++ b/ios/NativeSigner/Models/RustNative.swift
@@ -110,6 +110,7 @@ extension SignerDataModel {
         if !self.canaryDead {
             do {
                 print("onboarding...")
+                wipe()
                 if let source = Bundle.main.url(forResource: "Database", withExtension: "") {
                     //print(source)
                     var destination = try FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false)

--- a/ios/NativeSigner/Screens/SettingsScreen.swift
+++ b/ios/NativeSigner/Screens/SettingsScreen.swift
@@ -11,7 +11,7 @@ struct SettingsScreen: View {
     @EnvironmentObject var data: SignerDataModel
     @State var wipe = false
     @State var jailbreak = false
-    let content: MVerifierDetails
+    let content: MVerifierDetails?
     var body: some View {
         VStack (spacing: 2) {
             Button(action: {
@@ -31,9 +31,11 @@ struct SettingsScreen: View {
                     Spacer()
                 }
                 HStack {
+                    if let verifier = content {
                     AddressCard(address: Address(
-                        base58: "encryption: " + content.encryption, path: content.hex.truncateMiddle(length: 8), has_pwd: false, identicon: content.identicon, seed_name: "", multiselect: false
+                        base58: "encryption: " + verifier.encryption, path: verifier.hex.truncateMiddle(length: 8), has_pwd: false, identicon: verifier.identicon, seed_name: "", multiselect: false
                     ))
+                    }
                 }
             }
             .padding()


### PR DESCRIPTION
Fix bug with multiple seed creation.

Code is not readable at all; just test it - create seeds with similar and different phrases, one should be possible, another not.

Also wipe signer on init once more - just to prevent legacy stuff from coming up after update.

And prevent NavigationError event from appearing in Settings.