### PR TITLE
docs: Fix documentation around commands and arguments

### DIFF
--- a/docs/src/tutorials/Add-New-Network.md
+++ b/docs/src/tutorials/Add-New-Network.md
@@ -49,24 +49,24 @@ Let's get started!
 In `parity-signer/rust/generate_message`
 
 ```
-cargo run add_specs -u <network-ws-url> -<crypto>
+cargo run add-specs -u <network-ws-url> --encryption <crypto>
 
 ```
 ```
 // e.g.
-cargo run add_specs -u wss://statemint-rpc.polkadot.io -sr25519
+cargo run add-specs -u wss://statemint-rpc.polkadot.io --encryption sr25519
 
 ```
 
 For networks supporting several tokens:
 
 ```
-cargo run add_specs -d -u <network-ws-url> -<crypto> -token <decimals> <SYMBOL>
+cargo run add-specs -d -u <network-ws-url> --encryption <crypto> --token-decimals <decimals> --token-unit <SYMBOL>
 
 ```
 ```
 // e.g.
-cargo run add_specs -d -u wss://karura-rpc-0.aca-api.network -sr25519 -token 12 KAR
+cargo run add-specs -d -u wss://karura-rpc-0.aca-api.network --encryption sr25519 --token-decimals 12 --token-unit KAR
 
 ```
 
@@ -100,12 +100,12 @@ This will return a `<signature>` you need to make a signed QR.
 In `parity-signer/rust/generate_message`
 
 ```
-cargo run --release make -qr -crypto <crypto> -msgtype add_specs -payload <spec-file> -verifier -hex <public-key> -signature -hex <signature>
+cargo run --release make --goal qr --crypto <crypto> --msg add-specs --payload <spec-file> --verifier-hex <public-key> --signature-hex <signature>
 ```
 
 ```
 // e.g.
-cargo run --release make -qr -crypto sr25519 -msgtype add_specs -payload sign_me_add_specs_statemint_sr25519 -verifier -hex 0x927c307614dba6ec42f84411cc1e93c6579893859ce5a7ac3d8c2fb1649d1542 -signature -hex fa3ed5e1156d3d51349cd9bb4257387d8e32d49861c0952eaff1c2d982332e13afa8856bb6dfc684263aa3570499e067d4d78ea2dfa7a9b85e8ea273d3a81a86
+cargo run --release make --goal qr --crypto sr25519 --msg add-specs --payload sign_me_add_specs_statemint_sr25519 --verifier-hex 0x927c307614dba6ec42f84411cc1e93c6579893859ce5a7ac3d8c2fb1649d1542 --signature-hex fa3ed5e1156d3d51349cd9bb4257387d8e32d49861c0952eaff1c2d982332e13afa8856bb6dfc684263aa3570499e067d4d78ea2dfa7a9b85e8ea273d3a81a86
 ```
 
 <br/>
@@ -125,17 +125,17 @@ In Signer open scanner, scan your your `<spec-qr>` and approve chain specs.
 In `parity-signer/rust/generate_message`
 
 ```
-cargo run load_metadata -d -u `<network-ws-url>`
+cargo run load-metadata -d -u `<network-ws-url>`
 ```
 
 ```
 // e.g.
-cargo run load_metadata -d -u wss://statemint-rpc.polkadot.io
+cargo run load-metadata -d -u wss://statemint-rpc.polkadot.io
 ```
 
 <br/>
 
-This will fetch fresh `<metadata-file>`, update the database with it, and - most relevant to us currently - generate file with message body in `parity-signer/rust/files/for_signing`. 
+This will fetch fresh `<metadata_file>`, update the database with it, and - most relevant to us currently - generate file with message body in `parity-signer/rust/files/for_signing`.
 
 ### Sign Network Metadata
 
@@ -157,12 +157,12 @@ cat sign_me_load_metadata_statemintV800 | subkey sign --suri "bottom drive obey 
 In `parity-signer/rust/generate_message`
 
 ```
-cargo run --release make -qr -crypto <crypto> -msgtype load_metadata -payload <metadata-file> -verifier -hex <public-key> -signature -hex <signature>
+cargo run --release make --goal qr --crypto <crypto> --msg load-metadata --payload <metadata-file> --verifier-hex <public-key> --signature-hex <signature>
 ```
 
 ```
 // e.g.
-cargo run --release make -qr -crypto sr25519 -msgtype load_metadata -payload sign_me_load_metadata_statemintV800 -verifier -hex 0x927c307614dba6ec42f84411cc1e93c6579893859ce5a7ac3d8c2fb1649d1542 -signature -hex 6a8f8dab854bec99bd8534102a964a4e71f4370683e7ff116c84d7e8d5cb344efd3b90d27059b7c8058f5c4a5230b792009c351a16c007237921bcae2ede2d84
+cargo run --release make --goal qr --crypto sr25519 --msg load-metadata --payload sign_me_load-metadata_statemintV800 --verifier-hex 0x927c307614dba6ec42f84411cc1e93c6579893859ce5a7ac3d8c2fb1649d1542 --signature-hex 6a8f8dab854bec99bd8534102a964a4e71f4370683e7ff116c84d7e8d5cb344efd3b90d27059b7c8058f5c4a5230b792009c351a16c007237921bcae2ede2d84
 ```
 
 This QR might take some time to be generated. After it is finished you can find your `<metadata-qr>` in `parity-signer/rust/files/signed`. It is a multipart QR-"movie", if you image viewer does not render it correctly, we suggest to open it in a browser.

--- a/rust/generate_message/address_book
+++ b/rust/generate_message/address_book
@@ -144,13 +144,13 @@ wss://alphaville.zero.io				ok
 How do I add a custom network into Signer?
 
 `$ cargo run add-specs -d -u wss://rpc.astar.network --encryption sr25519`
-`$ cargo run make --goal qr -crypto none -msgtype add-specs --payload sign_me_add_specs_astar_sr25519`
+`$ cargo run make --goal qr -crypto none --msg add-specs --payload sign_me_add_specs_astar_sr25519`
 
 Now there is a scannable qr code with network specs in `../files/signed` folder named `add_specs_astar-sr25519_unverified`.
 Scan it to add the network into Signer.
 
 `$ cargo run load-metadata -d -u wss://rpc.astar.network`
-`$ cargo run make --goal qr -crypto none -msgtype load-metadata --payload sign_me_load_metadata_astarV4`
+`$ cargo run make --goal qr -crypto none --msg load-metadata --payload sign_me_load_metadata_astarV4`
 
 Now there is a scannable qr movie with network metadata in `../files/signed` folder, named `load_metadata_astarV4_unverified`.
 Scan it to add the metadata into Signer.

--- a/rust/generate_message/address_book
+++ b/rust/generate_message/address_book
@@ -143,8 +143,8 @@ wss://alphaville.zero.io				ok
 ===
 How do I add a custom network into Signer?
 
