### PR TITLE
fix: don't trigger second authorization request when checking for seed collision

### DIFF
--- a/ios/NativeSigner/Core/Keychain/KeychainAccessAdapter.swift
+++ b/ios/NativeSigner/Core/Keychain/KeychainAccessAdapter.swift
@@ -138,7 +138,7 @@ final class KeychainAccessAdapter: KeychainAccessAdapting {
         let query = queryProvider.query(for: .check)
         var queryResult: AnyObject?
         let osStatus = SecItemCopyMatching(query, &queryResult)
-        if !(osStatus == errSecSuccess && osStatus == errSecItemNotFound) {
+        if osStatus != errSecSuccess, osStatus != errSecItemNotFound {
             return .failure(.checkError)
         }
         if osStatus == errSecItemNotFound { return .success(false) }


### PR DESCRIPTION
## Purpose
This PR fixes issue introduced in refactor: https://github.com/paritytech/parity-signer/pull/1239
This bug required user to provide passcode twice when adding new keys, as `authenticated` was incorrectly set to `false`

## Scope
I basically messed out on bool logic check when refactoring 
Unfortunately at this stage I'm unable to provide unit tests for this change without further refactor to how we interact with Keychain 🙏🏻 

## Screenshots

### Before fix 
https://user-images.githubusercontent.com/1955364/187914710-a40ddd74-1c1e-48bf-ae70-3b9aa3be74c2.MP4

### After fix
https://user-images.githubusercontent.com/1955364/187913895-ec9ecd42-80c9-40e4-95d4-2b40c14363c2.MP4

