### PR TITLE
ci: do not publish docs on dependabots' commits

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -73,7 +73,7 @@ jobs:
         uses:                 peaceiris/actions-gh-pages@v3
         # published only from master AND if the triggerer is not dependabot
         # https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-797125425
-        if:                   ${{ github.ref == 'refs/heads/master' AND github.actor != 'dependabot[bot]' }}
+        if:                   ${{ github.ref == 'refs/heads/master' && github.actor != 'dependabot[bot]' }}
         with:
           github_token:       ${{ github.token }}
           force_orphan:       true


### PR DESCRIPTION
@montekki 's noticed that docs deployment job sometimes fails.

Research (https://github.com/paritytech/parity-signer/actions/workflows/docs.yml?query=branch%3Amaster) has shown that it's only dependabot's workflows that are failing upon PR acceptance. It's using the different token.

Details and security considerations, as well as a couple of workarounds: https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-797125425

I decided simply not to update the docs on dependabot's changes.