### PR TITLE
fix: Removing requirement of biometric

### DIFF
--- a/android/app/src/main/java/io/parity/signer/components/Authentication.kt
+++ b/android/app/src/main/java/io/parity/signer/components/Authentication.kt
@@ -9,8 +9,6 @@ import androidx.fragment.app.FragmentActivity
 
 
 class Authentication(val setAuth: (Boolean) -> Unit) {
-	var strongCredentials: Boolean = false
-
 
 	private lateinit var biometricPrompt: BiometricPrompt
 	lateinit var context: Context
@@ -19,22 +17,14 @@ class Authentication(val setAuth: (Boolean) -> Unit) {
 		val biometricManager = BiometricManager.from(context)
 
 		val promptInfo =
-			if (strongCredentials) {
 				BiometricPrompt.PromptInfo.Builder()
 					.setTitle("UNLOCK SIGNER")
 					.setSubtitle("Please authenticate yourself")
-					.setAllowedAuthenticators(BiometricManager.Authenticators.DEVICE_CREDENTIAL)
+					.setAllowedAuthenticators(BiometricManager.Authenticators.DEVICE_CREDENTIAL or BiometricManager.Authenticators.BIOMETRIC_WEAK)
 					.build()
-			} else {
-				BiometricPrompt.PromptInfo.Builder()
-					.setTitle("UNLOCK SIGNER")
-					.setSubtitle("Please authenticate yourself")
-					.setNegativeButtonText("Cancel")
-					.setAllowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_STRONG)
-					.build()
-			}
 
-		when (biometricManager.canAuthenticate(if (strongCredentials) BiometricManager.Authenticators.DEVICE_CREDENTIAL else BiometricManager.Authenticators.BIOMETRIC_STRONG)) {
+		when (biometricManager.canAuthenticate(BiometricManager.Authenticators.DEVICE_CREDENTIAL
+			or BiometricManager.Authenticators.BIOMETRIC_WEAK)) {
 			BiometricManager.BIOMETRIC_SUCCESS -> {
 
 				val executor = ContextCompat.getMainExecutor(context)
@@ -95,11 +85,8 @@ class Authentication(val setAuth: (Boolean) -> Unit) {
 			BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED -> {
 				Toast.makeText(
 					context,
-					"Authentication system not enrolled; please enable "
-						+ if (strongCredentials)
-						"password or pin code"
-					else
-						"biometric authentication",
+					"Authentication system not enrolled; please enable " +
+						"password, pin code or biometric authentication",
 					Toast.LENGTH_LONG
 				).show()
 				return

--- a/android/app/src/main/java/io/parity/signer/models/SignerDataModel.kt
+++ b/android/app/src/main/java/io/parity/signer/models/SignerDataModel.kt
@@ -126,7 +126,6 @@ class SignerDataModel : ViewModel() {
 		} else {
 			false
 		}
-		authentication.strongCredentials = hasStrongbox
 
 		Log.d("strongbox available:", hasStrongbox.toString())
 
@@ -145,10 +144,10 @@ class SignerDataModel : ViewModel() {
 
 		// Init crypto for seeds:
 		// https://developer.android.com/training/articles/keystore
-		masterKey = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+		masterKey = if (hasStrongbox) {
 			MasterKey.Builder(context)
 				.setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-				.setRequestStrongBoxBacked(true) // This might cause failures but shouldn't
+				.setRequestStrongBoxBacked(true)
 				.setUserAuthenticationRequired(true)
 				.build()
 		} else {


### PR DESCRIPTION
Removed requirement of strong biometric authentication for new android devices. 
User can now use any authentication that it set on device before unlocking secure storage to get the master key.