### PR TITLE
fix: forbid empty seed

### DIFF
--- a/rust/db_handling/src/identities.rs
+++ b/rust/db_handling/src/identities.rs
@@ -205,10 +205,14 @@ pub(crate) fn create_address<T: ErrorSource>(
 ) -> Result<PrepData, T::Error> {
     // Check that the seed phrase is not empty.
     // In upstream, empty seed phrase means default Alice seed phrase.
-    if seed_phrase.is_empty() {return Err(<T>::empty_seed())}
+    if seed_phrase.is_empty() {
+        return Err(<T>::empty_seed());
+    }
 
     // Check that the seed name is not empty.
-    if seed_name.is_empty() {return Err(<T>::empty_seed_name())}
+    if seed_name.is_empty() {
+        return Err(<T>::empty_seed_name());
+    }
     let mut address_prep = input_batch_prep.to_vec();
     let network_specs_key =
         NetworkSpecsKey::from_parts(&network_specs.genesis_hash, &network_specs.encryption);

--- a/rust/db_handling/src/identities.rs
+++ b/rust/db_handling/src/identities.rs
@@ -203,6 +203,12 @@ pub(crate) fn create_address<T: ErrorSource>(
     seed_name: &str,
     seed_phrase: &str,
 ) -> Result<PrepData, T::Error> {
+    // Check that the seed phrase is not empty.
+    // In upstream, empty seed phrase means default Alice seed phrase.
+    if seed_phrase.is_empty() {return Err(<T>::empty_seed())}
+
+    // Check that the seed name is not empty.
+    if seed_name.is_empty() {return Err(<T>::empty_seed_name())}
     let mut address_prep = input_batch_prep.to_vec();
     let network_specs_key =
         NetworkSpecsKey::from_parts(&network_specs.genesis_hash, &network_specs.encryption);

--- a/rust/definitions/src/error.rs
+++ b/rust/definitions/src/error.rs
@@ -160,6 +160,14 @@ pub trait ErrorSource {
     /// `Error` when time could not be formatted for history record
     fn timestamp_format(error: time::error::Format) -> Self::Error;
 
+    /// `Error` when unexpectedly got empty seed phrase: if fed in upstream,
+    /// empty seed phrase is interpreted as Alice seed phrase automatically.
+    fn empty_seed() -> Self::Error;
+
+    /// `Error` when unexpectedly got empty seed name: already forbidden on the
+    /// interface, unlikely to happen in general.
+    fn empty_seed_name() -> Self::Error;
+
     /// Print `Error` as a `String`
     ///
     /// Generated string is used in parsing cards, in Signer side anyhow

--- a/rust/definitions/src/error_active.rs
+++ b/rust/definitions/src/error_active.rs
@@ -168,6 +168,12 @@ impl ErrorSource for Active {
     fn timestamp_format(error: time::error::Format) -> Self::Error {
         ErrorActive::TimeFormat(error)
     }
+    fn empty_seed() -> Self::Error {
+        ErrorActive::SeedPhraseEmpty
+    }
+    fn empty_seed_name() -> Self::Error {
+        ErrorActive::SeedNameEmpty
+    }
     fn show(error: &Self::Error) -> String {
         match error {
             ErrorActive::NotHex(a) => {
@@ -421,6 +427,8 @@ impl ErrorSource for Active {
                 }
             },
             ErrorActive::TimeFormat(e) => format!("Unable to produce timestamp. {}", e),
+            ErrorActive::SeedPhraseEmpty => String::from("Seed phrase is empty."),
+            ErrorActive::SeedNameEmpty => String::from("Seed name is empty."),
         }
     }
 }
@@ -511,6 +519,12 @@ pub enum ErrorActive {
 
     /// Time formatting error
     TimeFormat(Format),
+
+    /// Got empty seed phrase
+    SeedPhraseEmpty,
+
+    /// Got empty seed name
+    SeedNameEmpty,
 }
 
 impl std::fmt::Display for ErrorActive {

--- a/rust/definitions/src/error_signer.rs
+++ b/rust/definitions/src/error_signer.rs
@@ -173,6 +173,12 @@ impl ErrorSource for Signer {
     fn timestamp_format(error: time::error::Format) -> Self::Error {
         ErrorSigner::TimeFormat(error)
     }
+    fn empty_seed() -> Self::Error {
+        ErrorSigner::SeedPhraseEmpty
+    }
+    fn empty_seed_name() -> Self::Error {
+        ErrorSigner::SeedNameEmpty
+    }
     fn show(error: &Self::Error) -> String {
         match error {
             ErrorSigner::Interface(a) => {
@@ -352,6 +358,8 @@ impl ErrorSource for Signer {
             ErrorSigner::WrongPasswordNewChecksum(_) => String::from("Wrong password."),
             ErrorSigner::NoNetworksAvailable => String::from("No networks available. Please load networks information to proceed."),
             ErrorSigner::TimeFormat(e) => format!("Unable to produce timestamp. {}", e),
+            ErrorSigner::SeedPhraseEmpty => String::from("Signer expected seed phrase, but the seed phrase is empty. Please report this bug."),
+            ErrorSigner::SeedNameEmpty => String::from("Signer expected seed name, but the seed name is empty. Please report this bug."),
         }
     }
 }
@@ -446,6 +454,12 @@ pub enum ErrorSigner {
 
     /// Time formatting error
     TimeFormat(Format),
+
+    /// Signer tried to use empty seed phrase, likely a bug on the interface
+    SeedPhraseEmpty,
+
+    /// Signer got empty seed name, likely a bug on the interface
+    SeedNameEmpty,
 }
 
 impl ErrorSigner {

--- a/rust/definitions/src/test_all_errors_signer.rs
+++ b/rust/definitions/src/test_all_errors_signer.rs
@@ -787,6 +787,12 @@ pub fn error_signer() -> Vec<ErrorSigner> {
         time::error::Format::InvalidComponent("distance"),
     ));
 
+    // `SeedPhraseEmpty` error.
+    out.push(ErrorSigner::SeedPhraseEmpty);
+
+    // `SeedNameEmpty` error.
+    out.push(ErrorSigner::SeedNameEmpty);
+
     out
 }
 
@@ -1178,6 +1184,8 @@ mod tests {
 "Wrong password."
 "No networks available. Please load networks information to proceed."
 "Unable to produce timestamp. The distance component cannot be formatted into the requested format."
+"Signer expected seed phrase, but the seed phrase is empty. Please report this bug."
+"Signer expected seed name, but the seed name is empty. Please report this bug."
 "#;
         assert!(print == print_expected, "\nReceived: {}", print);
     }

--- a/rust/navigator/src/tests.rs
+++ b/rust/navigator/src/tests.rs
@@ -2942,7 +2942,7 @@ fn flow_test_1() {
 
     do_action(Action::NewKey, "", "").unwrap().unwrap();
     // trying to create the missing root
-    let action = do_action(Action::GoForward, "", "").unwrap().unwrap();
+    let action = do_action(Action::GoForward, "", ALICE_SEED_PHRASE).unwrap().unwrap();
 
     let expected_action = ActionResult {
         screen_label: String::new(),
@@ -3733,7 +3733,7 @@ fn flow_test_1() {
     )
     .unwrap();
     // increment swiped `//westend`
-    let action = do_action(Action::Increment, "2", "").unwrap().unwrap();
+    let action = do_action(Action::Increment, "2", ALICE_SEED_PHRASE).unwrap().unwrap();
     let mut expected_action = ActionResult {
         screen_label: String::new(),
         back: true,
@@ -3849,7 +3849,7 @@ fn flow_test_1() {
         "",
     )
     .unwrap();
-    let action = do_action(Action::Increment, "1", "").unwrap().unwrap();
+    let action = do_action(Action::Increment, "1", ALICE_SEED_PHRASE).unwrap().unwrap();
 
     if let ScreenData::Keys { ref mut f } = expected_action.screen_data {
         f.set.insert(

--- a/rust/navigator/src/tests.rs
+++ b/rust/navigator/src/tests.rs
@@ -2942,7 +2942,9 @@ fn flow_test_1() {
 
     do_action(Action::NewKey, "", "").unwrap().unwrap();
     // trying to create the missing root
-    let action = do_action(Action::GoForward, "", ALICE_SEED_PHRASE).unwrap().unwrap();
+    let action = do_action(Action::GoForward, "", ALICE_SEED_PHRASE)
+        .unwrap()
+        .unwrap();
 
     let expected_action = ActionResult {
         screen_label: String::new(),
@@ -3733,7 +3735,9 @@ fn flow_test_1() {
     )
     .unwrap();
     // increment swiped `//westend`
-    let action = do_action(Action::Increment, "2", ALICE_SEED_PHRASE).unwrap().unwrap();
+    let action = do_action(Action::Increment, "2", ALICE_SEED_PHRASE)
+        .unwrap()
+        .unwrap();
     let mut expected_action = ActionResult {
         screen_label: String::new(),
         back: true,
@@ -3849,7 +3853,9 @@ fn flow_test_1() {
         "",
     )
     .unwrap();
-    let action = do_action(Action::Increment, "1", ALICE_SEED_PHRASE).unwrap().unwrap();
+    let action = do_action(Action::Increment, "1", ALICE_SEED_PHRASE)
+        .unwrap()
+        .unwrap();
 
     if let ScreenData::Keys { ref mut f } = expected_action.screen_data {
         f.set.insert(


### PR DESCRIPTION
Forbid empty seed in `create_address`, on Rust side. In Substrate empty seed is interpreted as default Alice seed ("bottom drive obey ...").
Also block empty seed name (already must be unaccessible from the user interface).