### PR TITLE
fix: work around to launch camer for caption on mac

### DIFF
--- a/rust/qr_reader_pc/src/lib.rs
+++ b/rust/qr_reader_pc/src/lib.rs
@@ -101,7 +101,7 @@ fn create_camera(camera_index: i32, width: u32, height: u32) -> anyhow::Result<v
     let mut frame = Mat::default();
 
     match camera.read(&mut frame) {
-        Ok(_) if frame.size()?.width > 0 => Ok(camera),
+        Ok(_) if frame.size()?.width >= 0 => Ok(camera),
         Ok(_) => Err(anyhow!("Zero frame size.")),
         Err(e) => Err(anyhow!("Can`t read camera. {}", e)),
     }


### PR DESCRIPTION
As discussed with Alexander @Slesarew here is a pr for the workaround to be able to launch camera for reading. Initial issue I was facing on my macbook was that qc_reader_pc was not able to start failing with the following error: 
Error: "QR reading error. Zero frame size."