### PR TITLE
ci: restructure the docs pipeline

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -71,8 +71,7 @@ jobs:
           mv ./docs/book/html/ ./user-docs
           echo "Removing everything but the docs dirs"
           shopt -s extglob
-          rm -vrf !("rustdocs"|"user-docs"|"README.md")
-          ls -la
+          rm -vrf !("rustdocs"|"user-docs")
 
       # deploy
       - name:                 Deploy rustdoc

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,9 +5,6 @@ on:
   push:
     branches:
       - master
-    paths:
-      - '.github/workflows/docs.yml'
-      - 'docs/**'
 
 jobs:
   rustdocs_user_docs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,7 +41,7 @@ jobs:
       - name:                 Generate cargo doc
         run:                  |
           cd rust
-          cargo doc -Dwarnings --all-features --verbose
+          RUSTFLAGS="-Dwarnings" cargo doc --all-features --verbose
 
       # user-docs
       # they are generated after rustdocs to check the relative links
@@ -61,7 +61,7 @@ jobs:
         with:
           crate:              mdbook-mermaid
 
-      - name:                 Build docs
+      - name:                 Build user-docs
         run:                  |
           mdbook build docs
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -71,7 +71,7 @@ jobs:
           mv ./docs/book/html/ ./user-docs
           echo "Removing everything but the docs dirs"
           shopt -s extglob
-          rm -v !("rustdocs"|"user-docs")
+          rm -vrf !("rustdocs"|"user-docs"|"README.md")
           ls -la
 
       # deploy

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -65,7 +65,10 @@ jobs:
         run:                  |
           mdbook build docs
 
-      - name:                 Cleanup
+      # deploy
+      - name:                 Cleanup before pushing
+        # executed only on master so PRs can use cache
+        if:                   ${{ github.ref == 'refs/heads/master' }}
         run:                  |
           mv ./rust/target/doc ./rustdocs
           mv ./docs/book/html/ ./user-docs
@@ -73,8 +76,7 @@ jobs:
           shopt -s extglob
           rm -vrf !("rustdocs"|"user-docs")
 
-      # deploy
-      - name:                 Deploy rustdoc
+      - name:                 Deploy rustdocs and user-docs
         uses:                 peaceiris/actions-gh-pages@v3
         if:                   ${{ github.ref == 'refs/heads/master' }}
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -80,4 +80,5 @@ jobs:
         if:                   ${{ github.ref == 'refs/heads/master' }}
         with:
           github_token:       ${{ github.token }}
+          force_orphan:       true
           publish_dir:        ./

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   rustdocs_user_docs:
-    name:                     Build rustdoc
+    name:                     Build rustdocs, user-docs and check links
     runs-on:                  ubuntu-latest
     steps:
 
@@ -41,7 +41,7 @@ jobs:
       - name:                 Generate cargo doc
         run:                  |
           cd rust
-          RUSTFLAGS="-Dwarnings" cargo doc --all-features --verbose
+          cargo doc --all-features --verbose
 
       # user-docs
       # they are generated after rustdocs to check the relative links

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,8 @@ jobs:
       - name:                 Generate cargo doc
         run:                  |
           cd rust
-          cargo doc --all-features --verbose
+          echo "Generating rustdocs to the user-docs dir so it's possible to check the links"
+          cargo doc --all-features --verbose --target-dir ../docs/book/html/rustdocs/
 
       # user-docs
       # they are generated after rustdocs to check the relative links
@@ -67,11 +68,11 @@ jobs:
         # executed only on master so PRs can use cache
         if:                   ${{ github.ref == 'refs/heads/master' }}
         run:                  |
-          mv ./rust/target/doc ./rustdocs
-          mv ./docs/book/html/ ./user-docs
           echo "Removing everything but the docs dirs"
           shopt -s extglob
-          rm -vrf !("rustdocs"|"user-docs")
+          rm -vrf !("./docs/book/html/")
+          echo "Hosting user-docs from root and rustdocs from ./rustdocs/"
+          mv ./docs/book/html/ ./
 
       - name:                 Deploy rustdocs and user-docs
         uses:                 peaceiris/actions-gh-pages@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,8 +10,8 @@ on:
       - 'docs/**'
 
 jobs:
