### PR TITLE
chore: make generate_message helpers public

### DIFF
--- a/rust/generate_message/src/lib.rs
+++ b/rust/generate_message/src/lib.rs
@@ -1078,7 +1078,7 @@ use definitions::error_active::{Active, ErrorActive};
 mod derivations;
 use derivations::process_derivations;
 pub mod fetch_metadata;
-mod helpers;
+pub mod helpers;
 use helpers::debug_meta_at_block;
 pub mod interpret_specs;
 mod load;


### PR DESCRIPTION
[Metadata portal](https://github.com/paritytech/metadata-portal) would benefit a lot by using `meta_fetch`, `specs_agnostic` and `MetaFetched` from `generate_message::helpers` module.