### PR TITLE
fix: replace apng-encoder with png

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -69,19 +69,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
-name = "apng-encoder"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c7f9987a57a1c655fde73fcda60bde986fa9410ab9d2912d894c83eb2eadb92"
-dependencies = [
- "byteorder",
- "enum-iterator",
- "enum-iterator-derive",
- "failure",
- "flate2",
-]
-
-[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -727,26 +714,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
-name = "enum-iterator"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdb0aac423d2d59cc8b22de1ebd0db7f8d07382b8189945c89ab882a1c659b5"
-dependencies = [
- "enum-iterator-derive",
-]
-
-[[package]]
-name = "enum-iterator-derive"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df9d0cef4b051baf3ef7f9b1674273dc78cd56e02cba60fa187f9c0ff4ff5e0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "environmental"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -760,28 +727,6 @@ checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
 dependencies = [
  "backtrace",
  "version_check",
-]
-
-[[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
 ]
 
 [[package]]
@@ -819,18 +764,6 @@ dependencies = [
  "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
-]
-
-[[package]]
-name = "flate2"
-version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
-dependencies = [
- "cfg-if",
- "crc32fast",
- "libc",
- "miniz_oxide 0.4.4",
 ]
 
 [[package]]
@@ -2164,9 +2097,9 @@ dependencies = [
 name = "qrcode_rtx"
 version = "0.1.0"
 dependencies = [
- "apng-encoder",
  "constants",
  "hex",
+ "png 0.17.5",
  "qrcode_static",
  "qrcodegen",
  "raptorq",

--- a/rust/qrcode_rtx/Cargo.toml
+++ b/rust/qrcode_rtx/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 hex = "0.4.3"
 raptorq = "1.6.4"
 qrcodegen = "1.6.0"
-apng-encoder = "0.3.0"
+png = "0.17.5"
 constants = {path = "../constants"}
 qrcode_static = {path = "../qrcode_static"}
 

--- a/rust/qrcode_rtx/src/lib.rs
+++ b/rust/qrcode_rtx/src/lib.rs
@@ -64,6 +64,7 @@ fn make_apng(data: Vec<QrCode>, output_name: &str) -> Result<(), Box<dyn std::er
     encoder.set_color(png::ColorType::Grayscale);
     encoder.set_animated(frames_count, 0)?;
     encoder.set_frame_delay(FPS_NOM, FPS_DEN)?;
+    encoder.set_depth(png::BitDepth::Eight);
 
     let mut writer = encoder.write_header()?;
     // making actual apng


### PR DESCRIPTION
The `apng-encode`  looks unmantained and also brings in `failure` which is also unmantained.

```
Crate:         failure
Version:       0.1.8
Warning:       unmaintained
Title:         failure is officially deprecated/unmaintained
Date:          2020-05-02
ID:            RUSTSEC-2020-0036
URL:           https://rustsec.org/advisories/RUSTSEC-2020-0036
Dependency tree:
failure 0.1.8
└── apng-encoder 0.3.0
    └── qrcode_rtx 0.1.0
        └── generate_message 0.1.0
            └── signer 0.1.0
```

`png` crate looks more alive, being benchmarked and fuzz-tested and has a far wider user base.