### PR TITLE
fix: do not follow web links in mdbook

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -25,7 +25,7 @@ expand = true
 heading-split-level = 2
 
 [output.linkcheck]
-follow-web-links = true
+follow-web-links = false
 cache-timeout = 43200
 warning-policy = "warn"
 


### PR DESCRIPTION
* it is flaky (apple.com and others ban CI from time to time)
* not buildable while on the airplane.