-`$ cargo run add_specs -d -u wss://rpc.astar.network -sr25519`
-`$ cargo run make -qr -crypto none -msgtype add_specs -payload sign_me_add_specs_astar_sr25519`
+`$ cargo run add-specs -d -u wss://rpc.astar.network -sr25519`
+`$ cargo run make -qr -crypto none -msgtype add-specs -payload sign_me_add_specs_astar_sr25519`
 
 Now there is a scannable qr code with network specs in `../files/signed` folder named `add_specs_astar-sr25519_unverified`.
 Scan it to add the network into Signer.

--- a/rust/generate_message/address_book
+++ b/rust/generate_message/address_book
@@ -144,13 +144,13 @@ wss://alphaville.zero.io				ok
 How do I add a custom network into Signer?
 
 `$ cargo run add-specs -d -u wss://rpc.astar.network --encryption sr25519`
-`$ cargo run make --goal qr -crypto none --msg add-specs --payload sign_me_add_specs_astar_sr25519`
+`$ cargo run make --goal qr --crypto none --msg add-specs --payload sign_me_add_specs_astar_sr25519`
 
 Now there is a scannable qr code with network specs in `../files/signed` folder named `add_specs_astar-sr25519_unverified`.
 Scan it to add the network into Signer.
 
 `$ cargo run load-metadata -d -u wss://rpc.astar.network`
-`$ cargo run make --goal qr -crypto none --msg load-metadata --payload sign_me_load_metadata_astarV4`
+`$ cargo run make --goal qr --crypto none --msg load-metadata --payload sign_me_load_metadata_astarV4`
 
 Now there is a scannable qr movie with network metadata in `../files/signed` folder, named `load_metadata_astarV4_unverified`.
 Scan it to add the metadata into Signer.

--- a/rust/generate_message/address_book
+++ b/rust/generate_message/address_book
@@ -149,8 +149,8 @@ How do I add a custom network into Signer?
 Now there is a scannable qr code with network specs in `../files/signed` folder named `add_specs_astar-sr25519_unverified`.
 Scan it to add the network into Signer.
 
-`$ cargo run load_metadata -d -u wss://rpc.astar.network`
-`$ cargo run make -qr -crypto none -msgtype load_metadata -payload sign_me_load_metadata_astarV4`
+`$ cargo run load-metadata -d -u wss://rpc.astar.network`
+`$ cargo run make -qr -crypto none -msgtype load-metadata -payload sign_me_load_metadata_astarV4`
 
 Now there is a scannable qr movie with network metadata in `../files/signed` folder, named `load_metadata_astarV4_unverified`.
 Scan it to add the metadata into Signer.

--- a/rust/generate_message/address_book
+++ b/rust/generate_message/address_book
@@ -144,13 +144,13 @@ wss://alphaville.zero.io				ok
 How do I add a custom network into Signer?
 
 `$ cargo run add-specs -d -u wss://rpc.astar.network --encryption sr25519`
-`$ cargo run make -qr -crypto none -msgtype add-specs -payload sign_me_add_specs_astar_sr25519`
+`$ cargo run make --goal qr -crypto none -msgtype add-specs --payload sign_me_add_specs_astar_sr25519`
 
 Now there is a scannable qr code with network specs in `../files/signed` folder named `add_specs_astar-sr25519_unverified`.
 Scan it to add the network into Signer.
 
 `$ cargo run load-metadata -d -u wss://rpc.astar.network`
-`$ cargo run make -qr -crypto none -msgtype load-metadata -payload sign_me_load_metadata_astarV4`
+`$ cargo run make --goal qr -crypto none -msgtype load-metadata --payload sign_me_load_metadata_astarV4`
 
 Now there is a scannable qr movie with network metadata in `../files/signed` folder, named `load_metadata_astarV4_unverified`.
 Scan it to add the metadata into Signer.

--- a/rust/generate_message/address_book
+++ b/rust/generate_message/address_book
@@ -143,7 +143,7 @@ wss://alphaville.zero.io				ok
 ===
 How do I add a custom network into Signer?
 
-`$ cargo run add-specs -d -u wss://rpc.astar.network -sr25519`
+`$ cargo run add-specs -d -u wss://rpc.astar.network --encryption sr25519`
 `$ cargo run make -qr -crypto none -msgtype add-specs -payload sign_me_add_specs_astar_sr25519`
 
 Now there is a scannable qr code with network specs in `../files/signed` folder named `add_specs_astar-sr25519_unverified`.

--- a/rust/generate_message/src/derivations.rs
+++ b/rust/generate_message/src/derivations.rs
@@ -18,7 +18,7 @@
 //!
 //! Example command line to generate derivations import QR:
 //!
-//! `$ cargo run derivations -qr -title westend-sr25519 -payload
+//! `$ cargo run derivations -qr --title westend-sr25519 -payload
 //! my_westend_set.txt`
 use db_handling::identities::prepare_derivations_import;
 use qrcode_rtx::make_pretty_qr;

--- a/rust/generate_message/src/helpers.rs
+++ b/rust/generate_message/src/helpers.rs
@@ -112,7 +112,7 @@ where
     }
 }
 
-/// Update the database after `add_specs` run.
+/// Update the database after `add-specs` run.
 ///
 /// Inputs `&str` URL address that was used for RPC calls and already completed
 /// [`NetworkSpecsToSend`].
@@ -789,7 +789,7 @@ fn common_specs_fetch(address: &str) -> Result<CommonSpecsFetch> {
 /// Check known [`NetworkSpecsToSend`] with network data fetched and apply token
 /// override.
 ///
-/// This is a helper function for `add_specs` runs with `-n` reference key, i.e.
+/// This is a helper function for `add-specs` runs with `-n` reference key, i.e.
 /// for cases when *some* network specs entry already exists in the database.
 ///
 /// Input [`NetworkSpecsToSend`] is the entry from the database to which the

--- a/rust/generate_message/src/helpers.rs
+++ b/rust/generate_message/src/helpers.rs
@@ -167,7 +167,7 @@ pub fn error_occured(e: Error, pass_errors: bool) -> Result<()> {
     }
 }
 
-/// Content to print during `load_metadata <-k/-p/-t>` processing.
+/// Content to print during `load-metadata<-k/-p/-t>` processing.
 pub enum Write {
     /// all payloads, `-t` key or no setting key was used
     All,
@@ -536,7 +536,7 @@ where
     sort_metavalues(known_metavalues)
 }
 
-/// Update the database after `load_metadata` run.
+/// Update the database after `load-metadata` run.
 ///
 /// Clear [`METATREE`] tree of the hot database and write new metadata set in
 /// it.

--- a/rust/generate_message/src/interpret_specs.rs
+++ b/rust/generate_message/src/interpret_specs.rs
@@ -32,7 +32,7 @@
 //!
 //! Command line with token override:
 //!
-//! `$ cargo run add-specs -d -u <url_address> -sr25519 -token <decimals> <unit>`
+//! `$ cargo run add-specs -d -u <url_address> --encryption sr25519 -token <decimals> <unit>`
 use definitions::network_specs::NetworkProperties;
 use serde_json::{map::Map, value::Value};
 use std::convert::TryInto;

