### PR TITLE
chore: add derived_keys_count to SeedNameCard

### DIFF
--- a/rust/db_handling/tests/tests.rs
+++ b/rust/db_handling/tests/tests.rs
@@ -81,6 +81,7 @@ fn print_seed_names() {
     let expected_cards = vec![SeedNameCard {
         seed_name: "Alice".to_string(),
         identicon: alice_sr_root().to_vec(),
+        derived_keys_count: 4, // "//westend", "//kusama", "//polkadot", "//Alice"
     }];
     assert!(cards == expected_cards, "\nReceived: \n{:?}", cards);
     fs::remove_dir_all(dbname).unwrap();
@@ -101,10 +102,12 @@ fn print_seed_names_with_orphan() {
         SeedNameCard {
             seed_name: "Alice".to_string(),
             identicon: alice_sr_root().to_vec(),
+            derived_keys_count: 4,
         },
         SeedNameCard {
             seed_name: "BobGhost".to_string(),
             identicon: empty_png().to_vec(),
+            derived_keys_count: 0,
         },
     ];
     assert!(cards == expected_cards, "\nReceived: \n{:?}", cards);

--- a/rust/definitions/src/navigation.rs
+++ b/rust/definitions/src/navigation.rs
@@ -258,6 +258,7 @@ pub struct MTransaction {
 pub struct SeedNameCard {
     pub seed_name: String,
     pub identicon: Vec<u8>,
+    pub derived_keys_count: u32,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/rust/navigator/src/tests.rs
+++ b/rust/navigator/src/tests.rs
@@ -1927,7 +1927,7 @@ fn flow_test_1() {
                 seed_name_cards: vec![SeedNameCard {
                     seed_name: "Portia".to_string(),
                     identicon: vec![],
-                    derived_keys_count: 0,
+                    derived_keys_count: 3,
                 }],
             },
         },
@@ -2720,12 +2720,12 @@ fn flow_test_1() {
                     SeedNameCard {
                         seed_name: "Alice".to_string(),
                         identicon: vec![],
-                        derived_keys_count: 0,
+                        derived_keys_count: 3,
                     },
                     SeedNameCard {
                         seed_name: "Portia".to_string(),
                         identicon: vec![],
-                        derived_keys_count: 0,
+                        derived_keys_count: 3,
                     },
                 ],
             },
@@ -3032,12 +3032,12 @@ fn flow_test_1() {
                     SeedNameCard {
                         seed_name: "Alice".to_string(),
                         identicon: vec![],
-                        derived_keys_count: 0,
+                        derived_keys_count: 4,
                     },
                     SeedNameCard {
                         seed_name: "Portia".to_string(),
                         identicon: vec![],
-                        derived_keys_count: 0,
+                        derived_keys_count: 3,
                     },
                 ],
             },
@@ -3362,7 +3362,7 @@ fn flow_test_1() {
                 seed_name_cards: vec![SeedNameCard {
                     seed_name: "Alice".to_string(),
                     identicon: alice_sr_root().to_vec(),
-                    derived_keys_count: 0,
+                    derived_keys_count: 4,
                 }],
             },
         },
@@ -3527,7 +3527,7 @@ fn flow_test_1() {
             seed_name_cards: vec![SeedNameCard {
                 seed_name: "Alice".to_string(),
                 identicon: alice_sr_root().to_vec(),
-                derived_keys_count: 0,
+                derived_keys_count: 4,
             }],
         },
     });
@@ -4453,7 +4453,7 @@ fn flow_test_1() {
                 seed_name_cards: vec![SeedNameCard {
                     seed_name: "Alice".to_string(),
                     identicon: alice_sr_root().to_vec(),
-                    derived_keys_count: 0,
+                    derived_keys_count: 6,
                 }],
             },
         },

--- a/rust/navigator/src/tests.rs
+++ b/rust/navigator/src/tests.rs
@@ -1927,6 +1927,7 @@ fn flow_test_1() {
                 seed_name_cards: vec![SeedNameCard {
                     seed_name: "Portia".to_string(),
                     identicon: vec![],
+                    derived_keys_count: 0,
                 }],
             },
         },
@@ -2719,10 +2720,12 @@ fn flow_test_1() {
                     SeedNameCard {
                         seed_name: "Alice".to_string(),
                         identicon: vec![],
+                        derived_keys_count: 0,
                     },
                     SeedNameCard {
                         seed_name: "Portia".to_string(),
                         identicon: vec![],
+                        derived_keys_count: 0,
                     },
                 ],
             },
@@ -3029,10 +3032,12 @@ fn flow_test_1() {
                     SeedNameCard {
                         seed_name: "Alice".to_string(),
                         identicon: vec![],
+                        derived_keys_count: 0,
                     },
                     SeedNameCard {
                         seed_name: "Portia".to_string(),
                         identicon: vec![],
+                        derived_keys_count: 0,
                     },
                 ],
             },
@@ -3357,6 +3362,7 @@ fn flow_test_1() {
                 seed_name_cards: vec![SeedNameCard {
                     seed_name: "Alice".to_string(),
                     identicon: alice_sr_root().to_vec(),
+                    derived_keys_count: 0,
                 }],
             },
         },
@@ -3521,6 +3527,7 @@ fn flow_test_1() {
             seed_name_cards: vec![SeedNameCard {
                 seed_name: "Alice".to_string(),
                 identicon: alice_sr_root().to_vec(),
+                derived_keys_count: 0,
             }],
         },
     });
@@ -4446,6 +4453,7 @@ fn flow_test_1() {
                 seed_name_cards: vec![SeedNameCard {
                     seed_name: "Alice".to_string(),
                     identicon: alice_sr_root().to_vec(),
+                    derived_keys_count: 0,
                 }],
             },
         },

--- a/rust/signer/src/signer.udl
+++ b/rust/signer/src/signer.udl
@@ -378,6 +378,7 @@ dictionary TransactionCardSet {
 dictionary SeedNameCard {
     string seed_name;
     sequence<u8> identicon;
+    u32 derived_keys_count;
 };
 
 dictionary MSeeds {


### PR DESCRIPTION
## Purpose
<!-- What is the goal of the proposed change? i.e.
This PR aims to address issue: #1234
This PR adds XYZ feature
This PR adds new GA workflow that runs unit tests
-->
Provide UI a number of derived keys
![image](https://user-images.githubusercontent.com/7165377/186417921-a5047209-a71f-4070-8d94-fcbcb5c8e5a8.png)


## Scope
<!-- What is the technical scope of the changes? i.e.:
- refactored module XYZ
- added unit tests for ABC
-->
Add `derived_keys_count` field to `SeedNameCard` struct


<!--
- [ ] Discuss and update [README](https://github.com/paritytech/parity-signer/blob/master/README.md) if needed
- [ ] Make sure that this doesn't break feature ABC before merging
-->
