### PR TITLE
chore: make code reusable by metadata-portal

### DIFF
--- a/rust/db_handling/src/identities.rs
+++ b/rust/db_handling/src/identities.rs
@@ -38,7 +38,6 @@ use parity_scale_codec::Encode;
 use regex::Regex;
 #[cfg(feature = "signer")]
 use sled::Batch;
-#[cfg(feature = "active")]
 use sp_core::H256;
 #[cfg(any(feature = "active", feature = "signer"))]
 use sp_core::{ecdsa, ed25519, sr25519, Pair};
@@ -1257,7 +1256,7 @@ fn prepare_secret_key_for_export(
             if public != &ed25519_pair.public() {
                 return Err(Error::WrongPassword);
             }
-            Ok(*ed25519_pair.seed())
+            Ok(ed25519_pair.seed().to_owned())
         }
         MultiSigner::Sr25519(public) => {
             let (sr25519_pair, seed) = sr25519::Pair::from_string_with_seed(full_address, pwd)

--- a/rust/definitions/Cargo.toml
+++ b/rust/definitions/Cargo.toml
@@ -10,7 +10,7 @@ frame-metadata = {version = "15.0.0", features = ["std", "legacy"]}
 hex = "0.4.3"
 parity-scale-codec = {version = "3.1.5", features = ["derive"]}
 plot_icon = {version = "0.2.0", default-features = false, features = ["pix"], optional = true}
-sc-executor-common = {git = "https://github.com/paritytech/substrate", optional = true}
+sc-executor-common = {git = "https://github.com/paritytech/substrate"}
 sc-executor-wasmi = {git = "https://github.com/paritytech/substrate", optional = true}
 sled = "0.34.6"
 sp-core = {git = "https://github.com/paritytech/substrate", default-features = false, features = ["full_crypto"]}
@@ -24,7 +24,6 @@ variant_count = {version = "1.1.0", optional = true}
 [features]
 default = ["test"]
 active = [
-	"sc-executor-common",
 	"sc-executor-wasmi",
 	"sp-io",
 	"sp-wasm-interface",

--- a/rust/definitions/src/keyring.rs
+++ b/rust/definitions/src/keyring.rs
@@ -37,7 +37,6 @@ use sp_runtime::MultiSigner;
 
 #[cfg(feature = "signer")]
 use crate::helpers::{get_multisigner, unhex};
-#[cfg(feature = "active")]
 use crate::{
     crypto::Encryption,
     error::{Error, Result},

--- a/rust/definitions/src/lib.rs
+++ b/rust/definitions/src/lib.rs
@@ -20,7 +20,6 @@ pub mod danger;
 
 pub mod error;
 
-#[cfg(feature = "active")]
 pub mod error_active;
 
 #[cfg(feature = "signer")]

--- a/rust/definitions/src/qr_transfers.rs
+++ b/rust/definitions/src/qr_transfers.rs
@@ -22,6 +22,7 @@
 //! This module deals with content part of QR codes.  
 
 use parity_scale_codec::{Decode, Encode};
+#[cfg(feature = "active")]
 use std::path::Path;
 
 use crate::crypto::Encryption;

--- a/rust/generate_message/src/parser.rs
+++ b/rust/generate_message/src/parser.rs
@@ -598,15 +598,15 @@ impl std::fmt::Display for Goal {
 pub struct Verifier {
     /// Use Alice key with a specified encryption scheme
     #[clap(long, name = "alice", value_parser = encryption_from_args)]
-    verifier_alice: Option<Encryption>,
+    pub verifier_alice: Option<Encryption>,
 
     /// Specify Verifier as a hex string argument
     #[clap(long, name = "HEX")]
-    verifier_hex: Option<String>,
+    pub verifier_hex: Option<String>,
 
     /// Read Verifier from a file
     #[clap(long, name = "FILE")]
-    verifier_file: Option<PathBuf>,
+    pub verifier_file: Option<PathBuf>,
 }
 
 /// Verifier-to-be, for `make` and `sign` commands.
@@ -632,11 +632,11 @@ pub enum Crypto {
 pub struct Signature {
     /// Supply signature in hex format as command line argument
     #[clap(long, value_name = "HEX")]
-    signature_hex: Option<String>,
+    pub signature_hex: Option<String>,
 
     /// Read signature from a file
     #[clap(long, value_name = "FILE")]
-    signature_file: Option<String>,
+    pub signature_file: Option<String>,
 }
 
 #[derive(clap::Args, Debug, Clone)]
@@ -646,11 +646,11 @@ pub struct Signature {
 pub struct Sufficient {
     /// Supply signature in hex format as command line argument
     #[clap(long, value_name = "HEX")]
-    sufficient_hex: Option<String>,
+    pub sufficient_hex: Option<String>,
 
     /// Read signature from a file
     #[clap(long, value_name = "FILE")]
-    sufficient_file: Option<String>,
+    pub sufficient_file: Option<String>,
 }
 /// Payload for `make` and `sign` commands.
 ///


### PR DESCRIPTION
## Purpose
Make code reusable for the `metadata-portal`

## Scope
<!-- What is the technical scope of the changes? i.e.:
- refactored module XYZ
- added unit tests for ABC
-->
- fix imports for `active` and `signer` features
- make `Verifier`,  `Signature` and `Sufficient` fields public