--- a/rust/generate_message/src/interpret_specs.rs
+++ b/rust/generate_message/src/interpret_specs.rs
@@ -32,7 +32,7 @@
 //!
 //! Command line with token override:
 //!
-//! `$ cargo run add-specs -d -u <url_address> --encryption sr25519 -token <decimals> <unit>`
+//! `$ cargo run add-specs -d -u <url_address> --encryption sr25519 --token-decimals <decimals> --token-unit <unit>`
 use definitions::network_specs::NetworkProperties;
 use serde_json::{map::Map, value::Value};
 use std::convert::TryInto;
@@ -72,7 +72,7 @@ pub fn interpret_properties(
                 (token_override.decimals, token_override.unit)
             } else {
                 // token override is possible, but not called for by the user
-                println!("Network supports several tokens. An array of tokenDecimals {} and an array of tokenSymbol {} were fetched. By default, decimals value will be set to 0, and unit value will be set to UNIT. To override, use -token <value_decimals> <value_unit>. To improve this behavior, please file a ticket.", decimals, unit);
+                println!("Network supports several tokens. An array of tokenDecimals {} and an array of tokenSymbol {} were fetched. By default, decimals value will be set to 0, and unit value will be set to UNIT. To override, use --token-decimals <value_decimals> --token-unit <value_unit>. To improve this behavior, please file a ticket.", decimals, unit);
                 (0, String::from("UNIT"))
             }
         }

--- a/rust/generate_message/src/interpret_specs.rs
+++ b/rust/generate_message/src/interpret_specs.rs
@@ -32,7 +32,7 @@
 //!
 //! Command line with token override:
 //!
-//! `$ cargo run add_specs -d -u <url_address> -sr25519 -token <decimals> <unit>`
+//! `$ cargo run add-specs -d -u <url_address> -sr25519 -token <decimals> <unit>`
 use definitions::network_specs::NetworkProperties;
 use serde_json::{map::Map, value::Value};
 use std::convert::TryInto;

--- a/rust/generate_message/src/lib.rs
+++ b/rust/generate_message/src/lib.rs
@@ -753,7 +753,7 @@
 //!    - `text` will generate only text file with hex-encoded update.
 //!    - default, i.e. if goal is not provided, both QR code and text file are generated.
 //!
-//! - Key `-crypto` followed by encryption used to make update signature:
+//! - Key `--crypto` followed by encryption used to make update signature:
 //!    - `ed25519`
 //!    - `sr25519`
 //!    - `ecdsa`
@@ -764,7 +764,7 @@
 //!    - `load-metadata`
 //!    - `add-specs`
 //!
-//! - Key `-verifier` (can be entered only if the `-crypto` argument was
+//! - Key `-verifier` (can be entered only if the `--crypto` argument was
 //! `ed25519`, `sr25519`, or `ecdsa`), followed by:
 //!    - `Alice` to generate messages "verified" by
 //! [Alice seed phrase](constants::ALICE_SEED_PHRASE) with derivation `//Alice`
@@ -776,7 +776,7 @@
 //! [`FOLDER`](constants::FOLDER) containing already generated payload as
 //! raw bytes
 //!
-//! - Key `-signature` (can be entered only if the `-crypto` argument was
+//! - Key `-signature` (can be entered only if the `--crypto` argument was
 //! `ed25519`, `sr25519`, or `ecdsa` **and** `-verifier` is not `Alice`),
 //! followed by:
 //!    - `-hex` followed by hex signature
@@ -833,7 +833,7 @@
 //!
 //! #### `make` for external signature
 //!
-//! `$ cargo run make --goal qr -crypto <encryption> --msg load-metadata
+//! `$ cargo run make --goal qr --crypto <encryption> --msg load-metadata
 //! -verifier -hex <public key> --payload sign_me_load_metadata_westendV9200
 //! -signature -hex <signature>`
 //!

--- a/rust/generate_message/src/lib.rs
+++ b/rust/generate_message/src/lib.rs
@@ -720,7 +720,7 @@
 //!
 //! <table>
 //!     <tr>
-//!         <th><code>msgtype</code></th>
+//!         <th><code>msg</code></th>
 //!         <th>default update file name</th>
 //!     </tr>
 //!     <tr>
@@ -759,7 +759,7 @@
 //!    - `ecdsa`
 //!    - `none` if the message is not verified
 //!
-//! - Key `-msgtype` followed by update type:
+//! - Key `--msg` followed by update type:
 //!    - `load-types`
 //!    - `load-metadata`
 //!    - `add-specs`
@@ -804,10 +804,10 @@
 //! [`FOLDER`](constants::FOLDER) for raw bytes file with contents of
 //! Signer-produced `SufficientCrypto` QR code
 //!
-//! - Key `-msgtype` followed by message type:
+//! - Key `-msg` followed by message type:
 //!    - `load-types`
 //!    - `load-metadata`
-//!    - `add_specs`
+//!    - `add-specs`
 //!
 //! - Key `--payload` followed by file path in dedicated
 //! [`FOLDER`](constants::FOLDER) containing already generated payload as
@@ -833,7 +833,7 @@
 //!
 //! #### `make` for external signature
 //!
-//! `$ cargo run make --goal qr -crypto <encryption> -msgtype load-metadata
+//! `$ cargo run make --goal qr -crypto <encryption> --msg load-metadata
 //! -verifier -hex <public key> --payload sign_me_load_metadata_westendV9200
 //! -signature -hex <signature>`
 //!
@@ -896,7 +896,7 @@
 //!
 //! `$ cargo run sign --goal qr --sufficient-hex
 //! 0146ebddef8cd9bb167dc30878d7113b7e168e6f0646beffd77d69d39bad76b47aceef7c58b5f952b6233b8aba5beb6f0000c8ca7f7cc16b7ada7cd45026fc3f3ec2289dd90dab0dfac38dfe3be843231443ddd30a3f3bbabb5cefcd2bbcef908c
-//! --msgtype load-metadata --payload sign_me_load_metadata_westendV9200`
+//! --msg load-metadata --payload sign_me_load_metadata_westendV9200`
 //!
 //! ## Remove a single metadata entry from the `METATREE`
 //!

--- a/rust/generate_message/src/lib.rs
+++ b/rust/generate_message/src/lib.rs
@@ -317,14 +317,14 @@
 //! `--all` key could be used with `--pass-errors` key, to stop processing after first
 //! error.
 //!
-//! Override key specifying encryption algorithm supported by the network is
-//! optional for `--name` reference key (since there is already an entry in the
-//! database with specified encryption) and mandatory for `--url` reference key.
+//! `--encryption` key to override specifying encryption algorithm supported by the
+//! network is optional for `--name` reference key (since there is already an entry in
+//! the database with specified encryption) and mandatory for `--url` reference key.
 //! Supported variants are:
 //!