-  user-docs:
-    name:                     User docs
+  rustdocs_user_docs:
+    name:                     Build rustdoc
     runs-on:                  ubuntu-latest
     steps:
 
@@ -20,14 +20,32 @@ jobs:
         with:
           access_token:       ${{ github.token }}
 
-      - name:                 Checkout repository
-        uses:                 actions/checkout@v3.0.2
-
-      - name:                 Use Rust toolchain
-        uses:                 actions-rs/toolchain@v1
+      - name:                 Checkout sources
+        uses:                 actions/checkout@v3
         with:
-          toolchain:          stable
+          fetch-depth:        1
+          submodules:         recursive
 
+      # rustdocs
+      # docs source dir ./rust/target/doc
+      - name:                 Install rustdocs dependencies
+        run:                  |
+          sudo apt update
+          sudo apt install -y clang libclang-dev libopencv-dev
+
+      - name:                 Rust Cache
+        uses:                 Swatinem/rust-cache@v1.3.0
+        with:
+          working-directory:  rust
+
+      - name:                 Generate cargo doc
+        run:                  |
+          cd rust
+          cargo doc -Dwarnings --all-features --verbose
+
+      # user-docs
+      # they are generated after rustdocs to check the relative links
+      # docs source dir ./docs/book/html/
       - name:                 Setup mdBook
         uses:                 peaceiris/actions-mdbook@v1.1.14
         with:
@@ -47,49 +65,19 @@ jobs:
         run:                  |
           mdbook build docs
 
-      - name:                 Deploy user documentation
-        uses:                 peaceiris/actions-gh-pages@v3
-        if:                 ${{ github.ref == 'refs/heads/master' }}
-        with:
-          github_token:       ${{ github.token }}
-          publish_dir:        ./docs/book/html/
-          destination_dir:    ./user-docs
-
-  rustdocs:
-    name:                     Build rustdoc
-    runs-on:                  ubuntu-latest
-    steps:
-
-      - name:                 Cancel Previous Runs
-        uses:                 styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token:       ${{ github.token }}
-
-      - name:                 Checkout sources
-        uses:                 actions/checkout@v3
-        with:
-          fetch-depth:        1
-          submodules:         recursive
-
-      - name:                 Install system dependancies
+      - name:                 Cleanup
         run:                  |
-          sudo apt update
-          sudo apt install -y clang libclang-dev libopencv-dev
+          mv ./rust/target/doc ./rustdocs
+          mv ./docs/book/html/ ./user-docs
+          echo "Removing everything but the docs dirs"
+          shopt -s extglob
+          rm -v !("rustdocs"|"user-docs")
+          ls -la
 
-      - name:                 Rust Cache
-        uses:                 Swatinem/rust-cache@v1.3.0
-        with:
-          working-directory:  rust
-
-      - name:                 cargo doc
-        run:                  |
-          cd rust
-          cargo doc --all-features --verbose
-
+      # deploy
       - name:                 Deploy rustdoc
         uses:                 peaceiris/actions-gh-pages@v3
         if:                   ${{ github.ref == 'refs/heads/master' }}
         with:
           github_token:       ${{ github.token }}
-          publish_dir:        ./rust/target/doc
-          destination_dir:    ./rustdocs
+          publish_dir:        ./


### PR DESCRIPTION
- places generating user-docs after rustdocs are built, so it's possible to check the links between them
- publishes user-docs to https://paritytech.github.io/parity-signer/user-docs/
- publishes rustdocs to i.e. https://paritytech.github.io/parity-signer/rustdocs/constants/index.html (it's better to choose an initial page and place an index.html like [this](https://github.com/paritytech/substrate/blob/master/scripts/ci/gitlab/pipeline/build.yml#L157))
- empties `gh-pages` branch after every deploy (on master) with `force_orphan: true`