### PR TITLE
docs: update iOS build docs to account for tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,25 @@ If you get errors like `cargo: feature X is required`, it most likely means you 
 cd scripts && ./build.sh ios
 ```
 
-**5.** Open the `NativeSigner.xcodeproj` project from the `ios` folder in your Xcode. Project features two schemes:
+**5.** Install dependencies
+Currently most of iOS tooling is integrated via [Homebrew](https://brew.sh) to avoid use of [CocoaPods](https://cocoapods.org).
+
+Before running project for the first time, run the following in the console
+
+```bash
+brew install swiftgen
+brew install swiftformat
+brew install swiftlint
+```
+
+If you are using M1 machine, it might be necessary to run following commands for XCode's Build Phases to run tooling correctly:
+```
+sudo ln -s /opt/homebrew/bin/swiftgen /usr/local/bin/swiftgen
+sudo ln -s /opt/homebrew/bin/swiftformat /usr/local/bin/swiftformat
+sudo ln -s /opt/homebrew/bin/swiftlint /usr/local/bin/swiftlint
+```
+
+**6.** Open the `NativeSigner.xcodeproj` project from the `ios` folder in your Xcode. Project features two schemes:
 - `NativeSigner` - used for deployments and running production-ready app on your devices
 - `NativeSigner-Dev` - development scheme that can be used to simulate offline mode without turning off WiFi on your Mac if you are using simulator.
 To run project, select one of the schemes and click `Run` (Cmd+R)


### PR DESCRIPTION
## Purpose
This PR updates build documentation for iOS to include tooling instructions

## Scope
- add instructions regarding one-time brew dependencies
- add M1-specific instructions