-//! - `-ed25519`
-//! - `-sr25519`
-//! - `-ecdsa`
+//! - `ed25519`
+//! - `sr25519`
+//! - `ecdsa`
 //!
 //! Sequence invoking token override could be used when processing an
 //! individual network that has multiple allowed decimals and unit values

--- a/rust/generate_message/src/lib.rs
+++ b/rust/generate_message/src/lib.rs
@@ -744,16 +744,14 @@
 //!
 //! ### `make` command
 //!
-//! `$ cargo run make <optional_target_key> <keys> <arguments>`
+//! `$ cargo run make <keys> <arguments>`
 //!
 //! Keys to be used in command line:
 //!
-//! - `<optional_target_key>`: `-qr` will generate only apng QR code, `-text`
-//! will generate only text file with hex-encoded update. By default, i.e. if
-//! content key is not provided, both QR code and text file are generated.
-//! `<optional_target_key>` is expected immediately after `make` command, if at
-//! all; keys to follow could go in any order, but with argument immediately
-//! following the key.
+//! - Key `--goal` followed by the type to to generate
+//!    - `qr` will generate only a png QR code
+//!    - `text` will generate only text file with hex-encoded update.
+//!    - default, i.e. if goal is not provided, both QR code and text file are generated.
 //!
 //! - Key `-crypto` followed by encryption used to make update signature:
 //!    - `ed25519`
@@ -790,16 +788,14 @@
 //!
 //! ### `sign` command
 //!
-//! `$ cargo run make <optional_target_key> <keys> <arguments>`
+//! `$ cargo run make <keys> <arguments>`
 //!
 //! Keys to be used in command line:
 //!
-//! - `<optional_target_key>`: `-qr` will generate only apng QR code, `-text`
-//! will generate only text file with hex-encoded update. By default, i.e. if
-//! content key is not provided, both QR code and text file are generated.
-//! `<optional_target_key>` is expected immediately after `sign` command, if at
-//! all; keys to follow could go in any order, but with argument immediately
-//! following the key.
+//! - Key `--goal` followed by the type to to generate
+//!    - `qr` will generate only a png QR code
+//!    - `text` will generate only text file with hex-encoded update.
+//!    - default, i.e. if goal is not provided, both QR code and text file are generated.
 //!
 //! - Key `-sufficient` followed by:
 //!    - `-hex` followed by hexadecimal string with contents of Signer-produced
@@ -837,7 +833,7 @@
 //!
 //! #### `make` for external signature
 //!
-//! `$ cargo run make -qr -crypto <encryption> -msgtype load-metadata
+//! `$ cargo run make --goal qr -crypto <encryption> -msgtype load-metadata
 //! -verifier -hex <public key> --payload sign_me_load_metadata_westendV9200
 //! -signature -hex <signature>`
 //!

--- a/rust/generate_message/src/lib.rs
+++ b/rust/generate_message/src/lib.rs
@@ -774,7 +774,7 @@
 //!    - `-file` followed by the path in dedicated [`FOLDER`](constants::FOLDER)
 //! for file with public key as raw bytes
 //!
-//! - Key `-payload` followed by file path in dedicated
+//! - Key `--payload` followed by file path in dedicated
 //! [`FOLDER`](constants::FOLDER) containing already generated payload as
 //! raw bytes
 //!
@@ -813,7 +813,7 @@
 //!    - `load-metadata`
 //!    - `add_specs`
 //!
-//! - Key `-payload` followed by file path in dedicated
+//! - Key `--payload` followed by file path in dedicated
 //! [`FOLDER`](constants::FOLDER) containing already generated payload as
 //! raw bytes
 //!
@@ -838,7 +838,7 @@
 //! #### `make` for external signature
 //!
 //! `$ cargo run make -qr -crypto <encryption> -msgtype load-metadata
-//! -verifier -hex <public key> -payload sign_me_load_metadata_westendV9200
+//! -verifier -hex <public key> --payload sign_me_load_metadata_westendV9200
 //! -signature -hex <signature>`
 //!
 //! Here `<signature>` is hexadecimal signature generated for the contents of

--- a/rust/generate_message/src/lib.rs
+++ b/rust/generate_message/src/lib.rs
@@ -328,10 +328,10 @@
 //!
 //! Sequence invoking token override could be used when processing an
 //! individual network that has multiple allowed decimals and unit values
-//! retrieved as arrays of equal size. To override token, key `--token` followed
-//! by `u8` decimals value and `String` unit value is used. By default, if no
-//! token override in provided, such networks have `0u8` decimals and `UNIT`
-//! unit set up.
+//! retrieved as arrays of equal size. To override token, key `--token-decimals`
+//! followed by `u8` decimals value and key `--token-unit` `String` unit value is used.
+//! By default, if no token override in provided, such networks have `0u8` decimals
+//! and `UNIT` unit set up.
 //!
 //! Title override could be used when processing an individual network, to set
 //! the title under which the network will be displayed in Signer, should the

--- a/rust/generate_message/src/lib.rs
+++ b/rust/generate_message/src/lib.rs
@@ -19,7 +19,7 @@
 //! updates:
 //!
 //! - `add-specs`, to add a new network (i.e. the network specs) into the Signer
-//! - `load_metadata`, to load into the Signer the network metadata, for
+//! - `load-metadata`, to load into the Signer the network metadata, for
 //! networks that already have corresponding network specs entry in the Signer
 //! database
 //! - `load_types`, to load types information (it is used to support the
@@ -31,7 +31,7 @@
 //! - `PNG` QR codes, static or dynamic multiframe depending on the data size
 //! - hex-encoded string (for tests)
 //!
-//! Information in `add-specs`, `load_metadata` and `load_types` could be either
+//! Information in `add-specs`, `load-metadata` and `load_types` could be either
 //! signed or unsigned. Using signed updates is strongly encouraged.
 //!
 //! Update has following general structure:
@@ -538,7 +538,7 @@
 //! `-a` key could be used with `--pass-errors` key, to stop processing after first
 //! error.
 //!
-//! `load_metadata` has no overrides available. Not all setting and reference
+//! `load-metadata` has no overrides available. Not all setting and reference
 //! key combinations are compatible, and not all overrides are supported. Users
 //! are encouraged to comment if they need some other than current key
 //! combinations available.
@@ -728,7 +728,7 @@
 //!         <td><code>add_specs_&ltnetwork_name&gt-&ltnetwork_encryption&gt</code></td>
 //!     </tr>
 //!     <tr>
-//!         <td><code>load_metadata</code></td>
+//!         <td><code>load-metadata</code></td>
 //!         <td><code>load_metadata_&ltnetwork_name&gtV&ltmetadata_version&gt</code></td>
 //!     </tr>
 //!     <tr>
@@ -763,7 +763,7 @@
 //!
 //! - Key `-msgtype` followed by update type:
 //!    - `load_types`
-//!    - `load_metadata`
+//!    - `load-metadata`
 //!    - `add-specs`
 //!
 //! - Key `-verifier` (can be entered only if the `-crypto` argument was
@@ -810,7 +810,7 @@
 //!
 //! - Key `-msgtype` followed by message type:
 //!    - `load_types`
