### PR TITLE
refactor: ios environment object removal

### DIFF
--- a/ios/NativeSigner/Alerts/AlertSelector.swift
+++ b/ios/NativeSigner/Alerts/AlertSelector.swift
@@ -9,9 +9,10 @@ import SwiftUI
 import CoreML
 
 struct AlertSelector: View {
-    @EnvironmentObject var data: SignerDataModel
+    let alertData: AlertData?
+    
     var body: some View {
-        switch (data.actionResult.alertData) {
+        switch (alertData) {
         case .none:
             EmptyView()
         case .errorData(let value):

--- a/ios/NativeSigner/Cards/HistoryCardExtended.swift
+++ b/ios/NativeSigner/Cards/HistoryCardExtended.swift
@@ -173,7 +173,7 @@ struct HistoryCardExtended: View {
                 Text("in network")
                 Text(value.networkName)
                 Text("Comment :")
-                Text(String(decoding: Data(base64Encoded: value.userComment) ?? Data(), as: UTF8.self))
+                Text(value.userComment)
             }
             case .transactionSigned(let value):
                 VStack {
@@ -189,7 +189,7 @@ struct HistoryCardExtended: View {
                     Text("in network")
                     Text(value.networkName)
                     Text("Comment :")
-                    Text(String(decoding: Data(base64Encoded: value.userComment) ?? Data(), as: UTF8.self))
+                    Text(value.userComment)
                 }
             case .typesAdded(_): HistoryCardTemplate(
                 image: "plus.viewfinder",
@@ -238,7 +238,7 @@ struct HistoryCardExtended: View {
                 timestamp: timestamp,
                 danger: false,
                 line1: "Generated signature for message",
-                line2: String(decoding: Data(base64Encoded: value.userComment) ?? Data(), as: UTF8.self)
+                line2: value.userComment
             )
             }
         }

--- a/ios/NativeSigner/Components/AddressCardControls.swift
+++ b/ios/NativeSigner/Components/AddressCardControls.swift
@@ -8,8 +8,9 @@
 import SwiftUI
 
 struct AddressCardControls: View {
-    @EnvironmentObject var data: SignerDataModel
-    var seed_name: String
+    let seed_name: String
+    let increment: (String) -> Void
+    let pushButton: (Action, String, String) -> Void
     var rowHeight: CGFloat = 39
     @State private var delete = false
     @State private var count: CGFloat = 1
@@ -17,10 +18,7 @@ struct AddressCardControls: View {
         HStack {
             Spacer()
             Button(action: {
-                let seed_phrase = data.getSeed(seedName: seed_name)
-                if seed_phrase != "" {
-                    data.pushButton(action: .increment, details: "1", seedPhrase: seed_phrase)
-                }
+                increment("1")
             }) {
                 ZStack {
                     RoundedRectangle(cornerRadius: 6).foregroundColor(Color("Crypto100"))
@@ -32,10 +30,7 @@ struct AddressCardControls: View {
                     count = exp(abs(drag.translation.height)/50)
                 }
                             .onEnded{_ in
-                    let seed_phrase = data.getSeed(seedName: seed_name)
-                    if seed_phrase != "" {
-                        data.pushButton(action: .increment, details: String(Int(count)), seedPhrase: seed_phrase)
-                    }
+                    increment(String(Int(count)))
                 })
                 .onAppear {
                     count = 1
@@ -56,8 +51,7 @@ struct AddressCardControls: View {
                         primaryButton: .cancel(),
                         secondaryButton: .destructive(
                             Text("Delete"),
-                            action: { data.pushButton(action: .removeKey)
-                            }
+                            action: { pushButton(.removeKey, "", "") }
                         )
                     )
                 })

--- a/ios/NativeSigner/Components/CameraView.swift
+++ b/ios/NativeSigner/Components/CameraView.swift
@@ -10,9 +10,10 @@ import AVFoundation
 
 struct CameraView: View {
     @StateObject var model = CameraViewModel()
-    @EnvironmentObject var data: SignerDataModel
     @State var total: Int? = 0
     @State var captured: Int? = 0
+    @State var resetCameraTrigger: Bool = false
+    let pushButton: (Action, String, String) -> Void
     let size = UIScreen.main.bounds.size.width
     var body: some View {
         ZStack {
@@ -29,14 +30,14 @@ struct CameraView: View {
                     .onReceive(model.$payload, perform: { payload in
                         if payload != nil {
                             DispatchQueue.main.async {
-                                data.pushButton(action: .transactionFetched, details: payload ?? "")
+                                pushButton(.transactionFetched, payload ?? "", "")
                             }
                         }
                     })
-                    .onReceive(data.$resetCamera, perform: { resetCamera in
-                        if resetCamera {
+                    .onChange(of: resetCameraTrigger, perform: { newResetCameraTrigger in
+                        if newResetCameraTrigger {
                             model.reset()
-                            data.resetCamera = false
+                            resetCameraTrigger = false
                         }
                     })
                     .onReceive(model.$total, perform: {rTotal in

--- a/ios/NativeSigner/Components/DocumentModal.swift
+++ b/ios/NativeSigner/Components/DocumentModal.swift
@@ -8,15 +8,12 @@
 import SwiftUI
 
 struct DocumentModal: View {
-    @EnvironmentObject var data: SignerDataModel
     @State var document: ShownDocument = .toc
     
     //paint top toggle buttons
-    
     init() {
         UISegmentedControl.appearance().selectedSegmentTintColor = UIColor(Color("Bg400"))
         UISegmentedControl.appearance().backgroundColor = UIColor(Color("Bg000"))
-        //UISegmentedControl.appearance().tintColor = UIColor(Color("Text600"))
         UISegmentedControl.appearance().setTitleTextAttributes([.foregroundColor: UIColor(Color("Text600"))], for: .selected)
         UISegmentedControl.appearance().setTitleTextAttributes([.foregroundColor: UIColor(Color("Text400"))], for: .normal)
     }
@@ -34,34 +31,20 @@ struct DocumentModal: View {
                 switch document {
                 case .pp:
                     ScrollView {
-                        Text(data.getPP())
+                        Text(getPP())
                             .font(FBase(style: .body1))
                             .foregroundColor(Color("Text600"))
                     }.padding()
                 case .toc:
                     ScrollView {
                         InstructionsSquare().padding(.bottom)
-                        Text(data.getTaC())
+                        Text(getTaC())
                             .font(FBase(style: .body1))
                             .foregroundColor(Color("Text600"))
                     }.padding()
-                    /*
-                case .about:
-                    ScrollView {
-                        Text("About").font(FBase(style: .h1)).foregroundColor(Color("Text600")).padding(.bottom, 10)
-                        Text("Parity Signer is an app for a device you keep offline.\nIt utilizes hardware-level security of your smartphone to turn it into a so-called cold storage for private keys from your blockchain accounts.\nWith Signer you can generate, manage and use blockchain credentials to sign blockchain transactions and otherwise use it as an air-gapped crypto wallet.").font(FBase(style: .body1)).foregroundColor(Color("Text600")).padding(.bottom, 10)
-                        Text("For more information, tutorials and documentation, visit").font(FBase(style: .body1)).foregroundColor(Color("Text600")).padding(.bottom, 10)
-                        Text("www.parity.io/technologies/signer").font(FBase(style: .button)).foregroundColor(Color("Action400")).padding(.bottom, 10)
-                        SettingsCardTemplate(
-                            text: "App version: " + (data.appVersion ?? "Unknown!"),
-                            withIcon: false,
-                            withBackground: false
-                        )
-                    }.padding(.horizontal)
-                     */
                 }
                 Spacer()
-            }//.padding()
+            }
         }
     }
 }

--- a/ios/NativeSigner/Components/Footer.swift
+++ b/ios/NativeSigner/Components/Footer.swift
@@ -24,11 +24,12 @@ struct WrenchSymbol: View {
 }
 
 struct Footer: View {
-    @EnvironmentObject var data: SignerDataModel
+    let footerButton: FooterButton?
+    let pushButton: (Action, String, String) -> Void
     var body: some View {
         HStack {
             Button(action: {
-                data.pushButton(action: .navbarLog)
+                pushButton(.navbarLog, "", "")
             }) {
                 VStack(alignment: .center) {
                     Image(systemName: "rectangle.grid.1x2.fill").imageScale(.medium)
@@ -37,11 +38,11 @@ struct Footer: View {
                     Text("Log")
                         
                 }
-                .foregroundColor(buttonColor(active: data.actionResult.footerButton == .log))
+                .foregroundColor(buttonColor(active: footerButton == .log))
             }
             Spacer()
             Button(action: {
-                data.pushButton(action: .navbarScan)
+                pushButton(.navbarScan, "", "")
             }) {
                 VStack {
                     Image(systemName: "viewfinder").imageScale(.medium)
@@ -49,21 +50,21 @@ struct Footer: View {
                         .padding(.bottom, 1.0)
                     Text("Scanner")
                 }
-                .foregroundColor(buttonColor(active: data.actionResult.footerButton == .scan))
+                .foregroundColor(buttonColor(active: footerButton == .scan))
             }
             Spacer()
             Button(action: {
-                data.pushButton(action: .navbarKeys)
+                pushButton(.navbarKeys, "", "")
             }) {
                 VStack{
                     KeySymbol()
                     Text("Keys")
                 }
-                .foregroundColor(buttonColor(active: data.actionResult.footerButton == .keys))
+                .foregroundColor(buttonColor(active: footerButton == .keys))
             }
             Spacer()
             Button(action: {
-                data.pushButton(action: .navbarSettings)
+                pushButton(.navbarSettings, "", "")
             }) {
                 VStack {
                     WrenchSymbol()
@@ -71,7 +72,7 @@ struct Footer: View {
                         .padding(.bottom, 1.0)
                     Text("Settings")
                 }
-                .foregroundColor(buttonColor(active: data.actionResult.footerButton == .settings))
+                .foregroundColor(buttonColor(active: footerButton == .settings))
             }
         }.font(.footnote)
     }

--- a/ios/NativeSigner/Components/Header.swift
+++ b/ios/NativeSigner/Components/Header.swift
@@ -8,41 +8,41 @@
 import SwiftUI
 
 struct Header: View {
-    @EnvironmentObject var data: SignerDataModel
+    let back: Bool
+    let screenLabel: String
+    let screenNameType: ScreenNameType?
+    let rightButton: RightButton?
+    let alert: Bool
+    let canaryDead: Bool
+    let alertShow: () -> Void
+    let pushButton: (Action, String, String) -> Void
     var body: some View {
         VStack {
             Spacer()
             HStack {
                 HStack(spacing: 8.0) {
-                    if data.actionResult.back {
+                    if back {
                         Button(action: {
-                            data.pushButton(action: .goBack)
+                            pushButton(.goBack, "", "")
                         }) {
-                            Image(systemName: data.actionResult.rightButton == .multiSelect ? "xmark" : "chevron.left")
+                            Image(systemName: rightButton == .multiSelect ? "xmark" : "chevron.left")
                                 .imageScale(.large)
                                 .foregroundColor(Color("Text500"))
                         }
                     }
-                    /*if data.actionResult.back {
-                     Button(action: {
-                     data.pushButton(buttonID: .GoBack)
-                     }) {
-                     SmallButton(text: "Cancel")
-                     }
-                     } else {*/
                     Spacer()
                 }
                 .frame(width: 72.0)
                 
                 Spacer()
-                Text(data.actionResult.screenLabel)
+                Text(screenLabel)
                     .foregroundColor(Color("Text600"))
-                    .font(data.actionResult.screenNameType == .h1 ? FBase(style: .h2) : FBase(style: .h4))
+                    .font(screenNameType == .h1 ? FBase(style: .h2) : FBase(style: .h4))
                     .tracking(0.1)
                 
-                if data.actionResult.rightButton == .multiSelect {
+                if rightButton == .multiSelect {
                     Button(action: {
-                        data.pushButton(action: .selectAll)
+                        pushButton(.selectAll, "", "")
                     }) {
                         SmallButton(text: "Select all")
                     }
@@ -52,14 +52,14 @@ struct Header: View {
                 HStack(spacing: 8.0) {
                     Spacer()
                     Button(action: {
-                        if data.alert && data.actionResult.rightButton == .newSeed {
-                            data.alertShow = true
+                        if alert && rightButton == .newSeed {
+                            alertShow()
                         } else {
-                            data.pushButton(action: .rightButtonAction)
+                            pushButton(.rightButtonAction, "", "")
                         }
                     }) {
                         switch(
-                            data.actionResult.rightButton
+                            rightButton
                         ) {
                         case .newSeed:
                             Image(systemName: "plus.circle")
@@ -83,7 +83,10 @@ struct Header: View {
                                 .foregroundColor(Color("Action400"))
                         }
                     }
-                    NavbarShield()
+                    NavbarShield(
+                        canaryDead: canaryDead,
+                        alert: alert,
+                        pushButton: pushButton)
                 }
                 .frame(width: 72.0)
             }

--- a/ios/NativeSigner/Components/HistoryCard.swift
+++ b/ios/NativeSigner/Components/HistoryCard.swift
@@ -152,14 +152,14 @@ struct HistoryCard: View {
                 timestamp: timestamp,
                 danger: true,
                 line1: "Signing failure",
-                line2: String(decoding: Data(base64Encoded: value.userComment) ?? Data(), as: UTF8.self)
+                line2: value.userComment
             )
             case .transactionSigned(let value): HistoryCardTemplate(
                 image: "signature",
                 timestamp: timestamp,
                 danger: false,
                 line1: "Generated signature",
-                line2: String(decoding: Data(base64Encoded: value.userComment) ?? Data(), as: UTF8.self)
+                line2: value.userComment
             )
             case .typesAdded(_): HistoryCardTemplate(
                 image: "plus.viewfinder",
@@ -208,7 +208,7 @@ struct HistoryCard: View {
                 timestamp: timestamp,
                 danger: false,
                 line1: "Generated signature for message",
-                line2: String(decoding: Data(base64Encoded: value.userComment) ?? Data(), as: UTF8.self)
+                line2: value.userComment
             )
             }
         }

--- a/ios/NativeSigner/Components/MultiselectBottomControl.swift
+++ b/ios/NativeSigner/Components/MultiselectBottomControl.swift
@@ -11,9 +11,9 @@ import SwiftUI
  * Panel with actions for multiselect
  */
 struct MultiselectBottomControl: View {
-    @EnvironmentObject var data: SignerDataModel
     @State var delete = false
     var selectedCount: String
+    var pushButton: (Action, String, String) -> Void
     var body: some View {
         ZStack {
             HStack {
@@ -31,14 +31,14 @@ struct MultiselectBottomControl: View {
                         secondaryButton: .destructive(
                             Text("Delete"),
                             action: {
-                                data.pushButton(action: .removeKey)
+                                pushButton(.removeKey, "", "")
                             }
                         )
                     )
                 })
                 Spacer()
                 Button(action: {
-                    data.pushButton(action: .exportMultiSelect)
+                    pushButton(.exportMultiSelect, "", "")
                 }) {
                     SmallButton(text: "Export")
                 }.disabled(selectedCount == "0")

--- a/ios/NativeSigner/Components/NavbarShield.swift
+++ b/ios/NativeSigner/Components/NavbarShield.swift
@@ -9,34 +9,28 @@ import SwiftUI
 import Network
 
 struct NavbarShield: View {
-    @EnvironmentObject var data: SignerDataModel
+    let canaryDead: Bool
+    let alert: Bool
+    let pushButton: (Action, String, String) -> Void
     var body: some View {
-        if data.canaryDead /*bluetooth detector: `|| data.bsDetector.canaryDead`*/ {
             Button(action: {
-                data.pushButton(action: .shield)
+                pushButton(.shield, "", "")
             }) {
+                if canaryDead /*bluetooth detector: `|| data.bsDetector.canaryDead`*/ {
                 Image(systemName: "shield.slash")
                     .imageScale(.large)
                     .foregroundColor(Color("SignalDanger"))
-            }
-        } else {
-            if data.alert {
-                Button(action: {
-                    data.pushButton(action: .shield)
-                }) {
-                    Image(systemName: "exclamationmark.shield")
-                        .imageScale(.large)
-                        .foregroundColor(Color("SignalWarning"))
+                } else {
+                    if alert {
+                        Image(systemName: "exclamationmark.shield")
+                            .imageScale(.large)
+                            .foregroundColor(Color("SignalWarning"))
+                    } else {
+                        Image(systemName: "lock.shield.fill")
+                            .imageScale(.large)
+                            .foregroundColor(Color("Crypto400"))
+                    }
                 }
-            } else {
-                Button(action: {
-                    data.pushButton(action: .shield)
-                }) {
-                    Image(systemName: "lock.shield.fill")
-                        .imageScale(.large)
-                        .foregroundColor(Color("Crypto400"))
-                }
-            }
         }
     }
 }

--- a/ios/NativeSigner/Modals/Backup.swift
+++ b/ios/NativeSigner/Modals/Backup.swift
@@ -8,8 +8,10 @@
 import SwiftUI
 
 struct Backup: View {
-    @EnvironmentObject var data: SignerDataModel
     let content: MBackup
+    let alert: Bool
+    let getSeedForBackup: (String) -> String
+    let pushButton: (Action, String, String) -> Void
     @State var secret: String = ""
     let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
     @State var countdown = 60
@@ -24,7 +26,7 @@ struct Backup: View {
                     HStack {
                         Spacer()
                         Button(action: {
-                            data.pushButton(action: .goBack)
+                            pushButton(.goBack, "", "")
                         }) {
                             Image(systemName: "xmark").imageScale(.large).foregroundColor(Color("Text300"))
                         }
@@ -45,11 +47,11 @@ struct Backup: View {
                             Spacer()
                         }
                         .onAppear{
-                            secret = data.getSeed(seedName: content.seedName, backup: true)
+                            secret = getSeedForBackup(content.seedName)
                             if secret == "" {
                                 failure = true
                                 countdown = -1
-                                secret = data.alert ? "Network connected! Seeds are not available now. Please enable airplane mode and disconnect all cables to access the seed phrase." : "Seeds are not available now! Come back again to access them."
+                                secret = alert ? "Network connected! Seeds are not available now. Please enable airplane mode and disconnect all cables to access the seed phrase." : "Seeds are not available now! Come back again to access them."
                             }
                         }
                         .onDisappear{

--- a/ios/NativeSigner/Modals/EnterPassword.swift
+++ b/ios/NativeSigner/Modals/EnterPassword.swift
@@ -8,8 +8,8 @@
 import SwiftUI
 
 struct EnterPassword: View {
-    @EnvironmentObject var data: SignerDataModel
     var content: MEnterPassword
+    let pushButton: (Action, String, String) -> Void
     @State private var password: String = ""
     @FocusState private var focused: Bool
     var body: some View {
@@ -45,7 +45,7 @@ struct EnterPassword: View {
                     text: "Next",
                     isCrypto: true,
                     action: {
-                    data.pushButton(action: .goForward, details: password)
+                    pushButton(.goForward, password, "")
                 },
                     isDisabled: password == ""
                 )

--- a/ios/NativeSigner/Modals/KeyMenu.swift
+++ b/ios/NativeSigner/Modals/KeyMenu.swift
@@ -8,8 +8,9 @@
 import SwiftUI
 
 struct KeyMenu: View {
-    @EnvironmentObject var data: SignerDataModel
     @State var removeConfirm = false
+    
+    let pushButton: (Action, String, String) -> Void
     var body: some View {
         MenuStack {
             HeaderBar(line1: "KEY MENU", line2: "Select action").padding(.top, 10)
@@ -25,7 +26,7 @@ struct KeyMenu: View {
             }
         }
         .alert(isPresented: $removeConfirm, content: {
-            Alert(title: Text("Forget this key?"), message: Text("This key will be removed for this network. Are you sure?"), primaryButton: .cancel(Text("Cancel")), secondaryButton: .destructive(Text("Remove key"), action: {data.pushButton(action: .removeKey)}))
+            Alert(title: Text("Forget this key?"), message: Text("This key will be removed for this network. Are you sure?"), primaryButton: .cancel(Text("Cancel")), secondaryButton: .destructive(Text("Remove key"), action: {pushButton(.removeKey, "", "")}))
         })
     }
 }

--- a/ios/NativeSigner/Modals/LogComment.swift
+++ b/ios/NativeSigner/Modals/LogComment.swift
@@ -8,7 +8,8 @@
 import SwiftUI
 
 struct LogComment: View {
-    @EnvironmentObject var data: SignerDataModel
+    
+    let pushButton: (Action, String, String) -> Void
     @State private var comment: String = ""
     @FocusState private var focused: Bool
     var body: some View {
@@ -35,7 +36,7 @@ struct LogComment: View {
                                 focused = true
                             }
                             .onSubmit {
-                                data.pushButton(action: .goForward, details: comment)
+                                pushButton(.goForward, comment, "")
                             }
                     }
                 }

--- a/ios/NativeSigner/Modals/LogMenu.swift
+++ b/ios/NativeSigner/Modals/LogMenu.swift
@@ -8,9 +8,9 @@
 import SwiftUI
 
 struct LogMenu: View {
-    @EnvironmentObject var data: SignerDataModel
     @State var clearConfirm = false
     var content: MLogRight
+    let pushButton: (Action, String, String) -> Void
     var body: some View {
         VStack {
             Spacer()
@@ -20,7 +20,7 @@ struct LogMenu: View {
                     BigButton(
                         text: "Add note",
                         action: {
-                            data.pushButton(action: .createLogComment)
+                            pushButton(.createLogComment, "", "")
                         }
                     )
                     BigButton(
@@ -37,7 +37,7 @@ struct LogMenu: View {
             .padding(.bottom, 24)
             .background(Color("Bg000"))
             .alert(isPresented: $clearConfirm, content: {
-                Alert(title: Text("Clear log?"), message: Text("Do you want this Signer to forget all logged events? This is not reversible."), primaryButton: .cancel(Text("Cancel")), secondaryButton: .destructive(Text("Clear log"), action: {data.pushButton(action: .clearLog)}))
+                Alert(title: Text("Clear log?"), message: Text("Do you want this Signer to forget all logged events? This is not reversible."), primaryButton: .cancel(Text("Cancel")), secondaryButton: .destructive(Text("Clear log"), action: {pushButton(.clearLog, "", "")}))
             })
         }
     }

--- a/ios/NativeSigner/Modals/ManageMetadata.swift
+++ b/ios/NativeSigner/Modals/ManageMetadata.swift
@@ -8,8 +8,8 @@
 import SwiftUI
 
 struct ManageMetadata: View {
-    @EnvironmentObject var data: SignerDataModel
     var content: MManageMetadata
+    let pushButton: (Action, String, String) -> Void
     @State var removeMetadataAlert = false
     @State var offset: CGFloat = 0
     var body: some View {
@@ -38,7 +38,7 @@ struct ManageMetadata: View {
                     text: "Sign this metadata",
                     isShaded: true,
                     isCrypto: true,
-                    action:{data.pushButton(action: .signMetadata)}
+                    action:{pushButton(.signMetadata, "", "")}
                 )
                 BigButton(
                     text: "Delete this metadata",
@@ -56,11 +56,11 @@ struct ManageMetadata: View {
                     .onEnded{drag in
             if drag.translation.height > 40 {
                 self.offset = UIScreen.main.bounds.size.height
-                data.pushButton(action: .goBack)
+                pushButton(.goBack, "", "")
             }
         })
         .alert(isPresented: $removeMetadataAlert, content: {
-            Alert(title: Text("Remove metadata?"), message: Text("This metadata will be removed for all networks"), primaryButton: .cancel(Text("Cancel")), secondaryButton: .destructive(Text("Remove metadata"), action: {data.pushButton(action: .removeMetadata)}))
+            Alert(title: Text("Remove metadata?"), message: Text("This metadata will be removed for all networks"), primaryButton: .cancel(Text("Cancel")), secondaryButton: .destructive(Text("Remove metadata"), action: {pushButton(.removeMetadata, "", "")}))
         })
     }
 }

--- a/ios/NativeSigner/Modals/ModalSelector.swift
+++ b/ios/NativeSigner/Modals/ModalSelector.swift
@@ -8,42 +8,81 @@
 import SwiftUI
 
 struct ModalSelector: View {
-    @EnvironmentObject var data: SignerDataModel
+    let modalData: ModalData?
+    let alert: Bool
+    let alertShow: () -> Void
+    let pushButton: (Action, String, String) -> Void
+    let removeSeed: (String) -> Void
+    let restoreSeed: (String, String, Bool) -> Void
+    let createAddress: (String, String) -> Void
+    let getSeedForBackup: (String) -> String
+    let sign: (String, String) -> Void
     
     var body: some View {
-        switch (data.actionResult.modalData) {
+        switch (modalData) {
         case .newSeedMenu:
-            NewSeedMenu()
+            NewSeedMenu(
+                alert: alert,
+                alertShow: alertShow,
+                pushButton: pushButton
+            )
         case .networkSelector(let value):
-            NetworkManager(content: value)
+            NetworkManager(
+                content: value,
+                pushButton: pushButton
+            )
         case .seedMenu(let value):
-            SeedMenu(content: value)
+            SeedMenu(
+                content: value,
+                alert: alert,
+                alertShow: alertShow,
+                removeSeed: removeSeed,
+                pushButton: pushButton
+            )
         case .backup(let value):
-            Backup(content: value)
+            Backup(content: value,
+                   alert: alert,
+                   getSeedForBackup: getSeedForBackup,
+                   pushButton: pushButton)
         case .passwordConfirm(let value):
-            PasswordConfirm(content: value)
+            PasswordConfirm(content: value,
+                            createAddress: createAddress)
         case .signatureReady(let value):
-            SignatureReady(content: value)
+            SignatureReady(content: value,
+                           pushButton: pushButton)
         case .enterPassword(let value):
-            EnterPassword(content: value)
+            EnterPassword(content: value,
+                          pushButton: pushButton)
         case .logRight(let value):
-            LogMenu(content: value)
+            LogMenu(content: value,
+                    pushButton: pushButton)
         case .networkDetailsMenu:
-            NetworkDetailsMenu()
-        case .manageMetadata(let value)://(let value):
-            ManageMetadata(content: value)//content: value)
+            NetworkDetailsMenu(
+                               pushButton: pushButton)
+        case .manageMetadata(let value):
+            ManageMetadata(content: value,
+                           pushButton: pushButton)
         case .sufficientCryptoReady(let value):
             SufficientCryptoReady(content: value)
         case .keyDetailsAction:
-            KeyMenu()
+            KeyMenu(
+                    pushButton: pushButton)
         case .typesInfo(let value):
-            TypesMenu(content: value)
+            TypesMenu(content: value,
+                      pushButton: pushButton)
         case .newSeedBackup(let value):
-            NewSeedBackupModal(content: value)
+            NewSeedBackupModal(content: value,
+                               restoreSeed: restoreSeed,
+                               pushButton: pushButton)
         case .logComment:
-            LogComment()
-        case .selectSeed://(let value):
-            EmptyView()//SelectSeed(content: value)
+            LogComment(
+                       pushButton: pushButton)
+        case .selectSeed(let value):
+            SelectSeed(
+                content: value,
+                sign: sign,
+                pushButton: pushButton
+            )
         case nil:
             EmptyView()
         }

--- a/ios/NativeSigner/Modals/NetworkDetailsMenu.swift
+++ b/ios/NativeSigner/Modals/NetworkDetailsMenu.swift
@@ -8,8 +8,9 @@
 import SwiftUI
 
 struct NetworkDetailsMenu: View {
-    @EnvironmentObject var data: SignerDataModel
     @State var removeNetworkAlert = false
+    
+    let pushButton: (Action, String, String) -> Void
     var body: some View {
         MenuStack {
             HeaderBar(line1: "MANAGE NETWORK", line2: "Select action").padding(.top, 10)
@@ -18,7 +19,7 @@ struct NetworkDetailsMenu: View {
                     text: "Sign network specs",
                     isShaded: true,
                     isCrypto: true,
-                    action:{data.pushButton(action: .signNetworkSpecs)}
+                    action:{pushButton(.signNetworkSpecs, "", "")}
                 )
                 BigButton(
                     text: "Delete network",
@@ -31,11 +32,11 @@ struct NetworkDetailsMenu: View {
         }
         .gesture(DragGesture().onEnded{drag in
             if drag.translation.height > 40 {
-                data.pushButton(action: .goBack)
+                pushButton(.goBack, "", "")
             }
         })
         .alert(isPresented: $removeNetworkAlert, content: {
-            Alert(title: Text("Remove network?"), message: Text("This network will be removed for whole device"), primaryButton: .cancel(Text("Cancel")), secondaryButton: .destructive(Text("Remove network"), action: {data.pushButton(action: .removeNetwork)}))
+            Alert(title: Text("Remove network?"), message: Text("This network will be removed for whole device"), primaryButton: .cancel(Text("Cancel")), secondaryButton: .destructive(Text("Remove network"), action: {pushButton(.removeNetwork, "", "")}))
         })
     }
 }

--- a/ios/NativeSigner/Modals/NetworkManager.swift
+++ b/ios/NativeSigner/Modals/NetworkManager.swift
@@ -8,12 +8,12 @@
 import SwiftUI
 
 struct NetworkManager: View {
-    @EnvironmentObject var data: SignerDataModel
-    var content: MNetworkMenu
+    let content: MNetworkMenu
+    let pushButton: (Action, String, String) -> Void
     var body: some View {
         VStack {
             Rectangle().frame(height: UIScreen.main.bounds.height/3).opacity(0.0001).gesture(TapGesture().onEnded{_ in
-                data.pushButton(action: .goBack)
+                pushButton(.goBack, "", "")
             })
             ZStack {
                 RoundedRectangle(cornerRadius: 20.0).foregroundColor(Color("Bg000"))
@@ -28,7 +28,7 @@ struct NetworkManager: View {
                             ForEach(content.networks.sorted(by: {$0.order < $1.order}), id: \.order) {network in
                                 ZStack {
                                     Button(action: {
-                                        data.pushButton(action: .changeNetwork, details: network.key)
+                                        pushButton(.changeNetwork, network.key, "")
                                     }) {
                                         NetworkCard(title: network.title, logo: network.logo, fancy: true)
                                     }

--- a/ios/NativeSigner/Modals/NewSeedBackupModal.swift
+++ b/ios/NativeSigner/Modals/NewSeedBackupModal.swift
@@ -8,8 +8,9 @@
 import SwiftUI
 
 struct NewSeedBackupModal: View {
-    @EnvironmentObject var data: SignerDataModel
     let content: MNewSeedBackup
+    let restoreSeed: (String, String, Bool) -> Void
+    let pushButton: (Action, String, String) -> Void
     @State var confirmBackup = false
     @State var createRoots = true
     var body: some View {
@@ -18,7 +19,6 @@ struct NewSeedBackupModal: View {
             VStack {
                 HeaderBar(line1: "Backup Seed Phrase", line2: content.seed)
                 ZStack {
-                    //RoundedRectangle(cornerRadius: 8).foregroundColor(Color("Crypto100")).frame(height: 200)
                     Text(content.seedPhrase)
                         .font(.system(size: 16, weight: .semibold, design: .monospaced))
                         .foregroundColor(Color("Crypto400"))
@@ -50,7 +50,7 @@ struct NewSeedBackupModal: View {
                     BigButton(
                         text: "Next",
                         action: {
-                            data.restoreSeed(seedName: content.seed, seedPhrase: content.seedPhrase, createRoots: createRoots)
+                            restoreSeed(content.seed, content.seedPhrase, createRoots)
                         },
                         isDisabled: !confirmBackup
                     )

--- a/ios/NativeSigner/Modals/NewSeedMenu.swift
+++ b/ios/NativeSigner/Modals/NewSeedMenu.swift
@@ -8,7 +8,9 @@
 import SwiftUI
 
 struct NewSeedMenu: View {
-    @EnvironmentObject var data: SignerDataModel
+    let alert: Bool
+    let alertShow: () -> Void
+    let pushButton: (Action, String, String) -> Void
     var body: some View {
         VStack {
             Spacer()
@@ -18,8 +20,8 @@ struct NewSeedMenu: View {
                     BigButton(
                         text: "New seed",
                         action: {
-                            if data.alert { data.alertShow = true } else {
-                                data.pushButton(action: .newSeed)
+                            if alert { alertShow() } else {
+                                pushButton(.newSeed, "", "")
                             }
                         }
                     )
@@ -27,8 +29,8 @@ struct NewSeedMenu: View {
                         text: "Recover seed",
                         isShaded: true,
                         action: {
-                            if data.alert { data.alertShow = true } else {
-                                data.pushButton(action: .recoverSeed)
+                            if alert { alertShow() } else {
+                                pushButton(.recoverSeed, "", "")
                             }
                         }
                     )

--- a/ios/NativeSigner/Modals/PasswordConfirm.swift
+++ b/ios/NativeSigner/Modals/PasswordConfirm.swift
@@ -8,8 +8,8 @@
 import SwiftUI
 
 struct PasswordConfirm: View {
-    @EnvironmentObject var data: SignerDataModel
     var content: MPasswordConfirm
+    let createAddress: (String, String) -> Void
     @State private var passwordCheck: String = ""
     @FocusState private var focused: Bool
     
@@ -46,7 +46,7 @@ struct PasswordConfirm: View {
                 BigButton(
                     text: "Next",
                     action: {
-                        data.createAddress(path: content.croppedPath+"///"+content.pwd, seedName: content.seedName)
+                        createAddress(content.croppedPath+"///"+content.pwd, content.seedName)
                     },
                     isDisabled: passwordCheck != content.pwd
                 )

--- a/ios/NativeSigner/Modals/SeedMenu.swift
+++ b/ios/NativeSigner/Modals/SeedMenu.swift
@@ -8,9 +8,12 @@
 import SwiftUI
 
 struct SeedMenu: View {
-    @EnvironmentObject var data: SignerDataModel
     @State var removeConfirm = false
     let content: MSeedMenu
+    let alert: Bool
+    let alertShow: () -> Void
+    let removeSeed: (String) -> Void
+    let pushButton: (Action, String, String) -> Void
     var body: some View {
         MenuStack {
             HeaderBar(line1: "SEED MENU", line2: "Select action").padding(.top, 10)
@@ -18,7 +21,7 @@ struct SeedMenu: View {
                 BigButton(
                     text: "Backup",
                     action: {
-                        data.pushButton(action: .backupSeed)
+                        pushButton(.backupSeed, "", "")
                     }
                 )
                 BigButton(
@@ -26,8 +29,8 @@ struct SeedMenu: View {
                     isShaded: true,
                     isCrypto: true,
                     action:{
-                        if data.alert { data.alertShow = true } else {
-                            data.pushButton(action: .newKey)
+                        if alert { alertShow() } else {
+                            pushButton(.newKey, "", "")
                         }
                     }
                 )
@@ -42,7 +45,7 @@ struct SeedMenu: View {
             }
         }
         .alert(isPresented: $removeConfirm, content: {
-            Alert(title: Text("Forget this seed?"), message: Text("This seed will be removed for all networks. This is not reversible. Are you sure?"), primaryButton: .cancel(Text("Cancel")), secondaryButton: .destructive(Text("Remove seed"), action: {data.removeSeed(seedName: content.seed)}))
+            Alert(title: Text("Forget this seed?"), message: Text("This seed will be removed for all networks. This is not reversible. Are you sure?"), primaryButton: .cancel(Text("Cancel")), secondaryButton: .destructive(Text("Remove seed"), action: {removeSeed(content.seed)}))
         })
     }
 }

--- a/ios/NativeSigner/Modals/SelectSeed.swift
+++ b/ios/NativeSigner/Modals/SelectSeed.swift
@@ -8,8 +8,9 @@
 import SwiftUI
 
 struct SelectSeed: View {
-    @EnvironmentObject var data: SignerDataModel
-    var content: MSeeds
+    let content: MSeeds
+    let sign: (String, String) -> Void
+    let pushButton: (Action, String, String) -> Void
     var body: some View {
         ZStack {
             RoundedRectangle(cornerRadius: 8).foregroundColor(Color("Bg100"))
@@ -19,10 +20,7 @@ struct SelectSeed: View {
                         ForEach(content.seedNameCards.sorted(by: {$0.seedName < $1.seedName}), id: \.seedName) {seedNameCard in
                             HStack {
                                 Button(action: {
-                                    let seedPhrase = data.getSeed(seedName: seedNameCard.seedName)
-                                    if seedPhrase != "" {
-                                        data.pushButton(action: .goForward, details: seedNameCard.seedName, seedPhrase: seedPhrase)
-                                    }
+                                    sign(seedNameCard.seedName, seedNameCard.seedName)
                                 }) {
                                     SeedCardForManager(seedNameCard: seedNameCard)
                                     Spacer()

--- a/ios/NativeSigner/Modals/SignatureReady.swift
+++ b/ios/NativeSigner/Modals/SignatureReady.swift
@@ -8,11 +8,11 @@
 import SwiftUI
 
 struct SignatureReady: View {
-    @EnvironmentObject var data: SignerDataModel
     @GestureState private var dragOffset = CGSize.zero
     @State var offset: CGFloat = 0
     @State var oldOffset: CGFloat = UIScreen.main.bounds.size.width
     var content: MSignatureReady
+    let pushButton: (Action, String, String) -> Void
     var body: some View {
         ZStack{
             RoundedRectangle(cornerRadius: 8).foregroundColor(Color("Bg000"))
@@ -23,7 +23,7 @@ struct SignatureReady: View {
                     .aspectRatio(contentMode: .fit).padding(12)
                 Spacer()
                 BigButton(text: "Done", action: {
-                    data.pushButton(action: .goBack)
+                    pushButton(.goBack, "", "")
                 })
             }.padding(16)
         }//.background(RoundedRectangle(cornerRadius: 8).foregroundColor(Color("Bg000")))

--- a/ios/NativeSigner/Modals/SufficientCryptoReady.swift
+++ b/ios/NativeSigner/Modals/SufficientCryptoReady.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct SufficientCryptoReady: View {
-    @EnvironmentObject var data: SignerDataModel
     @GestureState private var dragOffset = CGSize.zero
     @State var offset: CGFloat = 0
     @State var oldOffset: CGFloat = 0

--- a/ios/NativeSigner/Modals/TypesMenu.swift
+++ b/ios/NativeSigner/Modals/TypesMenu.swift
@@ -8,8 +8,9 @@
 import SwiftUI
 
 struct TypesMenu: View {
-    @EnvironmentObject var data: SignerDataModel
     var content: MTypesInfo
+    
+    let pushButton: (Action, String, String) -> Void
     @State var removeTypesAlert = false
     var body: some View {
         MenuStack {
@@ -27,7 +28,7 @@ struct TypesMenu: View {
                     text: "Sign types",
                     isShaded: true,
                     isCrypto: true,
-                    action:{data.pushButton(action: .signTypes)}
+                    action:{pushButton(.signTypes, "", "")}
                 )
                 BigButton(
                     text: "Delete types",
@@ -39,7 +40,7 @@ struct TypesMenu: View {
         }
         .gesture(DragGesture().onEnded{drag in
             if drag.translation.height > 40 {
-                data.pushButton(action: .goBack)
+                pushButton(.goBack, "", "")
             }
         })
         .alert(isPresented: $removeTypesAlert, content: {
@@ -47,7 +48,7 @@ struct TypesMenu: View {
                   message: Text("Types information needed for support of pre-v14 metadata will be removed. Are you sure?"),
                   primaryButton: .cancel(Text("Cancel")),
                   secondaryButton: .destructive(Text("Remove types"),
-                                                action: {data.pushButton(action: .removeTypes)}))
+                                                action: {pushButton(.removeTypes, "", "")}))
         })
     }
 }

--- a/ios/NativeSigner/Models/Documents.swift
+++ b/ios/NativeSigner/Models/Documents.swift
@@ -34,38 +34,40 @@ enum ShownDocument: String, CaseIterable, Identifiable {
 }
 
 /**
- * Fetch docs from assets
+ * Fetch and format docs from assets
  */
-extension SignerDataModel {
-    func getTaC() -> AttributedString {
-        if let path = Bundle.main.path(forResource: "terms-and-conditions", ofType: "txt") {
-            do {
-                let tac = try String(contentsOfFile: path, encoding: .utf8)
-                let taCMD = try! AttributedString(markdown: tac, options: AttributedString.MarkdownParsingOptions(interpretedSyntax: .inlineOnlyPreservingWhitespace))
-                return taCMD
-            } catch {
-                print("TaC file damaged")
-                return "Terms and conditions text corrupted! Please report bug."
-            }
-        } else {
-            print("TaC file not found!")
-            return "Terms and conditions not found! Please report bug."
+func getTaC() -> AttributedString {
+    if let path = Bundle.main.path(forResource: "terms-and-conditions", ofType: "txt") {
+        do {
+            let tac = try String(contentsOfFile: path, encoding: .utf8)
+            let taCMD = try! AttributedString(markdown: tac, options: AttributedString.MarkdownParsingOptions(interpretedSyntax: .inlineOnlyPreservingWhitespace))
+            return taCMD
+        } catch {
+            print("TaC file damaged")
+            return "Terms and conditions text corrupted! Please report bug."
         }
-    }
-    
-    func getPP() -> AttributedString {
-        if let path = Bundle.main.path(forResource: "privacy-policy", ofType: "txt") {
-            do {
-                let pp = try String(contentsOfFile: path, encoding: .utf8)
-                let ppMD = try! AttributedString(markdown: pp, options: AttributedString.MarkdownParsingOptions(interpretedSyntax: .inlineOnlyPreservingWhitespace))
-                return ppMD
-            } catch {
-                print("PP file damaged")
-                return "Privacy policy text corrupted! Please report bug."
-            }
-        } else {
-            print("PP file not found!")
-            return "Privacy policy not found! Please report bug."
-        }
+    } else {
+        print("TaC file not found!")
+        return "Terms and conditions not found! Please report bug."
     }
 }
+
+/**
+ * Fetch and format privacy policy from assets
+ */
+func getPP() -> AttributedString {
+    if let path = Bundle.main.path(forResource: "privacy-policy", ofType: "txt") {
+        do {
+            let pp = try String(contentsOfFile: path, encoding: .utf8)
+            let ppMD = try! AttributedString(markdown: pp, options: AttributedString.MarkdownParsingOptions(interpretedSyntax: .inlineOnlyPreservingWhitespace))
+            return ppMD
+        } catch {
+            print("PP file damaged")
+            return "Privacy policy text corrupted! Please report bug."
+        }
+    } else {
+        print("PP file not found!")
+        return "Privacy policy not found! Please report bug."
+    }
+}
+

--- a/ios/NativeSigner/Models/RustNative.swift
+++ b/ios/NativeSigner/Models/RustNative.swift
@@ -27,7 +27,6 @@ class SignerDataModel: ObservableObject {
     //Data state
     @Published var seedNames: [String] = []
     @Published var onboardingDone: Bool = false
-    @Published var lastError: String = ""
     @Published var authenticated: Bool = false
     
     //This just starts camera reset. Could be done cleaner probably.

--- a/ios/NativeSigner/Models/Seeds.swift
+++ b/ios/NativeSigner/Models/Seeds.swift
@@ -217,4 +217,19 @@ extension SignerDataModel {
             }
         }
     }
+    
+    /**
+     * Wrapper for signing with use of seed material
+     */
+    func sign(seedName: String, comment: String) {
+        if self.alert {
+            self.alertShow = true
+        } else {
+            self.pushButton(
+                action: .goForward,
+                details: comment,
+                seedPhrase: self.getSeed(seedName: seedName)
+            )
+        }
+    }
 }

--- a/ios/NativeSigner/Models/Seeds.swift
+++ b/ios/NativeSigner/Models/Seeds.swift
@@ -83,18 +83,15 @@ extension SignerDataModel {
         guard let accessFlags = SecAccessControlCreateWithFlags(kCFAllocatorDefault, kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly, .devicePasscode, &error) else {
             print("Access flags could not be allocated")
             print(error ?? "no error code")
-            self.lastError = "iOS key manager error, report a bug"
             return
         }
         if checkSeedPhraseCollision(seedPhrase: seedPhrase) {
             print("Key collision")
-            self.lastError = "This seed phrase already exists"
             return
         }
         if !authenticated { return }
         guard let finalSeedPhrase = seedPhrase.data(using: .utf8) else {
             print("could not encode seed phrase")
-            self.lastError = "Seed phrase contains non-0unicode symbols"
             return
         }
         let query: [String: Any] = [
@@ -109,8 +106,8 @@ extension SignerDataModel {
         guard status == errSecSuccess else {
             print("key add failure")
             print(status)
-            self.lastError = SecCopyErrorMessageString(status, nil)! as String
-            print(self.lastError)
+            let lastError = SecCopyErrorMessageString(status, nil)! as String
+            print(lastError)
             return
         }
         self.seedNames.append(seedName)
@@ -133,7 +130,6 @@ extension SignerDataModel {
         var item: AnyObject?
         guard let finalSeedPhrase = seedPhrase.data(using: .utf8) else {
             print("could not encode seed phrase")
-            self.lastError = "Seed phrase contains non-unicode symbols"
             return true
         }
         let query: [String: Any] = [
@@ -216,8 +212,8 @@ extension SignerDataModel {
                 updateSeedNames(seedNames: self.seedNames)
                 pushButton(action: .removeSeed)
             } else {
-                self.lastError = SecCopyErrorMessageString(status, nil)! as String
-                print("remove seed from secure storage error: " + self.lastError)
+                let lastError = SecCopyErrorMessageString(status, nil)! as String
+                print("remove seed from secure storage error: " + lastError)
             }
         }
     }

--- a/ios/NativeSigner/NativeSignerApp.swift
+++ b/ios/NativeSigner/NativeSignerApp.swift
@@ -9,25 +9,11 @@ import SwiftUI
 
 @main
 struct NativeSignerApp: App {
-    @StateObject var data = SignerDataModel()
     var body: some Scene {
         WindowGroup {
             MainScreenContainer()
-                .environmentObject(data)
                 .font(FBase(style: .body1))
                 .background(Color("Bg100"))
-            /*
-                .onReceive(data.bsDetector.$canaryDead, perform: { canaryDead in
-                    if canaryDead {
-                        if data.onboardingDone {
-                            device_was_online(nil, data.dbName)
-                            data.alert = true
-                        }
-                    } else {
-                        
-                    }
-                })
-             */
         }
     }
 }

--- a/ios/NativeSigner/Screens/EventDetails.swift
+++ b/ios/NativeSigner/Screens/EventDetails.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct EventDetails: View {
-    @EnvironmentObject var data: SignerDataModel
     let content: MLogDetails
     var body: some View {
         VStack {

--- a/ios/NativeSigner/Screens/ExportAddress.swift
+++ b/ios/NativeSigner/Screens/ExportAddress.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct ExportAddress: View {
-    @EnvironmentObject var data: SignerDataModel
     @State var showDetails = false
     var content: MKeyDetails
     var body: some View {

--- a/ios/NativeSigner/Screens/HistoryScreen.swift
+++ b/ios/NativeSigner/Screens/HistoryScreen.swift
@@ -9,21 +9,22 @@ import SwiftUI
 
 struct HistoryScreen: View {
     @EnvironmentObject var data: SignerDataModel
-    var content: MLog
+    let content: MLog
+    let pushButton: (Action, String, String) -> Void
     var body: some View {
         ScrollView {
             LazyVStack (spacing: 8) {
                 ForEach(content.log, id: \.timestamp) { history in
                     ForEach(history.events, id: \.self) { event in
                         Button(action: {
-                            data.pushButton(action: .showLogDetails, details: String(content.log.reversed().firstIndex(of: history) ?? 0))
+                            pushButton(.showLogDetails, String(content.log.reversed().firstIndex(of: history) ?? 0), "")
                         }) {
                             HistoryCard(
                                 event: event,
                                 timestamp: history.timestamp.padding(toLength: 16, withPad: " ", startingAt: 0)
                             )
                             .foregroundColor(Color("Text400"))
-                        }//.disabled(true)
+                        }
                     }
                 }
             }

--- a/ios/NativeSigner/Screens/KeyDetailsMulti.swift
+++ b/ios/NativeSigner/Screens/KeyDetailsMulti.swift
@@ -8,11 +8,11 @@
 import SwiftUI
 
 struct KeyDetailsMulti: View {
-    @EnvironmentObject var data: SignerDataModel
     @GestureState private var dragOffset = CGSize.zero
     @State var offset: CGFloat = 0
     @State var showDetails = false
     var content: MKeyDetailsMulti
+    let pushButton: (Action, String, String) -> Void
     var body: some View {
         ScrollView {
             VStack {
@@ -39,10 +39,10 @@ struct KeyDetailsMulti: View {
                         showDetails.toggle()
                     } else {
                         if drag.translation.width > 20 {
-                            data.pushButton(action: .nextUnit)
+                            pushButton(.nextUnit, "", "")
                         }
                         if drag.translation.width < -20 {
-                            data.pushButton(action: .previousUnit)
+                            pushButton(.previousUnit, "", "")
                         }
                     }
                 }

--- a/ios/NativeSigner/Screens/LandingView.swift
+++ b/ios/NativeSigner/Screens/LandingView.swift
@@ -8,10 +8,10 @@
 import SwiftUI
 
 struct LandingView: View {
-    @EnvironmentObject var data: SignerDataModel
     @State var tacAccept = false
     @State var ppAccept = false
     @State var accept = false
+    let onboard: () -> Void
     var body: some View {
         VStack {
             DocumentModal()
@@ -48,7 +48,7 @@ struct LandingView: View {
                     Alert(
                         title: Text("Accept privacy policy?"),
                         primaryButton: .default(Text("Decline")),
-                        secondaryButton: .default(Text("Accept"), action: {data.onboard()})
+                        secondaryButton: .default(Text("Accept"), action: {onboard()})
                     )
                 })
             }

--- a/ios/NativeSigner/Screens/MainScreenContainer.swift
+++ b/ios/NativeSigner/Screens/MainScreenContainer.swift
@@ -18,7 +18,18 @@ struct MainScreenContainer: View {
                 Header()
                 ZStack {
                     VStack (spacing:0) {
-                        ScreenSelector()
+                        ScreenSelector(
+                            screenData: data.actionResult.screenData,
+                            pushButton: {action, details, seedPhrase in data.pushButton(action: action, details: details, seedPhrase: seedPhrase)},
+                            getSeed: {seedName in return data.getSeed(seedName: seedName)},
+                            doJailbreak: data.jailbreak,
+                            pathCheck: {seed, path, network in
+                                return substratePathCheck(seedName: seed, path: path, network: network, dbname: data.dbName)
+                            },
+                            createAddress: {path, seedName in data.createAddress(path: path, seedName: seedName)},
+                            checkSeedCollision: {seedName in return data.checkSeedCollision(seedName: seedName)},
+                            restoreSeed: {seedName, seedPhrase, createRoots in data.restoreSeed(seedName: seedName, seedPhrase: seedPhrase, createRoots: createRoots)}
+                        )
                         Spacer()
                     }
                     ModalSelector()
@@ -63,7 +74,7 @@ struct MainScreenContainer: View {
                 if data.canaryDead /* || data.bsDetector.canaryDead)*/ {
                     Text("Please enable airplane mode, turn off bluetooth and wifi connection and disconnect all cables!").background(Color("Bg000"))
                 } else {
-                    LandingView()
+                    LandingView(onboard: {data.onboard()})
                 }
             } else {
                 Text("Please protect device with pin or password!").background(Color("Bg000"))

--- a/ios/NativeSigner/Screens/MainScreenContainer.swift
+++ b/ios/NativeSigner/Screens/MainScreenContainer.swift
@@ -9,17 +9,27 @@ import SwiftUI
 
 
 struct MainScreenContainer: View {
-    @EnvironmentObject var data: SignerDataModel
+    @StateObject var data = SignerDataModel()
     @GestureState private var dragOffset = CGSize.zero
     var body: some View {
         if data.onboardingDone {
             if data.authenticated {
                 VStack (spacing: 0) {
-                Header()
+                    Header(
+                        back: data.actionResult.back,
+                        screenLabel: data.actionResult.screenLabel,
+                        screenNameType: data.actionResult.screenNameType,
+                        rightButton: data.actionResult.rightButton,
+                        alert: data.alert,
+                        canaryDead: data.canaryDead,
+                        alertShow: {data.alertShow = true},
+                        pushButton: {action, details, seedPhrase in data.pushButton(action: action, details: details, seedPhrase: seedPhrase)})
                 ZStack {
                     VStack (spacing:0) {
                         ScreenSelector(
                             screenData: data.actionResult.screenData,
+                            appVersion: data.appVersion,
+                            alert: data.alert,
                             pushButton: {action, details, seedPhrase in data.pushButton(action: action, details: details, seedPhrase: seedPhrase)},
                             getSeed: {seedName in return data.getSeed(seedName: seedName)},
                             doJailbreak: data.jailbreak,
@@ -28,12 +38,33 @@ struct MainScreenContainer: View {
                             },
                             createAddress: {path, seedName in data.createAddress(path: path, seedName: seedName)},
                             checkSeedCollision: {seedName in return data.checkSeedCollision(seedName: seedName)},
-                            restoreSeed: {seedName, seedPhrase, createRoots in data.restoreSeed(seedName: seedName, seedPhrase: seedPhrase, createRoots: createRoots)}
+                            restoreSeed: {seedName, seedPhrase, createRoots in data.restoreSeed(seedName: seedName, seedPhrase: seedPhrase, createRoots: createRoots)},
+                            sign: {seedName, comment in data.sign(seedName: seedName, comment: comment)},
+                            doWipe: data.wipe,
+                            alertShow: {data.alertShow = true},
+                            increment: { seedName, details in
+                                let seedPhrase = data.getSeed(seedName: seedName)
+                                if seedPhrase != "" {
+                                    data.pushButton(action: .increment, details: "1", seedPhrase: seedPhrase)
+                                }
+                            }
                         )
                         Spacer()
                     }
-                    ModalSelector()
-                    AlertSelector()
+                    ModalSelector(
+                        modalData: data.actionResult.modalData,
+                        alert: data.alert,
+                        alertShow: {data.alertShow = true},
+                        pushButton: {action, details, seedPhrase in data.pushButton(action: action, details: details, seedPhrase: seedPhrase)},
+                        removeSeed: { seedName in data.removeSeed(seedName: seedName)},
+                        restoreSeed: {seedName, seedPhrase, createSeedKeys in data.restoreSeed(seedName: seedName, seedPhrase: seedPhrase, createRoots: createSeedKeys)},
+                        createAddress: {path, seedName in data.createAddress(path: path, seedName: seedName)},
+                        getSeedForBackup: {seedName in return data.getSeed(seedName: seedName, backup: true)},
+                        sign: {seedName, comment in data.sign(seedName: seedName, comment: comment)}
+                    )
+                    AlertSelector(
+                        alertData: data.actionResult.alertData
+                    )
                 }
                 .gesture(
                     DragGesture().updating($dragOffset, body: { (value, state, transaction) in
@@ -44,7 +75,10 @@ struct MainScreenContainer: View {
                 )
                 //Certain places are better off without footer
                 if data.actionResult.footer {
-                    Footer()
+                    Footer(
+                        footerButton: data.actionResult.footerButton,
+                        pushButton: {action, details, seedPhrase in data.pushButton(action: action, details: details, seedPhrase: seedPhrase)}
+                    )
                         .padding(.horizontal)
                         .padding(.vertical, 8)
                         .background(Color("Bg000"))

--- a/ios/NativeSigner/Screens/ManageNetworks.swift
+++ b/ios/NativeSigner/Screens/ManageNetworks.swift
@@ -8,13 +8,13 @@
 import SwiftUI
 
 struct ManageNetworks: View {
-    @EnvironmentObject var data: SignerDataModel
-    var content: MManageNetworks
+    let content: MManageNetworks
+    let pushButton: (Action, String, String) -> Void
     var body: some View {
         ScrollView {
             LazyVStack {
                 ForEach(content.networks.sorted(by: {$0.order < $1.order}), id: \.key) { network in
-                    Button(action: {data.pushButton(action: .goForward, details: network.key)}) {
+                    Button(action: {pushButton(.goForward, network.key, "")}) {
                         NetworkCard(title: network.title, logo: network.logo, fancy: true)
                     }
                 }

--- a/ios/NativeSigner/Screens/NetworkDetails.swift
+++ b/ios/NativeSigner/Screens/NetworkDetails.swift
@@ -8,8 +8,8 @@
 import SwiftUI
 
 struct NetworkDetails: View {
-    @EnvironmentObject var data: SignerDataModel
-    var content: MNetworkDetails
+    let content: MNetworkDetails
+    let pushButton: (Action, String, String) -> Void
     var body: some View {
         ZStack {
             VStack {
@@ -61,7 +61,7 @@ struct NetworkDetails: View {
                             metaEntry in
                             Button(
                                 action: {
-                                    data.pushButton(action: .manageMetadata, details: metaEntry.specsVersion)
+                                    pushButton(.manageMetadata, metaEntry.specsVersion, "")
                                 }
                             ){
                             MetadataCard(meta: metaEntry)

--- a/ios/NativeSigner/Screens/NewAddressScreen.swift
+++ b/ios/NativeSigner/Screens/NewAddressScreen.swift
@@ -8,13 +8,13 @@
 import SwiftUI
 
 struct NewAddressScreen: View {
-    
-    @EnvironmentObject var data: SignerDataModel
     @State var path: String = ""
     @FocusState private var focusedField: Bool
     @State private var derivationCheck: DerivationCheck? = nil
-    
     var content: MDeriveKey
+    let pathCheck: (String, String, String) -> DerivationCheck
+    let createAddress: (String, String) -> Void
+    let pushButton: (Action, String, String) -> Void
     
     var body: some View {
         ZStack {
@@ -36,16 +36,16 @@ struct NewAddressScreen: View {
                                 .keyboardType(.asciiCapable)
                                 .submitLabel(.done)
                                 .onChange(of: path) {pathNew in
-                                    derivationCheck = substratePathCheck(seedName: content.seedName, path: pathNew, network: content.networkSpecsKey, dbname: data.dbName)
+                                    derivationCheck = pathCheck(content.seedName, pathNew, content.networkSpecsKey)
                                     path = pathNew
                                 }
                                 .onSubmit {
                                     switch (derivationCheck?.whereTo) {
                                     case .pin:
-                                        data.createAddress(path: path, seedName: content.seedName)
+                                        createAddress(path, content.seedName)
                                         break
                                     case .pwd:
-                                        data.pushButton(action: .checkPassword, details: path)
+                                        pushButton(.checkPassword, path, "")
                                         break
                                     default:
                                         break
@@ -71,10 +71,10 @@ struct NewAddressScreen: View {
                         action: {
                             switch (derivationCheck?.whereTo) {
                             case .pin:
-                                data.createAddress(path: path, seedName: content.seedName)
+                                createAddress(path, content.seedName)
                                 break
                             case .pwd:
-                                data.pushButton(action: .checkPassword, details: path)
+                                pushButton(.checkPassword, path, "")
                                 break
                             default:
                                 break

--- a/ios/NativeSigner/Screens/NewSeedScreen.swift
+++ b/ios/NativeSigner/Screens/NewSeedScreen.swift
@@ -8,10 +8,11 @@
 import SwiftUI
 
 struct NewSeedScreen: View {
-    @EnvironmentObject var data: SignerDataModel
     @State private var seedName: String = ""
     @FocusState private var nameFocused: Bool
-    var content: MNewSeed
+    let content: MNewSeed
+    let checkSeedCollision: (String) -> Bool
+    let pushButton: (Action, String, String) -> Void
     
     var body: some View {
         VStack(alignment: .leading) {
@@ -28,33 +29,26 @@ struct NewSeedScreen: View {
                     .disableAutocorrection(true)
                     .keyboardType(.asciiCapable)
                     .submitLabel(.done)
-                    .onChange(of: seedName, perform: { _ in
-                        data.lastError = ""
-                    })
                     .onSubmit {
                         nameFocused = false
-                        if (seedName != "") && !data.checkSeedCollision(seedName: seedName) {
-                            data.pushButton(action: .goForward, details: seedName)
+                        if (seedName != "") && !checkSeedCollision(seedName) {
+                            pushButton(.goForward, seedName, "")
                         }
                     }
                     .onAppear(perform: {
                         nameFocused = content.keyboard
                     })
-                    .onDisappear {
-                        data.lastError = ""
-                    }
                     .padding(.horizontal, 8)
             }
             Text("Display name is visible only on this device").font(.callout)
-            Text(data.lastError).foregroundColor(.red)
             Spacer()
             BigButton(
                 text: "Generate seed phrase",
                 action: {
                     nameFocused = false
-                    data.pushButton(action: .goForward, details: seedName)
+                    pushButton(.goForward, seedName, "")
                 },
-                isDisabled: (seedName == "") || data.checkSeedCollision(seedName: seedName)
+                isDisabled: (seedName == "") || checkSeedCollision(seedName)
             )
             Spacer()
         }.padding()

--- a/ios/NativeSigner/Screens/RecoverSeedName.swift
+++ b/ios/NativeSigner/Screens/RecoverSeedName.swift
@@ -8,10 +8,11 @@
 import SwiftUI
 
 struct RecoverSeedName: View {
-    @EnvironmentObject var data: SignerDataModel
     @State private var seedName: String = ""
     @FocusState private var nameFocused: Bool
-    var content: MRecoverSeedName
+    let content: MRecoverSeedName
+    let checkSeedCollision: (String) -> Bool
+    let pushButton: (Action, String, String) -> Void
     
     var body: some View {
         VStack(alignment: .leading) {
@@ -28,12 +29,9 @@ struct RecoverSeedName: View {
                     .disableAutocorrection(true)
                     .keyboardType(.asciiCapable)
                     .submitLabel(.done)
-                    .onChange(of: seedName, perform: { newName in
-                        data.lastError = ""
-                    })
                     .onSubmit {
-                        if (seedName != "") && !data.checkSeedCollision(seedName: seedName) {
-                            data.pushButton(action: .goForward, details: seedName)
+                        if (seedName != "") && !checkSeedCollision(seedName) {
+                            pushButton(.goForward, seedName, "")
                         }
                     }
                     .onAppear(perform: {
@@ -43,14 +41,13 @@ struct RecoverSeedName: View {
                     .padding(.horizontal, 8)
             }
             Text("Display name visible only to you").font(.callout)
-            Text(data.lastError).foregroundColor(Color("SignalDanger"))
             Spacer()
             BigButton(
                 text: "Next",
                 action: {
-                    data.pushButton(action: .goForward, details: seedName)
+                    pushButton(.goForward, seedName, "")
                 },
-                isDisabled: (seedName == "") || data.checkSeedCollision(seedName: seedName)
+                isDisabled: (seedName == "") || checkSeedCollision(seedName)
             )
             Spacer()
         }.padding()

--- a/ios/NativeSigner/Screens/RecoverSeedPhrase.swift
+++ b/ios/NativeSigner/Screens/RecoverSeedPhrase.swift
@@ -8,12 +8,13 @@
 import SwiftUI
 
 struct RecoverSeedPhrase: View {
-    @EnvironmentObject var data: SignerDataModel
     @State private var userInput: String = " "
     @State private var createRoots: Bool = true
     @State private var shadowUserInput: String = " "
     @FocusState private var focus: Bool
-    var content: MRecoverSeedPhrase
+    let content: MRecoverSeedPhrase
+    let restoreSeed: (String, String, Bool) -> Void
+    let pushButton: (Action, String, String) -> Void
     
     var body: some View {
         ZStack {
@@ -46,7 +47,7 @@ struct RecoverSeedPhrase: View {
                                     .keyboardType(.asciiCapable)
                                     .submitLabel(.done)
                                     .onChange(of: userInput, perform: { word in
-                                        data.pushButton(action: .textEntry, details: word)
+                                        pushButton(.textEntry, word, "")
                                         shadowUserInput = word
                                     })
                                     .onSubmit {
@@ -73,7 +74,7 @@ struct RecoverSeedPhrase: View {
                                 ForEach(content.guessSet, id: \.self) { guess in
                                     VStack {
                                         Button(action: {
-                                            data.pushButton(action: .pushWord, details: guess)
+                                            pushButton(.pushWord, guess, "")
                                         }) {
                                             Text(guess)
                                                 .foregroundColor(Color("Crypto400"))
@@ -89,7 +90,6 @@ struct RecoverSeedPhrase: View {
                         }.frame(height: 23)
                         
                         Spacer()
-                        Text(data.lastError).foregroundColor(.red)
                         Button(action: {
                             createRoots.toggle()
                         }) {
@@ -106,7 +106,7 @@ struct RecoverSeedPhrase: View {
                                 BigButton(
                                     text: "Next",
                                     action: {
-                                        data.restoreSeed(seedName: content.seedName, seedPhrase: content.readySeed ?? "", createRoots: createRoots)
+                                        restoreSeed(content.seedName, content.readySeed ?? "", createRoots)
                                     },
                                     isDisabled: content.readySeed == nil
                                 )

--- a/ios/NativeSigner/Screens/ScreenSelector.swift
+++ b/ios/NativeSigner/Screens/ScreenSelector.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 struct ScreenSelector: View {
     let screenData: ScreenData
+    let appVersion: String?
+    let alert: Bool
     let pushButton: (Action, String, String) -> Void
     let getSeed: (String) -> String
     let doJailbreak: () -> Void
@@ -16,26 +18,50 @@ struct ScreenSelector: View {
     let createAddress: (String, String) -> Void
     let checkSeedCollision: (String) -> Bool
     let restoreSeed: (String, String, Bool) -> Void
+    let sign: (String, String) -> Void
+    let doWipe: () -> Void
+    let alertShow: () -> Void
+    let increment: (String, String) -> Void
     
     var body: some View {
         switch (screenData) {
         case .scan :
-            TransactionScreen()
+            TransactionScreen(
+                pushButton: pushButton
+            )
         case .keys(let value):
-            KeyManager(content: value)
+            KeyManager(
+                content: value,
+                alert: alert,
+                alertShow: alertShow,
+                increment: increment,
+                pushButton: pushButton
+            )
         case .settings(let value) :
-            SettingsScreen(content: value)
+            SettingsScreen(
+                content: value,
+                appVersion: appVersion,
+                doWipe: doWipe,
+                pushButton: pushButton
+            )
         case .log(let value) :
-            HistoryScreen(content: value)
+            HistoryScreen(
+                content: value,
+                pushButton: pushButton
+            )
         case .logDetails(let value):
             EventDetails(content: value)
         case .transaction(let value):
             TransactionPreview(
                 content: value,
+                sign: sign,
                 pushButton: pushButton
             )
         case .seedSelector(let value):
-            SeedManager(content: value)
+            SeedManager(
+                content: value,
+                pushButton: pushButton
+            )
         case .keyDetails(let value):
             ExportAddress(content: value)
         case .newSeed(let value):
@@ -69,16 +95,25 @@ struct ScreenSelector: View {
                 doJailbreak: doJailbreak
             )
         case .manageNetworks(let value):
-            ManageNetworks(content: value)
+            ManageNetworks(
+                content: value,
+                pushButton: pushButton
+            )
         case .nNetworkDetails(let value):
-            NetworkDetails(content: value)
+            NetworkDetails(
+                content: value,
+                pushButton: pushButton
+            )
         case .signSufficientCrypto(let value):
             SignSufficientCrypto(
                 content: value,
                 pushButton: pushButton,
                 getSeed: getSeed)
         case .selectSeedForBackup(let value):
-            SelectSeedForBackup(content: value)
+            SelectSeedForBackup(
+                content: value,
+                pushButton: pushButton
+            )
         case .documents:
             DocumentModal()
         case .keyDetailsMulti(let value):

--- a/ios/NativeSigner/Screens/ScreenSelector.swift
+++ b/ios/NativeSigner/Screens/ScreenSelector.swift
@@ -8,10 +8,17 @@
 import SwiftUI
 
 struct ScreenSelector: View {
-    @EnvironmentObject var data: SignerDataModel
+    let screenData: ScreenData
+    let pushButton: (Action, String, String) -> Void
+    let getSeed: (String) -> String
+    let doJailbreak: () -> Void
+    let pathCheck: (String, String, String) -> DerivationCheck
+    let createAddress: (String, String) -> Void
+    let checkSeedCollision: (String) -> Bool
+    let restoreSeed: (String, String, Bool) -> Void
     
     var body: some View {
-        switch (data.actionResult.screenData) {
+        switch (screenData) {
         case .scan :
             TransactionScreen()
         case .keys(let value):
@@ -23,33 +30,62 @@ struct ScreenSelector: View {
         case .logDetails(let value):
             EventDetails(content: value)
         case .transaction(let value):
-            TransactionPreview(content: value)
+            TransactionPreview(
+                content: value,
+                pushButton: pushButton
+            )
         case .seedSelector(let value):
             SeedManager(content: value)
         case .keyDetails(let value):
             ExportAddress(content: value)
         case .newSeed(let value):
-            NewSeedScreen(content: value)
+            NewSeedScreen(
+                content: value,
+                checkSeedCollision: checkSeedCollision,
+                pushButton: pushButton
+            )
         case .recoverSeedName(let value):
-            RecoverSeedName(content: value)
+            RecoverSeedName(
+                content: value,
+                checkSeedCollision: checkSeedCollision,
+                pushButton: pushButton
+            )
         case .recoverSeedPhrase(let value):
-            RecoverSeedPhrase(content: value)
+            RecoverSeedPhrase(
+                content: value,
+                restoreSeed: restoreSeed,
+                pushButton: pushButton
+            )
         case .deriveKey(let value):
-            NewAddressScreen(content: value)
+            NewAddressScreen(
+                content: value,
+                pathCheck: pathCheck,
+                createAddress: createAddress,
+                pushButton: pushButton
+            )
         case .vVerifier(let value):
-            VerifierScreen(content: value)
+            VerifierScreen(
+                content: value,
+                doJailbreak: doJailbreak
+            )
         case .manageNetworks(let value):
             ManageNetworks(content: value)
         case .nNetworkDetails(let value):
             NetworkDetails(content: value)
         case .signSufficientCrypto(let value):
-            SignSufficientCrypto(content: value)
+            SignSufficientCrypto(
+                content: value,
+                pushButton: pushButton,
+                getSeed: getSeed)
         case .selectSeedForBackup(let value):
             SelectSeedForBackup(content: value)
         case .documents:
             DocumentModal()
         case .keyDetailsMulti(let value):
-            KeyDetailsMulti(content: value)
+            KeyDetailsMulti(
+                content: value,
+                pushButton: pushButton
+            )
         }
     }
 }

--- a/ios/NativeSigner/Screens/SeedManager.swift
+++ b/ios/NativeSigner/Screens/SeedManager.swift
@@ -8,8 +8,8 @@
 import SwiftUI
 
 struct SeedManager: View {
-    @EnvironmentObject var data: SignerDataModel
-    var content: MSeeds
+    let content: MSeeds
+    let pushButton: (Action, String, String) -> Void
     var body: some View {
         VStack {
             ScrollView {
@@ -17,7 +17,7 @@ struct SeedManager: View {
                     ForEach(content.seedNameCards.sorted(by: {$0.seedName < $1.seedName}), id: \.seedName) {seedNameCard in
                         HStack {
                             Button(action: {
-                                data.pushButton(action: .selectSeed, details: seedNameCard.seedName)
+                                pushButton(.selectSeed, seedNameCard.seedName, "")
                             }) {
                                 SeedCardForManager(seedNameCard: seedNameCard)
                                 Spacer()

--- a/ios/NativeSigner/Screens/SelectSeedForBackup.swift
+++ b/ios/NativeSigner/Screens/SelectSeedForBackup.swift
@@ -8,8 +8,8 @@
 import SwiftUI
 
 struct SelectSeedForBackup: View {
-    @EnvironmentObject var data: SignerDataModel
-    var content: MSeeds
+    let content: MSeeds
+    let pushButton: (Action, String, String) -> Void
     var body: some View {
         VStack {
             ScrollView {
@@ -17,7 +17,7 @@ struct SelectSeedForBackup: View {
                     ForEach(content.seedNameCards.sorted(by: {$0.seedName < $1.seedName}), id: \.seedName) {seedNameCard in
                         HStack {
                             Button(action: {
-                                data.pushButton(action: .backupSeed, details: seedNameCard.seedName)
+                                pushButton(.backupSeed, seedNameCard.seedName, "")
                             }) {
                                 SeedCardForManager(seedNameCard: seedNameCard)
                                 Spacer()

--- a/ios/NativeSigner/Screens/SettingsScreen.swift
+++ b/ios/NativeSigner/Screens/SettingsScreen.swift
@@ -8,23 +8,25 @@
 import SwiftUI
 
 struct SettingsScreen: View {
-    @EnvironmentObject var data: SignerDataModel
     @State var wipe = false
     @State var jailbreak = false
     let content: MSettings
+    let appVersion: String?
+    let doWipe: () -> Void
+    let pushButton: (Action, String, String) -> Void
     var body: some View {
         VStack (spacing: 2) {
             Button(action: {
-                data.pushButton(action: .manageNetworks)
+                pushButton(.manageNetworks, "", "")
             }) {
                 SettingsCardTemplate(text: "Networks")
             }
             Button(action: {
-                data.pushButton(action: .backupSeed)
+                pushButton(.backupSeed, "", "")
             }) {
                 SettingsCardTemplate(text: "Backup keys")
             }
-            Button(action: {data.pushButton(action: .viewGeneralVerifier)}) {
+            Button(action: {pushButton(.viewGeneralVerifier, "", "")}) {
             VStack {
                 HStack {
                     Text("Verifier certificate").font(FBase(style: .h1)).foregroundColor(Color("Text600"))
@@ -66,19 +68,19 @@ struct SettingsScreen: View {
                     secondaryButton: .destructive(
                         Text("Wipe"),
                         action: {
-                            data.wipe()
+                            doWipe()
                         }
                     )
                 )
             })
             
             Button(action: {
-                data.pushButton(action: .showDocuments)
+                pushButton(.showDocuments, "", "")
             }) {
                 SettingsCardTemplate(text: "About")
             }
             SettingsCardTemplate(
-                text: "App version: " + (data.appVersion ?? "Unknown!"),
+                text: "App version: " + (appVersion ?? "Unknown!"),
                 withIcon: false,
                 withBackground: false
             )

--- a/ios/NativeSigner/Screens/SignSufficientCrypto.swift
+++ b/ios/NativeSigner/Screens/SignSufficientCrypto.swift
@@ -8,8 +8,9 @@
 import SwiftUI
 
 struct SignSufficientCrypto: View {
-    @EnvironmentObject var data: SignerDataModel
-    var content: MSignSufficientCrypto
+    let content: MSignSufficientCrypto
+    let pushButton: (Action, String, String) -> Void
+    let getSeed: (String) -> String
     var body: some View {
         VStack {
             Text("Select key for signing")
@@ -18,9 +19,9 @@ struct SignSufficientCrypto: View {
                 LazyVStack {
                     ForEach(content.identities, id: \.addressKey) {keyrecord in
                         Button(action: {
-                            let seedPhrase = data.getSeed(seedName: keyrecord.seedName)
+                            let seedPhrase = getSeed(keyrecord.seedName)
                             if seedPhrase != "" {
-                                data.pushButton(action: .goForward, details: keyrecord.addressKey, seedPhrase: seedPhrase)
+                                pushButton(.goForward, keyrecord.addressKey, seedPhrase)
                             }
                         }) {
                             AddressCard(address: Address(base58: keyrecord.publicKey, path: keyrecord.path, hasPwd: keyrecord.hasPwd, identicon: keyrecord.identicon, seedName: keyrecord.seedName, multiselect: nil))

--- a/ios/NativeSigner/Screens/TransactionPreview.swift
+++ b/ios/NativeSigner/Screens/TransactionPreview.swift
@@ -14,6 +14,7 @@ struct TransactionPreview: View {
     @State var offsetOld: CGFloat = 0
     @FocusState private var focus: Bool
     let content: MTransaction
+    let pushButton: (Action, String, String) -> Void
     var body: some View {
         VStack {
             TransactionBlock(cards: content.content.assemble())
@@ -73,7 +74,7 @@ struct TransactionPreview: View {
                         BigButton(
                             text: "Approve",
                             action: {
-                                data.pushButton(action: .goForward)
+                                pushButton(.goForward, "", "")
                             })
                     case .read:
                         EmptyView()
@@ -82,7 +83,7 @@ struct TransactionPreview: View {
                             text: "Select seed",
                             isCrypto: true,
                             action: {
-                                data.pushButton(action: .goForward)
+                                pushButton(.goForward, "", "")
                             })
                     case .done:
                         EmptyView()
@@ -94,7 +95,7 @@ struct TransactionPreview: View {
                             isDangerous: true,
                             action: {
                                 focus = false
-                                data.pushButton(action: .goBack)})
+                                pushButton(.goBack, "", "")})
                     }
                 }
             }

--- a/ios/NativeSigner/Screens/TransactionPreview.swift
+++ b/ios/NativeSigner/Screens/TransactionPreview.swift
@@ -8,12 +8,12 @@
 import SwiftUI
 
 struct TransactionPreview: View {
-    @EnvironmentObject var data: SignerDataModel
     @State private var comment = ""
     @State var offset: CGFloat = 0
     @State var offsetOld: CGFloat = 0
     @FocusState private var focus: Bool
     let content: MTransaction
+    let sign: (String, String) -> Void
     let pushButton: (Action, String, String) -> Void
     var body: some View {
         VStack {
@@ -59,14 +59,8 @@ struct TransactionPreview: View {
                             isCrypto: true,
                             action: {
                                 focus = false
-                                if data.alert {
-                                    data.alertShow = true
-                                } else {
-                                    data.pushButton(
-                                        action: .goForward,
-                                        details: Data(comment.utf8).base64EncodedString(),
-                                        seedPhrase: data.getSeed(seedName: content.authorInfo?.seedName ?? "")
-                                    )
+                                if let seedName = content.authorInfo?.seedName {
+                                    sign(seedName, comment)
                                 }
                             }
                         )

--- a/ios/NativeSigner/Screens/TransactionScreen.swift
+++ b/ios/NativeSigner/Screens/TransactionScreen.swift
@@ -8,9 +8,9 @@
 import SwiftUI
 
 struct TransactionScreen: View {
-    @EnvironmentObject var data: SignerDataModel
+    let pushButton: (Action, String, String) -> Void
     var body: some View {
-        CameraView()
+        CameraView(pushButton: pushButton)
     }
 }
 

--- a/ios/NativeSigner/Screens/VerifierScreen.swift
+++ b/ios/NativeSigner/Screens/VerifierScreen.swift
@@ -8,9 +8,9 @@
 import SwiftUI
 
 struct VerifierScreen: View {
-    @EnvironmentObject var data: SignerDataModel
     @State var jailbreak = false
     let content: MVerifierDetails
+    let doJailbreak: () -> Void
     var body: some View {
         VStack {
             HStack {
@@ -38,7 +38,7 @@ struct VerifierScreen: View {
                     secondaryButton: .destructive(
                         Text("I understand"),
                         action: {
-                            data.jailbreak()
+                            doJailbreak()
                         }
                     )
                 )


### PR DESCRIPTION
This is done to simplify code and bring it closer to Kotlin side; veriable is placed in main app now and only accessed for reading or through closures catpuring state at appropriate places.

Hopefully, now IDE previews could be implemented for all components if/when someone who effectively uses them wants to contribute.