### PR TITLE
feat: detect address collisions on derivation screen

### DIFF
--- a/rust/db_handling/src/interface_signer.rs
+++ b/rust/db_handling/src/interface_signer.rs
@@ -219,23 +219,35 @@ pub fn backup_prep (database_name: &str, seed_name: &str) -> Result<String, Erro
 
 /// Function to prepare key derivation screen.
 /// Gets seed name, network specs key and suggested derivation
-pub fn derive_prep (database_name: &str, seed_name: &str, network_specs_key: &NetworkSpecsKey, suggest: &str) -> Result<String, ErrorSigner> {
+pub fn derive_prep (database_name: &str, seed_name: &str, network_specs_key: &NetworkSpecsKey, collision: Option<(MultiSigner, AddressDetails)>, suggest: &str) -> Result<String, ErrorSigner> {
     let network_specs = get_network_specs(database_name, network_specs_key)?;
-    Ok(format!("\"seed_name\":\"{}\",\"network_title\":\"{}\",\"network_logo\":\"{}\",\"suggested_derivation\":\"{}\"", seed_name, network_specs.title, network_specs.logo, suggest))
-}
-
-/// Function to show (dynamically) if the derivation with the provided path and no password already exists
-/// and if it exists, prints its details
-pub fn dynamic_path_check (database_name: &str, seed_name: &str, path: &str, network_specs_key: &NetworkSpecsKey) -> Result<String, ErrorSigner> {
-    match derivation_no_pwd_exists (seed_name, path, network_specs_key, database_name)? {
-        Some((multisigner, _)) => {
-            let network_specs = get_network_specs(database_name, network_specs_key)?;
+    match collision {
+        Some((multisigner, address_details)) => {
             let address_base58 = print_multisigner_as_base58(&multisigner, Some(network_specs.base58prefix));
             let hex_identicon = match make_identicon_from_multisigner(&multisigner) {
                 Ok(a) => hex::encode(a),
                 Err(_) => String::new(),
             };
-            Ok(format!("\"base58\":\"{}\",\"path\":\"{}\",\"has_pwd\":\"false\",\"identicon\":\"{}\",\"seed_name\":\"{}\"", address_base58, path, hex_identicon, seed_name))
+            let collision_display = format!("\"base58\":\"{}\",\"path\":\"{}\",\"has_pwd\":{},\"identicon\":\"{}\",\"seed_name\":\"{}\"", address_base58, address_details.path, address_details.has_pwd, hex_identicon, seed_name);
+            Ok(format!("\"seed_name\":\"{}\",\"network_title\":\"{}\",\"network_logo\":\"{}\",\"suggested_derivation\":\"{}\",\"collision\":{{{}}}", seed_name, network_specs.title, network_specs.logo, suggest, collision_display))
+        },
+        None => Ok(format!("\"seed_name\":\"{}\",\"network_title\":\"{}\",\"network_logo\":\"{}\",\"suggested_derivation\":\"{}\"", seed_name, network_specs.title, network_specs.logo, suggest)),
+    }
+}
+
+/// Function to show (dynamically) if the derivation with the provided path and no password already exists
+/// and if it exists, prints its details
+pub fn dynamic_path_check (database_name: &str, seed_name: &str, path: &str, network_specs_key_hex: &str) -> Result<String, ErrorSigner> {
+    let network_specs_key = NetworkSpecsKey::from_hex(network_specs_key_hex)?;
+    match derivation_no_pwd_exists (seed_name, path, &network_specs_key, database_name)? {
+        Some((multisigner, _)) => {
+            let network_specs = get_network_specs(database_name, &network_specs_key)?;
+            let address_base58 = print_multisigner_as_base58(&multisigner, Some(network_specs.base58prefix));
+            let hex_identicon = match make_identicon_from_multisigner(&multisigner) {
+                Ok(a) => hex::encode(a),
+                Err(_) => String::new(),
+            };
+            Ok(format!("\"base58\":\"{}\",\"path\":\"{}\",\"has_pwd\":false,\"identicon\":\"{}\",\"seed_name\":\"{}\"", address_base58, path, hex_identicon, seed_name))
         },
         None => Ok(String::new()),
     }
@@ -322,14 +334,21 @@ pub fn purge_transactions (database_name: &str) -> Result<(), ErrorSigner> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use definitions::{crypto::Encryption, keyring::NetworkSpecsKey, network_specs::Verifier};
+    
     use sp_core::sr25519::Public;
     use std::fs;
     use std::convert::TryInto;
+    
+    use definitions::{crypto::Encryption, keyring::NetworkSpecsKey, network_specs::Verifier};
+    
     use crate::cold_default::populate_cold;
+    use crate::identities::try_create_address;
     use crate::manage_history::print_history;
     use crate::remove_types::remove_types_info;
+    
+    use super::*;
+    
+    const ALICE_SEED_PHRASE: &str = "bottom drive obey lake curtain smoke basket hold race lonely fit walk";
 
     #[test]
     fn print_seed_names() {
@@ -425,8 +444,42 @@ mod tests {
     fn derive_prep_alice() {
         let dbname = "for_tests/derive_prep_alice";
         populate_cold (dbname, Verifier(None)).unwrap();
-        let print = derive_prep(dbname, "Alice", &NetworkSpecsKey::from_parts(&hex::decode("e143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e").unwrap(), &Encryption::Sr25519), "//secret//derive").unwrap();
+        let print = derive_prep(dbname, "Alice", &NetworkSpecsKey::from_parts(&hex::decode("e143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e").unwrap(), &Encryption::Sr25519), None, "//secret//derive").unwrap();
         let expected_print = r#""seed_name":"Alice","network_title":"Westend","network_logo":"westend","suggested_derivation":"//secret//derive""#;
+        assert!(print == expected_print, "\nReceived: \n{}", print);
+        fs::remove_dir_all(dbname).unwrap();
+    }
+    
+    #[test]
+    fn derive_prep_alice_collided() {
+        let dbname = "for_tests/derive_prep_alice_collided";
+        populate_cold (dbname, Verifier(None)).unwrap();
+        let network_specs_key = NetworkSpecsKey::from_parts(&hex::decode("e143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e").unwrap(), &Encryption::Sr25519);
+        let print = derive_prep(dbname, "Alice", &network_specs_key, derivation_no_pwd_exists ("Alice", "//Alice", &network_specs_key, dbname).unwrap(), "//Alice").unwrap();
+        let expected_print = r#""seed_name":"Alice","network_title":"Westend","network_logo":"westend","suggested_derivation":"//Alice","collision":{"base58":"5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY","path":"//Alice","has_pwd":false,"identicon":"89504e470d0a1a0a0000000d49484452000000410000004108060000008ef7c9450000030e49444154789cedda4d6a544114c571330e0eb286640782d8ee4090081964033d105c90e0a0379041c020b8035b047790aca10792715b87e644eb59afeeb9f5f1e86edf7f70320cf7075d83a44fb6dbedb3ffbd4910369b4df12f393b3b3b093fbad605a1e668ab1e284d117a1e3fac2546138492e3bf3ede868d7b737a15d6570b8c2a8492e3510a809540a01a8c62841e006c6a8822845200d413019540b8106a8e67bd1198074346680180a642402a8484e001f8717d1f36eee5cd45d85d5e842ff7d761e3de5edc84d552204c845a00a6425800ac254433841c00b3205400a6425421a800c88b60d51201e52046113c0068df11d0184412c10b800e0101a5206484d5e243d8b8e5fa63d85d5e84cbd7e761e3eebe3d84dde54558ac5661e3d6cb65d838094105602a8405c054080b80291026420e8059102a00b32054003684c8220c019017c1ca8b60558280fe869811424f08290074ac088810cd113e25de84f7156fc2cfc49bf0a2f24d603202ca4158004c85b000980a3106805c082805a102300b42056016440e00450816809217c1ca8b501a20668419c189f0ebf6316cdcf3abd3b0bbbc08ef16ff7e863fafff7c86bd08af2ecfc3c67dbf7b089b4f4648013015c202602a8405c02c08092107c02c08158059102a00cb417441b0f22258cd08a11921b4970847f926a01c8405c054080b80a91039002423a014840ac02c081580591016007221587911acbc08a5cd08a11921f484802c88a3ff7b02ca21a400980a61013015c202603908192107c02c08158059102a001b83e88660e545b06a8a805210c78a400034238422043484f0221cfcff22d11001e5202c00a64258004c851802201301a9102a00b3205400664128004846b0f222587911d46404e48538048414001a45401e887d471803405904a44278110ee67b8c48454039080b80a9102a00aa4640b5102a00b3205a0220090179207279116a5200908c805a404c85a002201702abc1e88de0399e1521a052889e082500a81801f580981a005521b0128c14440940cdf1ac09022bc128adc5f1ac2902eb89d1f278d60561580d4a8fa3874d82b0effd06a580bfac7347ad900000000049454e44ae426082","seed_name":"Alice"}"#;
+        assert!(print == expected_print, "\nReceived: \n{}", print);
+        fs::remove_dir_all(dbname).unwrap();
+    }
+    
+    #[test]
+    fn derive_prep_alice_collided_with_password() {
+        let dbname = "for_tests/derive_prep_alice_collided_with_password";
+        populate_cold (dbname, Verifier(None)).unwrap();
+        let network_specs_key = NetworkSpecsKey::from_parts(&hex::decode("e143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e").unwrap(), &Encryption::Sr25519);
+        try_create_address ("Alice", ALICE_SEED_PHRASE, "//secret///abracadabra", &network_specs_key, dbname).unwrap();
+        let mut collision = None;
+        for (multisigner, address_details) in addresses_set_seed_name_network(dbname, "Alice", &network_specs_key).unwrap().into_iter() {
+            if address_details.path == "//secret" {
+                collision = Some((multisigner, address_details));
+                break;
+            }
+        }
+        let collision = match collision {
+            Some(a) => a,
+            None => panic!("Did not create address?"),
+        };
+        let print = derive_prep(dbname, "Alice", &network_specs_key, Some(collision), "//secret///abracadabra").unwrap();
+        let expected_print = r#""seed_name":"Alice","network_title":"Westend","network_logo":"westend","suggested_derivation":"//secret///abracadabra","collision":{"base58":"5EkMjdgyuHqnWA9oWXUoFRaMwMUgMJ1ik9KtMpPNuTuZTi2t","path":"//secret","has_pwd":true,"identicon":"89504e470d0a1a0a0000000d49484452000000410000004108060000008ef7c9450000038b49444154789ced99bd6ddc4010462d400d9c1bb02356e0d8210b70a60a95b900868e5d0123bb015f03079c777018e1bbd5707e76678903c41750c12e66debe48909eaed7eba78fce2e11cee773f392d3e9f4547e0c6548849e475b8c88921a61e4e36b3263a4446879fcd71f5fcaf79e3f3fff966f8c8c185d115a1e4f4801989610444f8ce6082302307b87688ad01a801819816809118ad0f3786674042612c31d212300b15704c21bc2152112e0f5f2bb7cef7979fe56be37a211ac79169e106684de000c8a6b21ac000cceb3b042a445d08419149742780330384fa32b82370091294d64cfd3426c46880420b2a5b3e7115b21c408d10044b674f63c460ae18e70f9f75abef73c7f7e29df1b51e9e5f27edefcdc3ecff2635c11bc01185ca489a3b01480f186c0795e3fa60e6146d01630b8481247612d006385c079513f428d5007205a9668442358b4fa61882342e12d821480685db2c5a3442038447a845578e4048f5a84f39a19eeafc2fd09cea37e883b02a12dc205923083e28b726f867bab726f827b5ebf9a5004425a840b346106c517e1fe0ce7ab705e33c17dcb4fe22e8215c04354da227bde1614e28870440846b07e738b4aff12ee7f87f3e83ccb6f0b77046901838b347114960230de1038cfeb27e18aa02d607091248ec25a00c60a81f3a27e35432258442358f4fa1d110a4784c290088bf0c8191e158d60cd8bfad5b82210da225c20093328ae85b0023038cfeb27e18e40488b708126cca0b814c21b80c17996df16a1081651698bec795b1c110a4784c25b04c20a61fdef302abd0af727385f84f39a19ee5b7e1214a0fcb8fd3d81d022480b185ca489a3f0aadc9be0dea2dc9be19ed7afc61d415bc0e022491c8557e1bc6682fb8b707f86f3a81f322c82c52a3caa6682475af4f8bd8b4048217a96483c4a040e401c110a7711883a447489f59b5b3482352fea476000c28c40688b708124cca0b816c20ac0e03caf1f634620bc21708126cca0b814c21b80c179961f530720dc112ca2d216d9f3187704221a225b3a7b1e2105203623109110d9d2d9f3b602106a04c21b222a6dfdef303a4f430b40a44520347114960230de1038cfa23b02d11b0285b5008c1502e7595801085704221242231aa1074f00c21d81c808b157046f00221481e989313a42e4f14c5304a235c4c8082d0188e608c488107b0720ba22302d31a4102d017a1ecfa444605a62b492f178263502333246e6e39921116a7aa28c7874cd2e111e9dff30b1bfacbc80bf400000000049454e44ae426082","seed_name":"Alice"}"#;
         assert!(print == expected_print, "\nReceived: \n{}", print);
         fs::remove_dir_all(dbname).unwrap();
     }
@@ -476,8 +529,8 @@ mod tests {
     fn path_is_known() {
         let dbname = "for_tests/path_is_known";
         populate_cold (dbname, Verifier(None)).unwrap();
-        let print = dynamic_path_check (dbname, "Alice", "//Alice", &NetworkSpecsKey::from_parts(&hex::decode("e143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e").unwrap(), &Encryption::Sr25519)).unwrap();
-        let expected_print = r#""base58":"5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY","path":"//Alice","has_pwd":"false","identicon":"89504e470d0a1a0a0000000d49484452000000410000004108060000008ef7c9450000030e49444154789cedda4d6a544114c571330e0eb286640782d8ee4090081964033d105c90e0a0379041c020b8035b047790aca10792715b87e644eb59afeeb9f5f1e86edf7f70320cf7075d83a44fb6dbedb3ffbd4910369b4df12f393b3b3b093fbad605a1e668ab1e284d117a1e3fac2546138492e3bf3ede868d7b737a15d6570b8c2a8492e3510a809540a01a8c62841e006c6a8822845200d413019540b8106a8e67bd1198074346680180a642402a8484e001f8717d1f36eee5cd45d85d5e842ff7d761e3de5edc84d552204c845a00a6425800ac254433841c00b3205400a6425421a800c88b60d51201e52046113c0068df11d0184412c10b800e0101a5206484d5e243d8b8e5fa63d85d5e84cbd7e761e3eebe3d84dde54558ac5661e3d6cb65d838094105602a8405c054080b80291026420e8059102a00b32054003684c8220c019017c1ca8b60558280fe869811424f08290074ac088810cd113e25de84f7156fc2cfc49bf0a2f24d603202ca4158004c85b000980a3106805c082805a102300b42056016440e00450816809217c1ca8b501a20668419c189f0ebf6316cdcf3abd3b0bbbc08ef16ff7e863fafff7c86bd08af2ecfc3c67dbf7b089b4f4648013015c202602a8405c02c08092107c02c08158059102a00cb417441b0f22258cd08a11921b4970847f926a01c8405c054080b80a91039002423a014840ac02c081580591016007221587911acbc08a5cd08a11921f484802c88a3ff7b02ca21a400980a61013015c202603908192107c02c08158059102a001b83e88660e545b06a8a805210c78a400034238422043484f0221cfcff22d11001e5202c00a64258004c851802201301a9102a00b3205400664128004846b0f222587911d46404e48538048414001a45401e887d471803405904a44278110ee67b8c48454039080b80a9102a00aa4640b5102a00b3205a0220090179207279116a5200908c805a404c85a002201702abc1e88de0399e1521a052889e082500a81801f580981a005521b0128c14440940cdf1ac09022bc128adc5f1ac2902eb89d1f278d60561580d4a8fa3874d82b0effd06a580bfac7347ad900000000049454e44ae426082","seed_name":"Alice""#;
+        let print = dynamic_path_check (dbname, "Alice", "//Alice", "0180e143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e").unwrap();
+        let expected_print = r#""base58":"5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY","path":"//Alice","has_pwd":false,"identicon":"89504e470d0a1a0a0000000d49484452000000410000004108060000008ef7c9450000030e49444154789cedda4d6a544114c571330e0eb286640782d8ee4090081964033d105c90e0a0379041c020b8035b047790aca10792715b87e644eb59afeeb9f5f1e86edf7f70320cf7075d83a44fb6dbedb3ffbd4910369b4df12f393b3b3b093fbad605a1e668ab1e284d117a1e3fac2546138492e3bf3ede868d7b737a15d6570b8c2a8492e3510a809540a01a8c62841e006c6a8822845200d413019540b8106a8e67bd1198074346680180a642402a8484e001f8717d1f36eee5cd45d85d5e842ff7d761e3de5edc84d552204c845a00a6425800ac254433841c00b3205400a6425421a800c88b60d51201e52046113c0068df11d0184412c10b800e0101a5206484d5e243d8b8e5fa63d85d5e84cbd7e761e3eebe3d84dde54558ac5661e3d6cb65d838094105602a8405c054080b80291026420e8059102a00b32054003684c8220c019017c1ca8b60558280fe869811424f08290074ac088810cd113e25de84f7156fc2cfc49bf0a2f24d603202ca4158004c85b000980a3106805c082805a102300b42056016440e00450816809217c1ca8b501a20668419c189f0ebf6316cdcf3abd3b0bbbc08ef16ff7e863fafff7c86bd08af2ecfc3c67dbf7b089b4f4648013015c202602a8405c02c08092107c02c08158059102a00cb417441b0f22258cd08a11921b4970847f926a01c8405c054080b80a91039002423a014840ac02c081580591016007221587911acbc08a5cd08a11921f484802c88a3ff7b02ca21a400980a61013015c202603908192107c02c08158059102a001b83e88660e545b06a8a805210c78a400034238422043484f0221cfcff22d11001e5202c00a64258004c851802201301a9102a00b3205400664128004846b0f222587911d46404e48538048414001a45401e887d471803405904a44278110ee67b8c48454039080b80a9102a00aa4640b5102a00b3205a0220090179207279116a5200908c805a404c85a002201702abc1e88de0399e1521a052889e082500a81801f580981a005521b0128c14440940cdf1ac09022bc128adc5f1ac2902eb89d1f278d60561580d4a8fa3874d82b0effd06a580bfac7347ad900000000049454e44ae426082","seed_name":"Alice""#;
         assert!(print == expected_print, "\nReceived: \n{}", print);
         fs::remove_dir_all(dbname).unwrap();
     }
@@ -486,7 +539,7 @@ mod tests {
     fn path_is_unknown() {
         let dbname = "for_tests/path_is_unknown";
         populate_cold (dbname, Verifier(None)).unwrap();
-        let print = dynamic_path_check (dbname, "Alice", "//secret", &NetworkSpecsKey::from_parts(&hex::decode("e143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e").unwrap(), &Encryption::Sr25519)).unwrap();
+        let print = dynamic_path_check (dbname, "Alice", "//secret", "0180e143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e").unwrap();
         let expected_print = r#""#;
         assert!(print == expected_print, "\nReceived: \n{}", print);
         fs::remove_dir_all(dbname).unwrap();

--- a/rust/navigator/src/navstate.rs
+++ b/rust/navigator/src/navstate.rs
@@ -11,7 +11,7 @@ use crate::alerts::Alert;
 
 //use plot_icon;
 use db_handling;
-use definitions::{error::{AddressKeySource, ErrorSigner, ErrorSource, ExtraAddressKeySourceSigner, InputSigner, InterfaceSigner, Signer}, keyring::{AddressKey, NetworkSpecsKey}, users::AddressDetails};
+use definitions::{error::{AddressGeneration, AddressGenerationCommon, AddressKeySource, ErrorSigner, ErrorSource, ExtraAddressKeySourceSigner, InputSigner, InterfaceSigner, Signer}, keyring::{AddressKey, NetworkSpecsKey}, users::AddressDetails};
 use transaction_parsing;
 use transaction_signing;
 
@@ -268,8 +268,15 @@ impl State {
                             match db_handling::identities::try_create_address (&derive_state.seed_name(), secret_seed_phrase, details_str, &derive_state.network_specs_key(), dbname) {
                                 Ok(()) => {new_navstate = Navstate::clean_screen(Screen::Keys(KeysState::new_in_network(&derive_state.seed_name(), &derive_state.network_specs_key())))},
                                 Err(e) => {
-                                    new_navstate.alert = Alert::Error;
-                                    errorline.push_str(&<Signer>::show(&e));
+                                    if let ErrorSigner::AddressGeneration(AddressGeneration::Common(AddressGenerationCommon::DerivationExists(ref multisigner, ref address_details, _))) = e {
+                                        new_navstate.screen = Screen::DeriveKey(derive_state.collided_with(&multisigner, &address_details));
+                                        new_navstate.alert = Alert::Error;
+                                        errorline.push_str(&<Signer>::show(&e));
+                                    }
+                                    else {
+                                        new_navstate.alert = Alert::Error;
+                                        errorline.push_str(&<Signer>::show(&e));
+                                    }
                                 },
                             }
                         },
@@ -1042,7 +1049,7 @@ impl State {
                 Screen::RecoverSeedName(ref seed_name) => format!("\"seed_name\":\"{}\",\"keyboard\":{}", seed_name, new_navstate.keyboard()),
                 Screen::RecoverSeedPhrase(ref seed_name) => format!("\"seed_name\":\"{}\",\"keyboard\":{}", seed_name, new_navstate.keyboard()),
                 Screen::DeriveKey(ref derive_state) => {
-                    match db_handling::interface_signer::derive_prep (dbname, &derive_state.seed_name(), &derive_state.network_specs_key(), &details_str) {
+                    match db_handling::interface_signer::derive_prep (dbname, &derive_state.seed_name(), &derive_state.network_specs_key(), derive_state.collision(), &details_str) {
                         Ok(a) => {
                             format!("{},\"keyboard\":{}", a, new_navstate.keyboard())
                         },

--- a/rust/navigator/src/screens.rs
+++ b/rust/navigator/src/screens.rs
@@ -72,6 +72,7 @@ pub struct AddressStateMulti {
 pub struct DeriveState {
     entered_info: EnteredInfo,
     keys_state: KeysState,
+    collision: Option<(MultiSigner, AddressDetails)>,
 }
 
 ///State of transaction screen
@@ -299,6 +300,7 @@ impl DeriveState {
         Self {
             entered_info: EnteredInfo(entered_string.to_string()),
             keys_state: keys_state.to_owned(),
+            collision: None,
         }
     }
     pub fn blank_keys_state(&self) -> KeysState {
@@ -317,10 +319,21 @@ impl DeriveState {
     pub fn path(&self) -> String {
         self.entered_info.0.to_owned()
     }
+    pub fn collision(&self) -> Option<(MultiSigner, AddressDetails)> {
+        self.collision.to_owned()
+    }
     pub fn update(&self, new_secret_string: &str) -> Self {
         Self {
             entered_info: EnteredInfo(new_secret_string.to_string()),
             keys_state: self.blank_keys_state(),
+            collision: self.collision(),
+        }
+    }
+    pub fn collided_with(&self, multisigner: &MultiSigner, address_details: &AddressDetails) -> Self {
+        Self {
+            entered_info: self.entered_info.to_owned(),
+            keys_state: self.blank_keys_state(),
+            collision: Some((multisigner.to_owned(), address_details.to_owned())),
         }
     }
 }

--- a/rust/signer/src/lib.rs
+++ b/rust/signer/src/lib.rs
@@ -71,11 +71,21 @@ export! {
         db_handling::identities::guess(part)
     }
 
-    @Java_io_parity_signer_models_SignerDataModel_substrateCheckPath
-    fn check_path(
+    @Java_io_parity_signer_models_SignerDataModel_substratePathCheck
+    fn path_check(
         path: &str
     ) -> anyhow::Result<bool, anyhow::Error> {
         db_handling::identities::check_derivation_format(path).map_err(|e| e.anyhow())
+    }
+
+    @Java_io_parity_signer_models_SignerDataModel_dynamicPathCheck
+    fn dynamic_path_check(
+        seed_name: &str,
+        path: &str,
+        network: &str,
+        dbname: &str
+    ) -> anyhow::Result<String, anyhow::Error> {
+        db_handling::interface_signer::dynamic_path_check(dbname, seed_name, path, network).map_err(|e| e.anyhow())
     }
 
     @Java_io_parity_signer_models_SignerDataModel_substrateValidateSeedphrase

--- a/rust/signer/src/lib.rs
+++ b/rust/signer/src/lib.rs
@@ -73,19 +73,12 @@ export! {
 
     @Java_io_parity_signer_models_SignerDataModel_substratePathCheck
     fn path_check(
-        path: &str
-    ) -> anyhow::Result<bool, anyhow::Error> {
-        db_handling::identities::check_derivation_format(path).map_err(|e| e.anyhow())
-    }
-
-    @Java_io_parity_signer_models_SignerDataModel_dynamicPathCheck
-    fn dynamic_path_check(
         seed_name: &str,
         path: &str,
         network: &str,
         dbname: &str
-    ) -> anyhow::Result<String, anyhow::Error> {
-        db_handling::interface_signer::dynamic_path_check(dbname, seed_name, path, network).map_err(|e| e.anyhow())
+    ) -> String {
+        db_handling::interface_signer::dynamic_path_check(dbname, seed_name, path, network)
     }
 
     @Java_io_parity_signer_models_SignerDataModel_substrateValidateSeedphrase


### PR DESCRIPTION
When user attempts to create an address they already have, warn them about it before Next button is pressed (by disabling it and showing collision) or after password is entered (for it's the earliest possible moment).

- [x] Backend handles
- [x] Tests
- [ ] iOS screens
- [ ] android screens