-//!    - `load_metadata`
+//!    - `load-metadata`
 //!    - `add_specs`
 //!
 //! - Key `-payload` followed by file path in dedicated
@@ -837,7 +837,7 @@
 //!
 //! #### `make` for external signature
 //!
-//! `$ cargo run make -qr -crypto <encryption> -msgtype load_metadata
+//! `$ cargo run make -qr -crypto <encryption> -msgtype load-metadata
 //! -verifier -hex <public key> -payload sign_me_load_metadata_westendV9200
 //! -signature -hex <signature>`
 //!

--- a/rust/generate_message/src/lib.rs
+++ b/rust/generate_message/src/lib.rs
@@ -764,7 +764,7 @@
 //!    - `load-metadata`
 //!    - `add-specs`
 //!
-//! - Key `-verifier` (can be entered only if the `--crypto` argument was
+//! - Key `--verifier` (can be entered only if the `--crypto` argument was
 //! `ed25519`, `sr25519`, or `ecdsa`), followed by:
 //!    - `Alice` to generate messages "verified" by
 //! [Alice seed phrase](constants::ALICE_SEED_PHRASE) with derivation `//Alice`
@@ -777,7 +777,7 @@
 //! raw bytes
 //!
 //! - Key `-signature` (can be entered only if the `--crypto` argument was
-//! `ed25519`, `sr25519`, or `ecdsa` **and** `-verifier` is not `Alice`),
+//! `ed25519`, `sr25519`, or `ecdsa` **and** `--verifier` is not `Alice`),
 //! followed by:
 //!    - `-hex` followed by hex signature
 //!    - `-file` followed by the path in dedicated [`FOLDER`](constants::FOLDER)
@@ -834,8 +834,8 @@
 //! #### `make` for external signature
 //!
 //! `$ cargo run make --goal qr --crypto <encryption> --msg load-metadata
-//! -verifier -hex <public key> --payload sign_me_load_metadata_westendV9200
-//! -signature -hex <signature>`
+//! --verifier-hex <public key> --payload sign_me_load_metadata_westendV9200
+//! --signature -hex <signature>`
 //!
 //! Here `<signature>` is hexadecimal signature generated for the contents of
 //! the payload file for `<public_key>` using `<encryption>` algorithm.

--- a/rust/generate_message/src/lib.rs
+++ b/rust/generate_message/src/lib.rs
@@ -455,7 +455,7 @@
 //!
 //! Make `add-specs` update payload for a new network:
 //!
-//! `$ cargo run add-specs -d -u wss://rococo-rpc.polkadot.io --encryption sr25519 -title Rococo`
+//! `$ cargo run add-specs -d -u wss://rococo-rpc.polkadot.io --encryption sr25519 --title Rococo`
 //!
 //! Make `add-specs` update payload for a new network with token set:
 //!

--- a/rust/generate_message/src/lib.rs
+++ b/rust/generate_message/src/lib.rs
@@ -18,7 +18,7 @@
 //! Crate `generate_message` can generate and the Signer can accept following
 //! updates:
 //!
-//! - `add_specs`, to add a new network (i.e. the network specs) into the Signer
+//! - `add-specs`, to add a new network (i.e. the network specs) into the Signer
 //! - `load_metadata`, to load into the Signer the network metadata, for
 //! networks that already have corresponding network specs entry in the Signer
 //! database
@@ -31,7 +31,7 @@
 //! - `PNG` QR codes, static or dynamic multiframe depending on the data size
 //! - hex-encoded string (for tests)
 //!
-//! Information in `add_specs`, `load_metadata` and `load_types` could be either
+//! Information in `add-specs`, `load_metadata` and `load_types` could be either
 //! signed or unsigned. Using signed updates is strongly encouraged.
 //!
 //! Update has following general structure:
@@ -453,13 +453,13 @@
 //!
 //! `$ cargo run add-specs --name westend-sr25519`
 //!
-//! Make `add_specs` update payload for a new network:
+//! Make `add-specs` update payload for a new network:
 //!
-//! `$ cargo run add_specs -d -u wss://rococo-rpc.polkadot.io --encryption sr25519 -title Rococo`
+//! `$ cargo run add-specs -d -u wss://rococo-rpc.polkadot.io --encryption sr25519 -title Rococo`
 //!
-//! Make `add_specs` update payload for a new network with token set:
+//! Make `add-specs` update payload for a new network with token set:
 //!
-//! `$ cargo run add_specs -d -u wss://acala.polkawallet.io --encryption sr25519 --token-decimals 12 --token-unit ACA --title Acala`
+//! `$ cargo run add-specs -d -u wss://acala.polkawallet.io --encryption sr25519 --token-decimals 12 --token-unit ACA --title Acala`
 //!
 //! ## Prepare `load_metadata` update payload
 //!
@@ -522,7 +522,7 @@
 //!     </tr>
 //! </table>
 //!
-//! Network metadata updates quite often, compared to `add_specs` command there
+//! Network metadata updates quite often, compared to `add-specs` command there
 //! is also setting key `-k` to print only the data that was not in the hot
 //! database before the fetch.
 //!
@@ -724,7 +724,7 @@
 //!         <th>default update file name</th>
 //!     </tr>
 //!     <tr>
-//!         <td><code>add_specs</code></td>
+//!         <td><code>add-specs</code></td>
 //!         <td><code>add_specs_&ltnetwork_name&gt-&ltnetwork_encryption&gt</code></td>
 //!     </tr>
 //!     <tr>
@@ -764,7 +764,7 @@
 //! - Key `-msgtype` followed by update type:
 //!    - `load_types`
 //!    - `load_metadata`
-//!    - `add_specs`
+//!    - `add-specs`
 //!
 //! - Key `-verifier` (can be entered only if the `-crypto` argument was
 //! `ed25519`, `sr25519`, or `ecdsa`), followed by:

--- a/rust/generate_message/src/lib.rs
+++ b/rust/generate_message/src/lib.rs
@@ -776,7 +776,7 @@
 //! [`FOLDER`](constants::FOLDER) containing already generated payload as
 //! raw bytes
 //!
-//! - Key `-signature` (can be entered only if the `--crypto` argument was
+//! - Key `--signature` (can be entered only if the `--crypto` argument was
 //! `ed25519`, `sr25519`, or `ecdsa` **and** `--verifier` is not `Alice`),
 //! followed by:
 //!    - `-hex` followed by hex signature
@@ -835,7 +835,7 @@
 //!
 //! `$ cargo run make --goal qr --crypto <encryption> --msg load-metadata
 //! --verifier-hex <public key> --payload sign_me_load_metadata_westendV9200
-//! --signature -hex <signature>`
+//! --signature-hex <signature>`
 //!
 //! Here `<signature>` is hexadecimal signature generated for the contents of
 //! the payload file for `<public_key>` using `<encryption>` algorithm.

