### PR TITLE
fix: check same name in add_specs, few nits

### DIFF
--- a/rust/db_handling/src/identities.rs
+++ b/rust/db_handling/src/identities.rs
@@ -38,8 +38,10 @@ use parity_scale_codec::Encode;
 use regex::Regex;
 #[cfg(feature = "signer")]
 use sled::Batch;
+#[cfg(feature = "active")]
+use sp_core::H256;
 #[cfg(any(feature = "active", feature = "signer"))]
-use sp_core::{ecdsa, ed25519, sr25519, Pair, H256};
+use sp_core::{ecdsa, ed25519, sr25519, Pair};
 #[cfg(any(feature = "active", feature = "signer"))]
 use sp_runtime::MultiSigner;
 #[cfg(any(feature = "active", feature = "signer"))]

--- a/rust/db_handling/src/tests.rs
+++ b/rust/db_handling/src/tests.rs
@@ -1990,7 +1990,7 @@ fn test_all_events() {
         &entries,
         &Event::NetworkVerifierSet {
             network_verifier_display: NetworkVerifierDisplay {
-                genesis_hash: hex::decode(
+                genesis_hash: H256::from_str(
                     "e143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e"
                 )
                 .unwrap(),

--- a/rust/definitions/src/error_signer.rs
+++ b/rust/definitions/src/error_signer.rs
@@ -240,7 +240,7 @@ impl ErrorSource for Signer {
                         format!("Mismatch found. {}", insert)
                     },
                     DatabaseSigner::FaultyMetadata{name, version, error} => format!("Bad metadata for {}{}. {}", name, version, error.show()),
-                    DatabaseSigner::UnexpectedGenesisHash{verifier_key, network_specs_key} => format!("No verifier information found for network with genesis hash {}, however genesis hash is encountered in network specs entry with key {}.", hex::encode(verifier_key.genesis_hash()), hex::encode(network_specs_key.key())),
+                    DatabaseSigner::UnexpectedGenesisHash{name, genesis_hash} => format!("Network {} with genesis hash {} has some network specs entries, while there is no verifier entry.", name, hex::encode(genesis_hash)),
                     DatabaseSigner::SpecsCollision{name, encryption} => format!("More than one entry for network specs with name {} and encryption {}.", name, encryption.show()),
                     DatabaseSigner::DifferentNamesSameGenesisHash{name1, name2, genesis_hash} => format!("Different network names ({}, {}) in database for same genesis hash {}.", name1, name2, hex::encode(genesis_hash)),
                     DatabaseSigner::CustomVerifierIsGeneral(key) => format!("Network with genesis hash {} verifier is set as a custom one. This custom verifier coinsides the database general verifier and not None. This should not have happened and likely indicates database corruption.", hex::encode(key.genesis_hash())),
@@ -260,7 +260,8 @@ impl ErrorSource for Signer {
                     InputSigner::SameNameVersionDifferentMeta{name, version} => format!("Metadata for {}{} is already in the database and is different from the one in received payload.", name, version),
                     InputSigner::MetadataKnown{name, version} => format!("Metadata for {}{} is already in the database.", name, version),
                     InputSigner::ImportantSpecsChanged(key) => format!("Similar network specs are already stored in the database under key {}. Network specs in received payload have different unchangeable values (base58 prefix, decimals, encryption, network name, unit).", hex::encode(key.key())),
-                    InputSigner::DifferentBase58{genesis_hash, base58_database, base58_input} => format!("Network with genesis hash {} already has entries in the database with base58 prefix {}. Received network specs have different base58 prefix {}.", hex::encode(genesis_hash), base58_database, base58_input),
+                    InputSigner::AddSpecsDifferentBase58{genesis_hash, name, base58_database, base58_input} => format!("Network {} with genesis hash {} already has entries in the database with base58 prefix {}. Received network specs have same genesis hash and different base58 prefix {}.", name, hex::encode(genesis_hash), base58_database, base58_input),
+                    InputSigner::AddSpecsDifferentName{genesis_hash, name_database, name_input} => format!("Network with genesis hash {} has name {} in the database. Received network specs have same genesis hash and name {}.", hex::encode(genesis_hash), name_database, name_input),
                     InputSigner::EncryptionNotSupported(code) => format!("Payload with encryption 0x{} is not supported.", code),
                     InputSigner::BadSignature => String::from("Received payload has bad signature."),
                     InputSigner::LoadMetaUnknownNetwork{name} => format!("Network {} is not in the database. Add network specs before loading the metadata.", name),
@@ -665,12 +666,11 @@ pub enum DatabaseSigner {
     /// entry, and the verifier could not be removed while network specs still
     /// remain, so this indicates the database got corrupted.
     UnexpectedGenesisHash {
-        /// `VerifierKey` that was not found in the database
-        verifier_key: VerifierKey,
+        /// network name
+        name: String,
 
-        /// `NetworkSpecsKey` for entry that has the genesis hash corresponding
-        /// to not found `verifier_key`
-        network_specs_key: NetworkSpecsKey,
+        /// network genesis hash
+        genesis_hash: H256,
     },
 
     /// More than one entry found for network specs with given `name` and
@@ -1012,10 +1012,24 @@ pub enum InputSigner {
     /// same encryption, i.e. **possibly different** [`NetworkSpecsKey`],
     /// and base58 prefix in stored network specs is different from the base58
     /// prefix in the received ones.
-    DifferentBase58 {
+    AddSpecsDifferentBase58 {
         genesis_hash: H256,
+        name: String,
         base58_database: u16,
         base58_input: u16,
+    },
+
+    /// [`NetworkSpecsToSend`](crate::network_specs::NetworkSpecsToSend)
+    /// received in `add_specs` payload are for a network that already has
+    /// [`NetworkSpecs`](crate::network_specs::NetworkSpecs) entry in
+    /// the `SPECSTREE` tree of the Signer database with not necessarily
+    /// same encryption, i.e. **possibly different** [`NetworkSpecsKey`],
+    /// and network name in stored network specs is different from the network
+    /// name in the received ones.
+    AddSpecsDifferentName {
+        genesis_hash: H256,
+        name_database: String,
+        name_input: String,
     },
 
     /// There is a limited number of encryption algorithms supported by the

--- a/rust/definitions/src/history.rs
+++ b/rust/definitions/src/history.rs
@@ -19,6 +19,7 @@
 //! `Event::HistoryCleared`.
 use blake2_rfc::blake2b::blake2b;
 use parity_scale_codec::{Decode, Encode};
+use sp_core::H256;
 use sp_runtime::MultiSigner;
 #[cfg(feature = "signer")]
 use std::convert::TryInto;
@@ -151,7 +152,7 @@ impl NetworkSpecsExport {
 /// Event content for setting network verifier
 #[derive(Debug, Decode, Encode, PartialEq, Clone)]
 pub struct NetworkVerifierDisplay {
-    pub genesis_hash: Vec<u8>,
+    pub genesis_hash: H256,
     pub valid_current_verifier: ValidCurrentVerifier,
     pub general_verifier: Verifier,
 }

--- a/rust/definitions/src/keyring.rs
+++ b/rust/definitions/src/keyring.rs
@@ -155,8 +155,8 @@ impl VerifierKey {
     }
 
     /// Get genesis hash from the [`VerifierKey`]
-    pub fn genesis_hash(&self) -> Vec<u8> {
-        self.0.as_bytes().to_vec()
+    pub fn genesis_hash(&self) -> H256 {
+        self.0
     }
 
     /// Transform [`VerifierKey`] into `Vec<u8>` database key  

--- a/rust/definitions/src/metadata.rs
+++ b/rust/definitions/src/metadata.rs
@@ -26,6 +26,7 @@ use sc_executor_common::{
 #[cfg(feature = "active")]
 use sc_executor_wasmi::create_runtime;
 use sled::IVec;
+#[cfg(feature = "active")]
 use sp_core::H256;
 #[cfg(feature = "active")]
 use sp_io::SubstrateHostFunctions;

--- a/rust/definitions/src/test_all_errors_signer.rs
+++ b/rust/definitions/src/test_all_errors_signer.rs
@@ -349,8 +349,8 @@ fn database_signer() -> Vec<DatabaseSigner> {
     // All remaining [`DatabaseSigner`] errors.
     out.append(&mut vec![
         DatabaseSigner::UnexpectedGenesisHash {
-            verifier_key: VerifierKey::from_parts(genesis_hash()),
-            network_specs_key: network_specs_key_good(),
+            name: String::from("westend"),
+            genesis_hash: genesis_hash(),
         },
         DatabaseSigner::SpecsCollision {
             name: String::from("westend"),
@@ -418,10 +418,16 @@ fn input_signer() -> Vec<InputSigner> {
             version: 9122,
         },
         InputSigner::ImportantSpecsChanged(network_specs_key_good()),
-        InputSigner::DifferentBase58 {
+        InputSigner::AddSpecsDifferentBase58 {
             genesis_hash: genesis_hash(),
+            name: String::from("westend"),
             base58_database: 42,
             base58_input: 104,
+        },
+        InputSigner::AddSpecsDifferentName {
+            genesis_hash: genesis_hash(),
+            name_database: String::from("westend"),
+            name_input: String::from("WeStEnD"),
         },
         InputSigner::EncryptionNotSupported(String::from("03")),
         InputSigner::BadSignature,
@@ -1043,7 +1049,7 @@ mod tests {
 "Database error. Bad metadata for westend9000. Base58 prefix 104 from system pallet constants does not match the base58 prefix from network specs 42."
 "Database error. Bad metadata for westend9000. Metadata vector does not start with 0x6d657461."
 "Database error. Bad metadata for westend9000. Runtime metadata could not be decoded."
-"Database error. No verifier information found for network with genesis hash e143f23803ca50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e, however genesis hash is encountered in network specs entry with key 0150e143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e."
+"Database error. Network westend with genesis hash e143f23803ca50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e has some network specs entries, while there is no verifier entry."
 "Database error. More than one entry for network specs with name westend and encryption sr25519."
 "Database error. Different network names (westend, WeStEnD) in database for same genesis hash e143f23803ca50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e."
 "Database error. Network with genesis hash 853faffbfc6713c1f899bf16547fcfbf733ae8361b8ca0129699d01d4f2181fd verifier is set as a custom one. This custom verifier coinsides the database general verifier and not None. This should not have happened and likely indicates database corruption."
@@ -1067,7 +1073,8 @@ mod tests {
 "Bad input data. Metadata for kusama9110 is already in the database and is different from the one in received payload."
 "Bad input data. Metadata for westend9122 is already in the database."
 "Bad input data. Similar network specs are already stored in the database under key 0150e143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e. Network specs in received payload have different unchangeable values (base58 prefix, decimals, encryption, network name, unit)."
-"Bad input data. Network with genesis hash e143f23803ca50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e already has entries in the database with base58 prefix 42. Received network specs have different base58 prefix 104."
+"Bad input data. Network westend with genesis hash e143f23803ca50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e already has entries in the database with base58 prefix 42. Received network specs have same genesis hash and different base58 prefix 104."
+"Bad input data. Network with genesis hash e143f23803ca50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e has name westend in the database. Received network specs have same genesis hash and name WeStEnD."
 "Bad input data. Payload with encryption 0x03 is not supported."
 "Bad input data. Received payload has bad signature."
 "Bad input data. Network kulupu is not in the database. Add network specs before loading the metadata."

--- a/rust/signer/src/signer.udl
+++ b/rust/signer/src/signer.udl
@@ -87,7 +87,7 @@ dictionary NetworkSpecsExport {
 };
 
 dictionary NetworkVerifierDisplay {
-    sequence<u8> genesis_hash;
+    H256 genesis_hash;
     ValidCurrentVerifier valid_current_verifier;
     Verifier general_verifier;
 };

--- a/rust/transaction_parsing/src/add_specs.rs
+++ b/rust/transaction_parsing/src/add_specs.rs
@@ -29,13 +29,21 @@ pub fn add_specs(data_hex: &str, database_name: &str) -> Result<TransactionActio
     let possible_valid_current_verifier =
         try_get_valid_current_verifier(&verifier_key, database_name)?;
     let general_verifier = get_general_verifier(database_name)?;
-    if let Some((_, known_network_specs)) =
-        genesis_hash_in_specs(&verifier_key, &open_db::<Signer>(database_name)?)?
+    if let Some(specs_invariants) =
+        genesis_hash_in_specs(specs.genesis_hash, &open_db::<Signer>(database_name)?)?
     {
-        if specs.base58prefix != known_network_specs.base58prefix {
-            return Err(ErrorSigner::Input(InputSigner::DifferentBase58 {
-                genesis_hash: specs.genesis_hash,
-                base58_database: known_network_specs.base58prefix,
+        if specs.name != specs_invariants.name {
+            return Err(ErrorSigner::Input(InputSigner::AddSpecsDifferentName {
+                genesis_hash: specs_invariants.genesis_hash,
+                name_database: specs_invariants.name,
+                name_input: specs.name,
+            }));
+        }
+        if specs.base58prefix != specs_invariants.base58prefix {
+            return Err(ErrorSigner::Input(InputSigner::AddSpecsDifferentBase58 {
+                genesis_hash: specs_invariants.genesis_hash,
+                name: specs_invariants.name,
+                base58_database: specs_invariants.base58prefix,
                 base58_input: specs.base58prefix,
             }));
         }

--- a/rust/transaction_parsing/src/load_metadata.rs
+++ b/rust/transaction_parsing/src/load_metadata.rs
@@ -54,8 +54,8 @@ pub fn load_metadata(
             }))
         }
     };
-    let (network_specs_key, network_specs) =
-        match genesis_hash_in_specs(&verifier_key, &open_db::<Signer>(database_name)?)? {
+    let specs_invariants =
+        match genesis_hash_in_specs(genesis_hash, &open_db::<Signer>(database_name)?)? {
             Some(a) => a,
             None => {
                 return Err(ErrorSigner::Input(InputSigner::LoadMetaNoSpecs {
@@ -65,18 +65,18 @@ pub fn load_metadata(
                 }))
             }
         };
-    if meta_values.name != network_specs.name {
+    if meta_values.name != specs_invariants.name {
         return Err(ErrorSigner::Input(InputSigner::LoadMetaWrongGenesisHash {
             name_metadata: meta_values.name,
-            name_specs: network_specs.name,
-            genesis_hash: network_specs.genesis_hash,
+            name_specs: specs_invariants.name,
+            genesis_hash,
         }));
     }
     if let Some(prefix_from_meta) = meta_values.optional_base58prefix {
-        if prefix_from_meta != network_specs.base58prefix {
+        if prefix_from_meta != specs_invariants.base58prefix {
             return Err(<Signer>::faulty_metadata(
                 MetadataError::Base58PrefixSpecsMismatch {
-                    specs: network_specs.base58prefix,
+                    specs: specs_invariants.base58prefix,
                     meta: prefix_from_meta,
                 },
                 MetadataSource::Incoming(IncomingMetadataSourceSigner::ReceivedData),
@@ -203,7 +203,7 @@ pub fn load_metadata(
                     },
                     u: checksum,
                     stub: StubNav::LoadMeta {
-                        l: network_specs_key,
+                        l: specs_invariants.first_network_specs_key,
                     },
                 }),
                 None => Ok(TransactionAction::Stub {
@@ -214,7 +214,7 @@ pub fn load_metadata(
                     },
                     u: checksum,
                     stub: StubNav::LoadMeta {
-                        l: network_specs_key,
+                        l: specs_invariants.first_network_specs_key,
                     },
                 }),
             },
@@ -228,7 +228,7 @@ pub fn load_metadata(
                     },
                     u: checksum,
                     stub: StubNav::LoadMeta {
-                        l: network_specs_key,
+                        l: specs_invariants.first_network_specs_key,
                     },
                 }),
                 None => Ok(TransactionAction::Stub {
@@ -239,7 +239,7 @@ pub fn load_metadata(
                     },
                     u: checksum,
                     stub: StubNav::LoadMeta {
-                        l: network_specs_key,
+                        l: specs_invariants.first_network_specs_key,
                     },
                 }),
             },

--- a/rust/transaction_parsing/src/tests.rs
+++ b/rust/transaction_parsing/src/tests.rs
@@ -1718,7 +1718,7 @@ fn add_specs_bad_westend_ed25519_not_signed() {
         error: Some(vec![TransactionCard {
             index: 0,
             indent: 0,
-            card: Card::ErrorCard { f: "Bad input data. Network with genesis hash e143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e already has entries in the database with base58 prefix 42. Received network specs have different base58 prefix 115.".to_string()
+            card: Card::ErrorCard { f: "Bad input data. Network westend with genesis hash e143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e already has entries in the database with base58 prefix 42. Received network specs have same genesis hash and different base58 prefix 115.".to_string()
             },
         }]),
         ..Default::default()


### PR DESCRIPTION
Name must be checked in `add_specs` update across all encryptions.