### PR TITLE
ci: workaround mdbook bug

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,14 +32,14 @@ jobs:
       - name:                 Rust Cache
         uses:                 Swatinem/rust-cache@v1.3.0
         with:
-          # must match with cargo ... --target-dir
-          working-directory:  docs/book/src/rustdocs/
+          working-directory:  rust
 
       - name:                 Generate cargo doc
         run:                  |
           cd rust
           echo "_____Generating rustdocs to the book/src dir so it's published to check the links_____"
-          cargo doc --all-features --verbose --target-dir ../docs/book/src/rustdocs/
+          cargo doc --all-features --verbose
+          mv ./target/doc/ ../docs/book/src/rustdocs/
 
       # user-docs
       # they are generated after rustdocs to check the relative links
@@ -68,8 +68,6 @@ jobs:
         # executed only on master so PRs can use cache
         # if:                   ${{ github.ref == 'refs/heads/master' }}
         run:                  |
-          echo "_____Removing cargo debug info_____"
-          rm -rf ./docs/book/rustdocs/debug
           echo "_____Removing everything but the docs dir_____"
           rm -rf /tmp/book/
           mv -v ./docs/book/ /tmp/book/
@@ -82,8 +80,6 @@ jobs:
           du -sh ./*
           echo "_____du -sh ./src/rustdocs/*"
           du -sh ./src/rustdocs/* || exit 0
-          echo "_____du -sh ./src/rustdocs/doc/*"
-          du -sh ./src/rustdocs/doc/* || exit 0
 
       - name:                 Deploy rustdocs and user-docs
         uses:                 peaceiris/actions-gh-pages@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,6 @@ jobs:
           submodules:         recursive
 
       # rustdocs
-      # docs source dir ./rust/target/doc
       - name:                 Install rustdocs dependencies
         run:                  |
           sudo apt update
@@ -33,13 +32,14 @@ jobs:
       - name:                 Rust Cache
         uses:                 Swatinem/rust-cache@v1.3.0
         with:
-          working-directory:  rust
+          # must match with cargo ... --target-dir
+          working-directory:  docs/book/src/rustdocs/
 
       - name:                 Generate cargo doc
         run:                  |
           cd rust
-          echo "Generating rustdocs to the user-docs dir so it's possible to check the links"
-          cargo doc --all-features --verbose --target-dir ../docs/book/rustdocs/
+          echo "_____Generating rustdocs to the book/src dir so it's published to check the links_____"
+          cargo doc --all-features --verbose --target-dir ../docs/book/src/rustdocs/
 
       # user-docs
       # they are generated after rustdocs to check the relative links
@@ -68,19 +68,20 @@ jobs:
         # executed only on master so PRs can use cache
         # if:                   ${{ github.ref == 'refs/heads/master' }}
         run:                  |
-          echo "Removing everything but the docs dir"
-          rm -rf /tmp/html/ /tmp/rustdocs/
+          echo "_____Removing everything but the docs dir_____"
+          rm -rf /tmp/html/
           mv -v ./docs/book/html/ /tmp/html/
-          mv -v ./docs/book/rustdocs/ /tmp/rustdocs/
           rm -vrf *
-          echo "Hosting user-docs from ./html/ and rustdocs from ./rustdocs/"
-          mv -v /tmp/html/ ./
-          mv -v /tmp/rustdocs/ ./
+          echo "_____Hosting user-docs from root and rustdocs from ./rustdocs/_____"
+          mv -v /tmp/html/* ./
+          echo "_____ls ./"
           ls ./
+          echo "_____ls ./rustdocs"
           ls ./rustdocs
+          echo "_____du -sh ./rustdocs/*"
           du -sh ./rustdocs/*
-          ls ./html
-          du -sh ./html/*
+          echo "_____du -sh ./*"
+          du -sh ./*
 
       - name:                 Deploy rustdocs and user-docs
         uses:                 peaceiris/actions-gh-pages@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,7 +39,7 @@ jobs:
           cd rust
           echo "_____Generating rustdocs to the book/src dir so it's published to check the links_____"
           cargo doc --all-features --verbose
-          mv ./target/doc/ ../docs/book/src/rustdocs/
+          mv ./target/doc/ ../docs/src/rustdocs/
 
       # user-docs
       # they are generated after rustdocs to check the relative links

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -68,18 +68,16 @@ jobs:
         # executed only on master so PRs can use cache
         # if:                   ${{ github.ref == 'refs/heads/master' }}
         run:                  |
-          echo "_____Removing everything but the docs dir_____"
-          rm -rf /tmp/book/
-          mv -v ./docs/book/ /tmp/book/
-          rm -vrf *
           echo "_____Hosting user-docs from root and rustdocs from ./rustdocs/_____"
-          mv -v /tmp/book/html/* ./
+          mv ./docs/book/html ./public
           echo "_____ls ./"
           ls ./
           echo "_____du -sh ./*"
           du -sh ./*
-          echo "_____du -sh ./rustdocs/*"
-          du -sh ./rustdocs/* || exit 0
+          echo "_____du -sh ./docs/book/html/*"
+          du -sh ./public/* || exit 0
+          echo "_____du -sh ./docs/book/html/rustdocs/*"
+          du -sh ./public/rustdocs/* || exit 0
 
       - name:                 Deploy rustdocs and user-docs
         uses:                 peaceiris/actions-gh-pages@v3
@@ -88,4 +86,4 @@ jobs:
         with:
           github_token:       ${{ github.token }}
           force_orphan:       true
-          publish_dir:        ./
+          publish_dir:        ./public

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -73,13 +73,13 @@ jobs:
           mv -v ./docs/book/ /tmp/book/
           rm -vrf *
           echo "_____Hosting user-docs from root and rustdocs from ./rustdocs/_____"
-          mv -v /tmp/book/* ./
+          mv -v /tmp/book/html/* ./
           echo "_____ls ./"
           ls ./
           echo "_____du -sh ./*"
           du -sh ./*
-          echo "_____du -sh ./src/rustdocs/*"
-          du -sh ./src/rustdocs/* || exit 0
+          echo "_____du -sh ./rustdocs/*"
+          du -sh ./rustdocs/* || exit 0
 
       - name:                 Deploy rustdocs and user-docs
         uses:                 peaceiris/actions-gh-pages@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -69,19 +69,23 @@ jobs:
         # if:                   ${{ github.ref == 'refs/heads/master' }}
         run:                  |
           echo "_____Removing everything but the docs dir_____"
-          rm -rf /tmp/html/
-          mv -v ./docs/book/html/ /tmp/html/
+          rm -rf /tmp/book/
+          mv -v ./docs/book/ /tmp/book/
           rm -vrf *
           echo "_____Hosting user-docs from root and rustdocs from ./rustdocs/_____"
-          mv -v /tmp/html/* ./
+          mv -v /tmp/book/* ./
           echo "_____ls ./"
           ls ./
-          echo "_____ls ./rustdocs"
-          ls ./rustdocs
-          echo "_____du -sh ./rustdocs/*"
-          du -sh ./rustdocs/*
           echo "_____du -sh ./*"
           du -sh ./*
+          echo "_____ls ./rustdocs"
+          ls ./rustdocs || exit 0
+          echo "_____find . -name "rustdocs"
+          find . -name "rustdocs" || exit 0
+          echo "_____find . -name "rustdocs" -exec "ls" {} \;"
+          find . -name "rustdocs" -exec "ls" {} \; || exit 0
+          echo "_____du -sh ./rustdocs/*"
+          du -sh ./rustdocs/* || exit 0
 
       - name:                 Deploy rustdocs and user-docs
         uses:                 peaceiris/actions-gh-pages@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -68,6 +68,8 @@ jobs:
         # executed only on master so PRs can use cache
         # if:                   ${{ github.ref == 'refs/heads/master' }}
         run:                  |
+          echo "_____Removing cargo debug info_____"
+          rm -rf ./docs/book/rustdocs/debug
           echo "_____Removing everything but the docs dir_____"
           rm -rf /tmp/book/
           mv -v ./docs/book/ /tmp/book/
@@ -78,14 +80,10 @@ jobs:
           ls ./
           echo "_____du -sh ./*"
           du -sh ./*
-          echo "_____ls ./rustdocs"
-          ls ./rustdocs || exit 0
-          echo "_____find . -name "rustdocs"
-          find . -name "rustdocs" || exit 0
-          echo "_____find . -name "rustdocs" -exec "ls" {} \;"
-          find . -name "rustdocs" -exec "ls" {} \; || exit 0
-          echo "_____du -sh ./rustdocs/*"
-          du -sh ./rustdocs/* || exit 0
+          echo "_____du -sh ./src/rustdocs/*"
+          du -sh ./src/rustdocs/* || exit 0
+          echo "_____du -sh ./src/rustdocs/doc/*"
+          du -sh ./src/rustdocs/doc/* || exit 0
 
       - name:                 Deploy rustdocs and user-docs
         uses:                 peaceiris/actions-gh-pages@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,7 +39,7 @@ jobs:
         run:                  |
           cd rust
           echo "Generating rustdocs to the user-docs dir so it's possible to check the links"
-          cargo doc --all-features --verbose --target-dir ../docs/book/html/rustdocs/
+          cargo doc --all-features --verbose --target-dir ../docs/book/rustdocs/
 
       # user-docs
       # they are generated after rustdocs to check the relative links
@@ -66,19 +66,26 @@ jobs:
       # deploy
       - name:                 Cleanup before pushing
         # executed only on master so PRs can use cache
-        if:                   ${{ github.ref == 'refs/heads/master' }}
+        # if:                   ${{ github.ref == 'refs/heads/master' }}
         run:                  |
           echo "Removing everything but the docs dir"
-          rm -rf /tmp/html/
+          rm -rf /tmp/html/ /tmp/rustdocs/
           mv -v ./docs/book/html/ /tmp/html/
+          mv -v ./docs/book/rustdocs/ /tmp/rustdocs/
           rm -vrf *
-          echo "Hosting user-docs from root and rustdocs from ./rustdocs/"
-          mv -v /tmp/html/* ./
+          echo "Hosting user-docs from ./html/ and rustdocs from ./rustdocs/"
+          mv -v /tmp/html/ ./
+          mv -v /tmp/rustdocs/ ./
+          ls ./
+          ls ./rustdocs
+          du -sh ./rustdocs/*
+          ls ./html
+          du -sh ./html/*
 
       - name:                 Deploy rustdocs and user-docs
         uses:                 peaceiris/actions-gh-pages@v3
         # published only from master
-        if:                   ${{ github.ref == 'refs/heads/master' }}
+        # if:                   ${{ github.ref == 'refs/heads/master' }}
         with:
           github_token:       ${{ github.token }}
           force_orphan:       true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
         run:                  |
           cd rust
           echo "_____Generating rustdocs to the book/src dir so it's published to check the links_____"
-          cargo doc --all-features --verbose
+          cargo doc --all-features --verbose --no-deps
           mv ./target/doc/ ../docs/src/rustdocs/
 
       # user-docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,13 +37,13 @@ jobs:
       - name:                 Generate cargo doc
         run:                  |
           cd rust
-          echo "_____Generating rustdocs to the book/src dir so it's published to check the links_____"
+          echo "_____Generating rustdocs to ./docs/book/src dir so it's published from ./rustdocs/"
+          echo "_____And to check the relative links to the rustdoc while mdbook build_____"
           cargo doc --all-features --verbose --no-deps
           mv ./target/doc/ ../docs/src/rustdocs/
 
       # user-docs
       # they are generated after rustdocs to check the relative links
-      # docs source dir ./docs/book/html/
       - name:                 Setup mdBook
         uses:                 peaceiris/actions-mdbook@v1.1.14
         with:
@@ -60,30 +60,21 @@ jobs:
           crate:              mdbook-mermaid
 
       - name:                 Build user-docs
+        # docs source dir ./docs/book/html/
         run:                  |
           mdbook build docs
+          echo "_____Hosting user-docs from root and rustdocs from ./rustdocs/_____"
+          echo "_____gh-pages branch would be the size of_____"
+          du -sh ./docs/book/html/
+          du -sh ./docs/book/html/*
 
       # deploy
-      - name:                 Cleanup before pushing
-        # executed only on master so PRs can use cache
-        # if:                   ${{ github.ref == 'refs/heads/master' }}
-        run:                  |
-          echo "_____Hosting user-docs from root and rustdocs from ./rustdocs/_____"
-          mv ./docs/book/html ./public
-          echo "_____ls ./"
-          ls ./
-          echo "_____du -sh ./*"
-          du -sh ./*
-          echo "_____du -sh ./docs/book/html/*"
-          du -sh ./public/* || exit 0
-          echo "_____du -sh ./docs/book/html/rustdocs/*"
-          du -sh ./public/rustdocs/* || exit 0
-
       - name:                 Deploy rustdocs and user-docs
         uses:                 peaceiris/actions-gh-pages@v3
         # published only from master
-        # if:                   ${{ github.ref == 'refs/heads/master' }}
+        if:                   ${{ github.ref == 'refs/heads/master' }}
         with:
           github_token:       ${{ github.token }}
           force_orphan:       true
-          publish_dir:        ./public
+          # this is the only dir that's pushed to gh-pages branch
+          publish_dir:        ./docs/book/html


### PR DESCRIPTION
Previously I tried to put rustdocs into an `mdbook`-generated `./docs/book/html` dir. This was done to have user-docs in the root https://paritytech.github.io/parity-signer and rustdocs in https://paritytech.github.io/parity-signer/rustdocs.

But [apparently](https://github.com/rust-lang/mdBook/issues/218) `mdbook` doesn't have a flag to skip cleaning the book output-dir. Also, I couldn't find if it's possible to mention this rustdocs dir in the `SUMMARY.md` or `book.toml`.

UPD: thanks to https://users.rust-lang.org/t/how-to-create-link-between-rustdoc-and-mdbook/50189/4

It leads me to the [doc](https://rust-lang.github.io/mdBook/guide/creating.html#source-files) dimly saying that:

> All other files in the `src` directory will be included in the output. So if you have images or other static files, just include them somewhere in the `src` directory.

This means that the `rustdoc` can be hosted from there.

Another thing to note is that `peaceiris/actions-gh-pages`'s `publish_dir` is the only thing that should reach `gh-pages` branch. This makes cleaning the entire repo unneeded, this helps with caching.