--- a/rust/generate_message/src/lib.rs
+++ b/rust/generate_message/src/lib.rs
@@ -22,7 +22,7 @@
 //! - `load-metadata`, to load into the Signer the network metadata, for
 //! networks that already have corresponding network specs entry in the Signer
 //! database
-//! - `load_types`, to load types information (it is used to support the
+//! - `load-types`, to load types information (it is used to support the
 //! transactions parsing in networks with legacy metadata, `RuntimeMetadata`
 //! version below `V14`)
 //!
@@ -31,7 +31,7 @@
 //! - `PNG` QR codes, static or dynamic multiframe depending on the data size
 //! - hex-encoded string (for tests)
 //!
-//! Information in `add-specs`, `load-metadata` and `load_types` could be either
+//! Information in `add-specs`, `load-metadata` and `load-types` could be either
 //! signed or unsigned. Using signed updates is strongly encouraged.
 //!
 //! Update has following general structure:
@@ -732,7 +732,7 @@
 //!         <td><code>load_metadata_&ltnetwork_name&gtV&ltmetadata_version&gt</code></td>
 //!     </tr>
 //!     <tr>
-//!         <td><code>load_types</code></td>
+//!         <td><code>load-types</code></td>
 //!         <td><code>load_types</code></td>
 //!     </tr>
 //! </table>
@@ -762,7 +762,7 @@
 //!    - `none` if the message is not verified
 //!
 //! - Key `-msgtype` followed by update type:
-//!    - `load_types`
+//!    - `load-types`
 //!    - `load-metadata`
 //!    - `add-specs`
 //!
@@ -809,7 +809,7 @@
 //! Signer-produced `SufficientCrypto` QR code
 //!
 //! - Key `-msgtype` followed by message type:
-//!    - `load_types`
+//!    - `load-types`
 //!    - `load-metadata`
 //!    - `add_specs`
 //!

--- a/rust/generate_message/src/load.rs
+++ b/rust/generate_message/src/load.rs
@@ -2,7 +2,7 @@
 //!
 //! This module deals with processing commands:
 //!
-//! - `$ cargo run load_metadata <key(s)> <(argument)>` to produce
+//! - `$ cargo run load-metadata <key(s)> <(argument)>` to produce
 //! `load_metadata` update payloads from the database entries and through RPC
 //! calls and update the hot database
 //!
@@ -28,14 +28,14 @@ use crate::helpers::{
 };
 use crate::parser::{Content, InstructionMeta, Set};
 
