### PR TITLE
fix: load_metadata update: additional name check

### DIFF
--- a/rust/db_handling/src/helpers.rs
+++ b/rust/db_handling/src/helpers.rs
@@ -181,19 +181,9 @@ pub fn get_valid_current_verifier(
 /// outputs network specs key for the network with the lowest order.
 ///
 /// If there are several entries with same genesis hash, all of them must have
-/// identical base58 prefix. Base58 prefix from found network specs is used in
-/// `add_specs` module of `transaction_parsing` crate directly, and therefore is
-/// checked here.
-///
-/// When the entries are added in the database, only the entries with same
-/// base58 prefix are allowed for a given network, as identified by genesis
-/// hash. This is done to keep consistency between the network specs and
-/// network metadata, that potentially also can contain the base58 prefix, but
-/// has no specified associated [`Encryption`](definitions::crypto::Encryption),
-/// i.e. could be used with any [`NetworkSpecs`] containing given genesis hash.
-///
-/// If later on different values are found, it indicates the database
-/// corruption.
+/// identical base58 prefix and network name. Network name is, and base58 prefix
+/// could be a part of the network metadata, and therefore must not depend on
+/// encryption used.
 #[cfg(feature = "signer")]
 pub fn genesis_hash_in_specs(
     verifier_key: &VerifierKey,
@@ -202,7 +192,7 @@ pub fn genesis_hash_in_specs(
     let genesis_hash = verifier_key.genesis_hash();
     let chainspecs = open_tree::<Signer>(database, SPECSTREE)?;
     let mut specs_set: Vec<(NetworkSpecsKey, NetworkSpecs)> = Vec::new();
-    let mut found_base58prefix = None;
+    let mut found_permanent_specs: Option<(u16, String)> = None;
     for (network_specs_key_vec, network_specs_encoded) in chainspecs.iter().flatten() {
         let network_specs_key = NetworkSpecsKey::from_ivec(&network_specs_key_vec);
         let network_specs = NetworkSpecs::from_entry_with_key_checked::<Signer>(
@@ -210,10 +200,20 @@ pub fn genesis_hash_in_specs(
             network_specs_encoded,
         )?;
         if network_specs.genesis_hash.as_bytes() == &genesis_hash[..] {
-            found_base58prefix = match found_base58prefix {
-                Some(base58prefix) => {
+            found_permanent_specs = match found_permanent_specs {
+                Some((base58prefix, name)) => {
                     if base58prefix == network_specs.base58prefix {
-                        Some(base58prefix)
+                        if name == network_specs.name {
+                            Some((base58prefix, name))
+                        } else {
+                            return Err(ErrorSigner::Database(
+                                DatabaseSigner::DifferentNamesSameGenesisHash {
+                                    name1: name,
+                                    name2: network_specs.name.to_string(),
+                                    genesis_hash: network_specs.genesis_hash,
+                                },
+                            ));
+                        }
                     } else {
                         return Err(ErrorSigner::Database(
                             DatabaseSigner::DifferentBase58Specs {
@@ -224,7 +224,7 @@ pub fn genesis_hash_in_specs(
                         ));
                     }
                 }
-                None => Some(network_specs.base58prefix),
+                None => Some((network_specs.base58prefix, network_specs.name.to_string())),
             };
             specs_set.push((network_specs_key, network_specs))
         }

--- a/rust/definitions/src/error_signer.rs
+++ b/rust/definitions/src/error_signer.rs
@@ -271,6 +271,7 @@ impl ErrorSource for Signer {
                         };
                         format!("Network {} was previously known to the database with verifier {}. However, no network specs are in the database at the moment. Add network specs before loading the metadata.", name, insert)
                     },
+                    InputSigner::LoadMetaWrongGenesisHash {name_metadata, name_specs, genesis_hash} => format!("Update payload contains metadata for network {}. Genesis hash in payload ({}) matches database genesis hash for another network, {}.", name_metadata, hex::encode(genesis_hash), name_specs),
                     InputSigner::NeedVerifier{name, verifier_value} => format!("Saved network {} information was signed by verifier {}. Received information is not signed.", name, verifier_value.show_error()),
                     InputSigner::NeedGeneralVerifier{content, verifier_value} => {
                         let insert = match content {
@@ -685,11 +686,10 @@ pub enum DatabaseSigner {
 
     /// While searching for all networks with same genesis hash, found that
     /// there are networks with same genesis hash, but different names.
-    // TODO: is this really an error? if it is, add error to data loading too.
     DifferentNamesSameGenesisHash {
         name1: String,
         name2: String,
-        genesis_hash: Vec<u8>,
+        genesis_hash: H256,
     },
 
     /// Network [`CurrentVerifier`](crate::network_specs::CurrentVerifier) is
@@ -1079,6 +1079,28 @@ pub enum InputSigner {
 
         /// Signer general verifier
         general_verifier: Verifier,
+    },
+
+    /// User attempted to load into Signer the metadata for the network that
+    /// has a [`NetworkSpecs`](crate::network_specs::NetworkSpecs) entry in the
+    /// `SPECSTREE` tree of the Signer database, but specs have a different
+    /// network name.
+    ///
+    /// Most likely, wrong genesis hash was attached to the metadata update.
+    ///
+    /// Since the network metadata in `METATREE` is identified by network name,
+    /// and verifier is identified by the genesis hash, this should be checked
+    /// on `load_metadata`.
+    LoadMetaWrongGenesisHash {
+        /// network name as it is in the received metadata
+        name_metadata: String,
+
+        /// network name as it is in the network specs for genesis hash
+        name_specs: String,
+
+        /// genesis hash from the `load_metadata` payload, that was used to find
+        /// the network specs and verifier information
+        genesis_hash: H256,
     },
 
     /// Received `add_specs` or `load_metadata` update payload is not verified.

--- a/rust/definitions/src/test_all_errors_signer.rs
+++ b/rust/definitions/src/test_all_errors_signer.rs
@@ -359,7 +359,7 @@ fn database_signer() -> Vec<DatabaseSigner> {
         DatabaseSigner::DifferentNamesSameGenesisHash {
             name1: String::from("westend"),
             name2: String::from("WeStEnD"),
-            genesis_hash: genesis_hash().as_bytes().to_vec(),
+            genesis_hash: genesis_hash(),
         },
         DatabaseSigner::CustomVerifierIsGeneral(verifier_key()),
         DatabaseSigner::TwoRootKeys {
@@ -432,6 +432,11 @@ fn input_signer() -> Vec<InputSigner> {
             name: String::from("westend"),
             valid_current_verifier: ValidCurrentVerifier::General,
             general_verifier: verifier_sr25519(),
+        },
+        InputSigner::LoadMetaWrongGenesisHash {
+            name_metadata: String::from("acala"),
+            name_specs: String::from("westend"),
+            genesis_hash: genesis_hash(),
         },
         InputSigner::NeedVerifier {
             name: String::from("kulupu"),
@@ -1067,6 +1072,7 @@ mod tests {
 "Bad input data. Received payload has bad signature."
 "Bad input data. Network kulupu is not in the database. Add network specs before loading the metadata."
 "Bad input data. Network westend was previously known to the database with verifier public key: 8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48, encryption: sr25519 (general verifier). However, no network specs are in the database at the moment. Add network specs before loading the metadata."
+"Bad input data. Update payload contains metadata for network acala. Genesis hash in payload (e143f23803ca50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e) matches database genesis hash for another network, westend."
 "Bad input data. Saved network kulupu information was signed by verifier public key: 8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48, encryption: ed25519. Received information is not signed."
 "Bad input data. General verifier in the database is public key: 8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48, encryption: sr25519. Received unsigned westend network information could be accepted only if signed by the general verifier."
 "Bad input data. General verifier in the database is public key: 8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48, encryption: sr25519. Received unsigned types information could be accepted only if signed by the general verifier."

--- a/rust/transaction_parsing/src/holds.rs
+++ b/rust/transaction_parsing/src/holds.rs
@@ -62,7 +62,7 @@ fn collect_set(
                             DatabaseSigner::DifferentNamesSameGenesisHash {
                                 name1: n,
                                 name2: network_specs.name,
-                                genesis_hash,
+                                genesis_hash: network_specs.genesis_hash,
                             },
                         ));
                     }

--- a/rust/transaction_parsing/src/load_metadata.rs
+++ b/rust/transaction_parsing/src/load_metadata.rs
@@ -65,6 +65,13 @@ pub fn load_metadata(
                 }))
             }
         };
+    if meta_values.name != network_specs.name {
+        return Err(ErrorSigner::Input(InputSigner::LoadMetaWrongGenesisHash {
+            name_metadata: meta_values.name,
+            name_specs: network_specs.name,
+            genesis_hash: network_specs.genesis_hash,
+        }));
+    }
     if let Some(prefix_from_meta) = meta_values.optional_base58prefix {
         if prefix_from_meta != network_specs.base58prefix {
             return Err(<Signer>::faulty_metadata(


### PR DESCRIPTION
When processing `load_metadata` update, Signer must check the network name.