-/// Process `load_metadata` command according to the [`InstructionMeta`]
+/// Process `load-metadata` command according to the [`InstructionMeta`]
 /// received from the command line.
 pub fn gen_load_meta(instruction: InstructionMeta) -> Result<()> {
     match instruction.set.into() {
         // `-f` setting key: produce payload files from existing database
         // entries.
         Set::F => match instruction.content.into() {
-            // `$ cargo run load_metadata -f -a`
+            // `$ cargo run load-metadata -f -a`
             //
             // Make payloads for all metadata entries in the database.
             Content::All { pass_errors } => {
@@ -52,7 +52,7 @@ pub fn gen_load_meta(instruction: InstructionMeta) -> Result<()> {
                 Ok(())
             }
 
-            // `$ cargo run load_metadata -f -n <network_name>`
+            // `$ cargo run load-metadata -f -n <network_name>`
             //
             // Make payload(s) for all metadata entries in the database for
             // network with user-entered name.
@@ -67,7 +67,7 @@ pub fn gen_load_meta(instruction: InstructionMeta) -> Result<()> {
         // `-d` setting key: get network data using RPC calls, **do not**
         // update the database, export payload files.
         Set::D => match instruction.content.into() {
-            // `$ cargo run load_metadata -d -a`
+            // `$ cargo run load-metadata -d -a`
             //
             // Make RPC calls for all networks in `ADDRESS_BOOK`, produce
             // `load_metadata` payload files.
@@ -85,7 +85,7 @@ pub fn gen_load_meta(instruction: InstructionMeta) -> Result<()> {
                 Ok(())
             }
 
-            // `$ cargo run load_metadata -d -n <network_name>`
+            // `$ cargo run load-metadata -d -n <network_name>`
             //
             // Make RPC calls for network with user-entered name and produce
             // `load_metadata` payload file.
@@ -95,7 +95,7 @@ pub fn gen_load_meta(instruction: InstructionMeta) -> Result<()> {
             // be found.
             Content::Name { s: name } => meta_d_n(&name, &instruction.db, &instruction.files_dir),
 
-            // `$ cargo run load_metadata -d -u <url_address>`
+            // `$ cargo run load-metadata -d -u <url_address>`
             //
             // Make RPC calls for network at user-entered URL address and
             // produce `load_metadata` payload file.
@@ -115,7 +115,7 @@ pub fn gen_load_meta(instruction: InstructionMeta) -> Result<()> {
         Set::K => {
             let write = Write::OnlyNew;
             match instruction.content.into() {
-                // `$ cargo run load_metadata -k -a`
+                // `$ cargo run load-metadata -k -a`
                 //
                 // Make RPC calls, update the database as needed and produce
                 // payload files if new data is fetched for all networks in
@@ -128,7 +128,7 @@ pub fn gen_load_meta(instruction: InstructionMeta) -> Result<()> {
                     meta_kpt_a(&write, pass_errors, &instruction.db, &instruction.files_dir)
                 }
 
-                // `$ cargo run load_metadata -k -n <network_name>`
+                // `$ cargo run load-metadata -k -n <network_name>`
                 //
                 // Make RPC calls, update the database as needed and produce
                 // payload file if new data is fetched for network with
@@ -157,7 +157,7 @@ pub fn gen_load_meta(instruction: InstructionMeta) -> Result<()> {
         Set::P => {
             let write = Write::None;
             match instruction.content.into() {
-                // `$ cargo run load_metadata -p -a`
+                // `$ cargo run load-metadata -p -a`
                 //
                 // Make RPC calls and update the database as needed for all
                 // networks in address book.
@@ -167,7 +167,7 @@ pub fn gen_load_meta(instruction: InstructionMeta) -> Result<()> {
                     meta_kpt_a(&write, pass_errors, &instruction.db, &instruction.files_dir)
                 }
 
-                // `$ cargo run load_metadata -p -n <network_name>`
+                // `$ cargo run load-metadata -p -n <network_name>`
                 //
                 // Make RPC calls and update the database as needed for network
                 // with specified name.
@@ -194,7 +194,7 @@ pub fn gen_load_meta(instruction: InstructionMeta) -> Result<()> {
         Set::T => {
             let write = Write::All;
             match instruction.content.into() {
-                // `$ cargo run load_metadata -a`
+                // `$ cargo run load-metadata -a`
                 //
                 // Make RPC calls, update the database as needed and produce
                 // payload files for all networks in address book.
@@ -204,7 +204,7 @@ pub fn gen_load_meta(instruction: InstructionMeta) -> Result<()> {
                     meta_kpt_a(&write, pass_errors, &instruction.db, &instruction.files_dir)
                 }
 
-                // `$ cargo run load_metadata -n <network_name>`
+                // `$ cargo run load-metadata -n <network_name>`
                 //
                 // Make RPC calls, update the database as needed and produce
                 // payload file for network with specified name.
@@ -228,7 +228,7 @@ pub fn gen_load_meta(instruction: InstructionMeta) -> Result<()> {
     }
 }
 
-/// `load_metadata -f -a` for individual [`AddressSpecs`] value.
+/// `load-metadata-f -a` for individual [`AddressSpecs`] value.
 ///
 /// - Get metadata entries from database [`METATREE`] by [`MetaKeyPrefix`]
 /// generated with network name. At most two entries are expected.
@@ -263,7 +263,7 @@ where
     Ok(())
 }
 
-/// `load_metadata -f -n <network_name>`
+/// `load-metadata-f -n <network_name>`
 ///
 /// - Get all available [`AddressSpecs`] from the database and search for the
 /// one with user-entered network name
@@ -278,7 +278,7 @@ where
     meta_f_a_element(&search_name(name, &db_path)?, &db_path, &files_dir)
 }
 
-/// `load_metadata -d -a` for individual [`AddressSpecs`] value.
+/// `load-metadata-d -a` for individual [`AddressSpecs`] value.
 ///
 /// - Fetch network information using RPC calls at `address` in [`AddressSpecs`]
 /// and interpret it
@@ -292,7 +292,7 @@ where
     load_metadata_print(&meta_fetch.cut(), files_dir)
 }
 
-/// `load_metadata -d -n <network_name>`
+/// `load-metadata-d -n <network_name>`
 ///
 /// - Get all available [`AddressSpecs`] from the database and search for the
 /// one with user-entered network name
@@ -307,7 +307,7 @@ where
     meta_d_a_element(&search_name(name, db_path)?, files_dir)
 }
 
-/// `load_metadata -d -u <url_address>`
+/// `load-metadata-d -u <url_address>`
 ///
 /// - Fetch network information using RPC calls at user-entered `address` and
 /// interpret it
@@ -336,7 +336,7 @@ where
     load_metadata_print(&meta_fetched.cut(), files_dir)
 }
 
-/// `load_metadata <-k/-p/-t> -a`
+/// `load-metadata<-k/-p/-t> -a`
 ///
 /// - Get all available [`AddressSpecs`] from the database
 /// - Get and sort existing metadata entries from [`METATREE`], with block
@@ -360,7 +360,7 @@ where
     db_upd_metadata(sorted_meta_values, &db_path)
 }
 
-/// `load_metadata <-k/-p/-t> -a` for individual [`AddressSpecs`] value.
+/// `load-metadata<-k/-p/-t> -a` for individual [`AddressSpecs`] value.
 ///
 /// - Fetch network information using RPC calls at `address` in [`AddressSpecs`]
 /// and interpret it
@@ -407,7 +407,7 @@ where
     Ok(())
 }
 
-/// `load_metadata <-k/-p/-t> -n <network_name>`
+/// `load-metadata<-k/-p/-t> -n <network_name>`
 ///
 /// - Get and sort existing metadata entries from [`METATREE`], with block
 /// data from [`META_HISTORY`](constants::META_HISTORY) if available

--- a/rust/generate_message/src/parser.rs
+++ b/rust/generate_message/src/parser.rs
@@ -659,7 +659,7 @@ pub struct Sufficient {
 /// Payload content details are described in [`definitions::qr_transfers`].
 #[derive(clap::ValueEnum, Clone, Debug)]
 pub enum Msg {
-    /// `load_types` payload
+    /// `load-types` payload
     LoadTypes,
 
     /// `load-metadata` payload

--- a/rust/generate_message/src/parser.rs
+++ b/rust/generate_message/src/parser.rs
@@ -287,7 +287,7 @@ pub enum Show {
     BlockHistory,
 }
 
-/// Command details for `load_metadata`.
+/// Command details for `load-metadata`.
 #[derive(clap::Args, Debug)]
 pub struct InstructionMeta {
     /// Setting key, as read from command line
@@ -378,7 +378,7 @@ impl From<ContentArgs> for Content {
     }
 }
 
-/// Reference key for `load_metadata` and `add-specs` commands.
+/// Reference key for `load-metadata` and `add-specs` commands.
 #[derive(Subcommand, Debug)]
 pub enum Content {
     /// Deal with all relevant database entries
@@ -403,7 +403,7 @@ pub enum Content {
     },
 }
 
-/// Setting key for `load_metadata` and `add-specs` commands.
+/// Setting key for `load-metadata` and `add-specs` commands.
 #[derive(clap::ValueEnum, Clone, Debug)]
 pub enum Set {
     /// Key `-d`: do **not** update the database, make RPC calls, and produce
@@ -662,7 +662,7 @@ pub enum Msg {
     /// `load_types` payload
     LoadTypes,
 
-    /// `load_metadata` payload
+    /// `load-metadata` payload
     LoadMetadata,
 
     /// `add-specs` payload

--- a/rust/generate_message/src/parser.rs
+++ b/rust/generate_message/src/parser.rs
@@ -320,7 +320,7 @@ impl From<SetFlags> for Set {
     }
 }
 
-/// Command details for `add_specs`.
+/// Command details for `add-specs`.
 #[derive(clap::Args, Debug)]
 #[clap(group(clap::ArgGroup::new("referencekey")
                 .required(true)
@@ -330,7 +330,7 @@ pub struct InstructionSpecs {
     #[clap(flatten)]
     pub set: SetFlags,
 
-    /// Overrides, relevant only for `add_specs` command
+    /// Overrides, relevant only for `add-specs` command
     #[clap(flatten)]
     pub over: Override,
 
@@ -378,7 +378,7 @@ impl From<ContentArgs> for Content {
     }
 }
 
-/// Reference key for `load_metadata` and `add_specs` commands.
+/// Reference key for `load_metadata` and `add-specs` commands.
 #[derive(Subcommand, Debug)]
 pub enum Content {
     /// Deal with all relevant database entries
@@ -403,7 +403,7 @@ pub enum Content {
     },
 }
 
-/// Setting key for `load_metadata` and `add_specs` commands.
+/// Setting key for `load_metadata` and `add-specs` commands.
 #[derive(clap::ValueEnum, Clone, Debug)]
 pub enum Set {
     /// Key `-d`: do **not** update the database, make RPC calls, and produce
@@ -665,7 +665,7 @@ pub enum Msg {
     /// `load_metadata` payload
     LoadMetadata,
 
-    /// `add_specs` payload
+    /// `add-specs` payload
     AddSpecs,
 }
 
@@ -704,7 +704,7 @@ pub struct Derivations {
     pub db: PathBuf,
 }
 
-/// Overrides for `add_specs` command.
+/// Overrides for `add-specs` command.
 #[derive(Args, Debug)]
 pub struct Override {
     /// [`Encryption`] override to specify encryption algorithm used by a new

--- a/rust/generate_message/src/remove.rs
+++ b/rust/generate_message/src/remove.rs
@@ -26,7 +26,7 @@
 //!
 //! ### Command line
 //!
-//! `$ cargo run remove -title <address_book_title>`
+//! `$ cargo run remove title <address_book_title>`
 //!
 //! Network title in the address book is unique identifier for a network with
 //! given encryption. It always is constructed as
@@ -51,7 +51,7 @@
 //!
 //! ### Example
 //!
-//! `$ cargo run remove -title westend-sr25519`
+//! `$ cargo run remove title westend-sr25519`
 //!
 //! If one of the default networks gets removed, it could be added back,
 //! however, it will not be marked as default anymore.

--- a/rust/generate_message/src/specs.rs
+++ b/rust/generate_message/src/specs.rs
@@ -2,7 +2,7 @@
 //!
 //! This module deals with processing command
 //!
-//! `$ cargo run add_specs <keys> <argument(s)>`
+//! `$ cargo run add-specs <keys> <argument(s)>`
 use definitions::{crypto::Encryption, keyring::NetworkSpecsKey, metadata::AddressBookEntry};
 use std::path::Path;
 
@@ -15,14 +15,14 @@ use crate::helpers::{
 };
 use crate::parser::{Content, InstructionSpecs, Override, Set, Token};
 
-/// Process `add_specs` command according to the [`InstructionSpecs`] received
+/// Process `add-specs` command according to the [`InstructionSpecs`] received
 /// from the command line.
 pub fn gen_add_specs(instruction: InstructionSpecs) -> Result<()> {
     match instruction.set.into() {
         // `-f` setting key: produce `add_specs` payload files from existing
         // database entries.
         Set::F => match instruction.content.clone().into() {
-            // `$ cargo run add_specs -f -a`
+            // `$ cargo run add-specs -f -a`
             //
             // Make `add_specs` payloads for all specs entries in the database.
             Content::All { pass_errors: _ } => {
@@ -45,7 +45,7 @@ pub fn gen_add_specs(instruction: InstructionSpecs) -> Result<()> {
                 Ok(())
             }
 
-            // `$ cargo run add_specs -f -n <address_book_title>
+            // `$ cargo run add-specs -f -n <address_book_title>
             // <optional encryption override> <optional signer title override>`
             //
             // Make `add_specs` payload for single specs entry from the
@@ -86,7 +86,7 @@ pub fn gen_add_specs(instruction: InstructionSpecs) -> Result<()> {
             // Same as `-d -a` combination, of no use.
             Content::Name { .. } => Err(Error::NotSupported),
 
-            // `$ cargo run add_specs -d -u network_url_address
+            // `$ cargo run add-specs -d -u network_url_address
             // <encryption override> <optional token override> <optional signer
             // title override>`
             //
@@ -131,7 +131,7 @@ pub fn gen_add_specs(instruction: InstructionSpecs) -> Result<()> {
             // use.
             Content::All { pass_errors: _ } => Err(Error::NotSupported),
 
-            // `$ cargo run add_specs -p -n network_address_book_title
+            // `$ cargo run add-specs -p -n network_address_book_title
             // <encryption override> <optional title override>
             // <optional token override>`
             //
@@ -154,7 +154,7 @@ pub fn gen_add_specs(instruction: InstructionSpecs) -> Result<()> {
                 )
             }
 
-            // `$ cargo run add_specs -p -u network_url_address
+            // `$ cargo run add-specs -p -u network_url_address
             // <encryption override> <optional token override>`
             //
             // Update the database by making RPC calls at `network_url_address`.
@@ -191,7 +191,7 @@ pub fn gen_add_specs(instruction: InstructionSpecs) -> Result<()> {
             // this command seems to be of no use.
             Content::All { pass_errors: _ } => Err(Error::NotSupported),
 
-            // `$ cargo run add_specs -n network_address_book_title
+            // `$ cargo run add-specs -n network_address_book_title
             // <encryption override>`
             //
             // Network already has an entry in the database and could be
@@ -210,7 +210,7 @@ pub fn gen_add_specs(instruction: InstructionSpecs) -> Result<()> {
                 instruction.files_dir,
             ),
 
-            // `$ cargo run add_specs -u network_url_address
+            // `$ cargo run add-specs -u network_url_address
             // <encryption override> <optional token override>`
             //
             // Update the database by making RPC calls at `network_url_address`
@@ -243,7 +243,7 @@ pub fn gen_add_specs(instruction: InstructionSpecs) -> Result<()> {
     }
 }
 
-/// `add_specs -f -a` for individual address book entry.
+/// `add-specs -f -a` for individual address book entry.
 ///
 /// - Get network specs
 /// [`NetworkSpecsToSend`](definitions::network_specs::NetworkSpecsToSend) from
@@ -257,7 +257,7 @@ where
     add_specs_print(&network_specs, files_dir)
 }
 
-/// `add_specs -f -n <address_book_title> <override(s)>`
+/// `add-specs -f -n <address_book_title> <override(s)>`
 ///
 /// Token override is not allowed. Encryption and title override are optional.
 /// Overrides are used to modify the entry for specified address book title.
@@ -299,7 +299,7 @@ where
     }
 }
 
-/// `add_specs -d -u <url_address> <override(s)>`
+/// `add-specs -d -u <url_address> <override(s)>`
 ///
 /// Encryption override is mandatory. Title override is optional. Token override
 /// is possible if token set is fetched.
@@ -328,7 +328,7 @@ where
     add_specs_print(&specs, &files_dir)
 }
 
-/// `add_specs <-p/-t> -n <address_book_title> <override(s)>`
+/// `add-specs <-p/-t> -n <address_book_title> <override(s)>`
 ///
 /// Encryption and title overrides are possible. Token override is possible if
 /// network has token set.
@@ -448,7 +448,7 @@ where
     }
 }
 
-/// `add_specs <-p/-t> -u <url_address> <override(s)>`
+/// `add-specs <-p/-t> -u <url_address> <override(s)>`
 ///
 /// Encryption override is mandatory. Title override is optional. Token override
 /// is possible if token set is fetched.


### PR DESCRIPTION
## Purpose

Fixing a pile of out of date documentation around arguments and commands

This PR aims to address issue: #1253 

## Scope
- add_specs -> add-specs
- load_metadata -> load-metadata
- load_types -> load-types
- Fix add-spec encryption flag docs
- Fix title flag on add-spec and derivations
- Fix cargo run remove title
- Lots of places where it had one `-` and needed `--`
- Update make goal documentation
- Replace references to the old msgtype with msg 
- Update `--token` with `--token-decimals` and `--token-unit`
- Update the add new network tutorial

## Discussion
- I tried to make the commits do one thing at a time. That might help reviewing if you want to take it commit by commit
- On some of these there is the option of going back to `_`. aka the docs were right and the code was wrong.
- I tried to leave payloads with `_` as that is the spec as opposed to commands and arguments. I've tried not to miss any either way, but this is a lot of search and one-by-one replacements. Someone with more context may want to double check.
