### PR TITLE
style: add remove key confirmation bottom sheet

### DIFF
--- a/ios/NativeSigner.xcodeproj/project.pbxproj
+++ b/ios/NativeSigner.xcodeproj/project.pbxproj
@@ -192,6 +192,8 @@
 		6DC5643B28B8D189003D540B /* KeychainAccessAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DC5643A28B8D189003D540B /* KeychainAccessAdapter.swift */; };
 		6DC5643D28B91EFE003D540B /* NavbarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DC5643C28B91EFE003D540B /* NavbarButton.swift */; };
 		6DC5644028B929EA003D540B /* KeyDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DC5643F28B929EA003D540B /* KeyDetailsView.swift */; };
+		6DD9FF1628C8B85300FB6195 /* HorizontalActionsBottomModal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DD9FF1528C8B85300FB6195 /* HorizontalActionsBottomModal.swift */; };
+		6DD9FF1928C8C9B000FB6195 /* Animations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DD9FF1828C8C9AF00FB6195 /* Animations.swift */; };
 		6DDEF11028AD105F004CA2FD /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DDEF10F28AD105F004CA2FD /* TabBarView.swift */; };
 		6DDEF11428AD12FA004CA2FD /* Tab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DDEF11328AD12FA004CA2FD /* Tab.swift */; };
 		6DDEF11828AD4215004CA2FD /* TabTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DDEF11728AD4215004CA2FD /* TabTests.swift */; };
@@ -435,6 +437,8 @@
 		6DC5643A28B8D189003D540B /* KeychainAccessAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainAccessAdapter.swift; sourceTree = "<group>"; };
 		6DC5643C28B91EFE003D540B /* NavbarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavbarButton.swift; sourceTree = "<group>"; };
 		6DC5643F28B929EA003D540B /* KeyDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyDetailsView.swift; sourceTree = "<group>"; };
+		6DD9FF1528C8B85300FB6195 /* HorizontalActionsBottomModal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalActionsBottomModal.swift; sourceTree = "<group>"; };
+		6DD9FF1828C8C9AF00FB6195 /* Animations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Animations.swift; sourceTree = "<group>"; };
 		6DDEF10F28AD105F004CA2FD /* TabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
 		6DDEF11328AD12FA004CA2FD /* Tab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tab.swift; sourceTree = "<group>"; };
 		6DDEF11728AD4215004CA2FD /* TabTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabTests.swift; sourceTree = "<group>"; };
@@ -541,6 +545,7 @@
 		2D7A7BC726BA97A50053C1E0 /* Modals */ = {
 			isa = PBXGroup;
 			children = (
+				6DD9FF1428C8B83C00FB6195 /* Alerts */,
 				6D88CFF628C634BC001FB0A1 /* KeySet */,
 				6DC5642C28B652D0003D540B /* AddKeySet */,
 				2DA5F897275F865400D8DD29 /* ModalSelector.swift */,
@@ -762,6 +767,7 @@
 				6DF7751A28B399AC0040012E /* CornerRadius.swift */,
 				6D95E97428B500EE00E28A11 /* Heights.swift */,
 				6DC5642F28B65B9C003D540B /* AnimationDuration.swift */,
+				6DD9FF1828C8C9AF00FB6195 /* Animations.swift */,
 			);
 			path = Design;
 			sourceTree = "<group>";
@@ -1048,6 +1054,14 @@
 				6DF7257728BE0E08007CD9B6 /* DerivedKeyRow.swift */,
 			);
 			path = KeyDetails;
+			sourceTree = "<group>";
+		};
+		6DD9FF1428C8B83C00FB6195 /* Alerts */ = {
+			isa = PBXGroup;
+			children = (
+				6DD9FF1528C8B85300FB6195 /* HorizontalActionsBottomModal.swift */,
+			);
+			path = Alerts;
 			sourceTree = "<group>";
 		};
 		6DDEF11228AD12F2004CA2FD /* ViewModels */ = {
@@ -1365,6 +1379,7 @@
 				2DA5F87627566D7C00D8DD29 /* TransactionPreview.swift in Sources */,
 				6D88CFF228C60AED001FB0A1 /* FullScreenRoundedModal.swift in Sources */,
 				2DAA82AF278874F3002917C0 /* NetworkLogo.swift in Sources */,
+				6DD9FF1928C8C9B000FB6195 /* Animations.swift in Sources */,
 				2DA5F85E27566C3600D8DD29 /* TCFieldName.swift in Sources */,
 				2D78032528294D4C00E4D01E /* ShieldAlertComponent.swift in Sources */,
 				6D57DC4D289D652400005C63 /* Dispatching.swift in Sources */,
@@ -1494,6 +1509,7 @@
 				2DA5F82B2756631D00D8DD29 /* KeyManager.swift in Sources */,
 				2DE72C0F26A99885002BB752 /* RustNative.swift in Sources */,
 				2D48F3AE2770AD6B004B27BE /* NetworkDetailsMenu.swift in Sources */,
+				6DD9FF1628C8B85300FB6195 /* HorizontalActionsBottomModal.swift in Sources */,
 				6D91F3EE28C16163007560F5 /* CircularProgressView.swift in Sources */,
 				6D019973289D183600F4C317 /* NavigationCoordinator.swift in Sources */,
 				6DBD21F7289A798C005D539B /* ErrorDisplayed+Show.swift in Sources */,

--- a/ios/NativeSigner/Components/Buttons/ActionButton.swift
+++ b/ios/NativeSigner/Components/Buttons/ActionButton.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct ActionButtonStyle: ButtonStyle {
     let backgroundColor: Color
     let foregroundColor: Color
+    @Binding var isDisabled: Bool
 
     func makeBody(configuration: Self.Configuration) -> some View {
         configuration.label
@@ -19,26 +20,66 @@ struct ActionButtonStyle: ButtonStyle {
             .frame(height: Heights.actionButton, alignment: .center)
             .cornerRadius(CornerRadius.extraExtraLarge)
             .font(Fontstyle.labelL.base)
+            .disabled(isDisabled)
+    }
+
+    static func primary(isDisabled: Binding<Bool> = Binding<Bool>.constant(false)) -> ActionButtonStyle {
+        ActionButtonStyle(
+            backgroundColor: Asset.accentPink500.swiftUIColor,
+            foregroundColor: (isDisabled.wrappedValue ? Asset.accentForegroundTextDisabled : Asset.accentForegroundText)
+                .swiftUIColor,
+            isDisabled: isDisabled
+        )
+    }
+
+    static func primaryDestructive(isDisabled: Binding<Bool> = Binding<Bool>.constant(false)) -> ActionButtonStyle {
+        ActionButtonStyle(
+            backgroundColor: Asset.accentRed400.swiftUIColor,
+            foregroundColor: (isDisabled.wrappedValue ? Asset.accentForegroundTextDisabled : Asset.accentForegroundText)
+                .swiftUIColor,
+            isDisabled: isDisabled
+        )
+    }
+
+    static func secondary(isDisabled: Binding<Bool> = Binding<Bool>.constant(false)) -> ActionButtonStyle {
+        ActionButtonStyle(
+            backgroundColor: Asset.fill18.swiftUIColor,
+            foregroundColor: (isDisabled.wrappedValue ? Asset.textAndIconsDisabled : Asset.textAndIconsPrimary)
+                .swiftUIColor,
+            isDisabled: isDisabled
+        )
+    }
+
+    static func emptyPrimary(isDisabled: Binding<Bool> = Binding<Bool>.constant(false)) -> ActionButtonStyle {
+        ActionButtonStyle(
+            backgroundColor: .clear,
+            foregroundColor: Asset.textAndIconsPrimary.swiftUIColor,
+            isDisabled: isDisabled
+        )
+    }
+
+    static func emptySecondary(isDisabled: Binding<Bool> = Binding<Bool>.constant(false)) -> ActionButtonStyle {
+        ActionButtonStyle(
+            backgroundColor: .clear,
+            foregroundColor: Asset.textAndIconsSecondary.swiftUIColor,
+            isDisabled: isDisabled
+        )
     }
 }
 
 struct ActionButton: View {
     private let action: () -> Void
     private let text: LocalizedStringKey
-    private let style: ActionButtonStyle
-
-    @Binding var isDisabled: Bool
+    private var style: ActionButtonStyle
 
     init(
-        action: @escaping () -> Void,
+        action: @escaping @autoclosure () -> Void,
         text: LocalizedStringKey,
-        style: ActionButtonStyle,
-        isDisabled: Binding<Bool> = Binding<Bool>.constant(false)
+        style: ActionButtonStyle
     ) {
         self.action = action
         self.text = text
         self.style = style
-        _isDisabled = isDisabled
     }
 
     var body: some View {
@@ -49,6 +90,5 @@ struct ActionButton: View {
             .frame(maxWidth: .infinity)
         }
         .buttonStyle(style)
-        .disabled(isDisabled)
     }
 }

--- a/ios/NativeSigner/Components/Buttons/EmptyButton.swift
+++ b/ios/NativeSigner/Components/Buttons/EmptyButton.swift
@@ -31,63 +31,64 @@ struct EmptyButton: View {
     }
 }
 
-struct EmptyButton_Previews: PreviewProvider {
-    static var previews: some View {
-        VStack(alignment: .center, spacing: 10) {
-            Text("<< Enabled >>")
-            EmptyButton(
-                action: {},
-                text: "Short Title"
-            )
-            .padding(10)
-            EmptyButton(
-                action: {},
-                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-            )
-            .padding(10)
-            Text("<< Disabled >>")
-            EmptyButton(
-                action: {},
-                text: "Short Title",
-                style: .emptyPrimary(isDisabled: Binding<Bool>.constant(true))
-            )
-            .padding(10)
-            EmptyButton(
-                action: {},
-                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-                style: .emptyPrimary(isDisabled: Binding<Bool>.constant(true))
-            )
-            .padding(10)
-        }
-        .preferredColorScheme(.dark)
-        .previewLayout(.sizeThatFits)
-        VStack(alignment: .center, spacing: 10) {
-            Text("<< Enabled >>")
-            EmptyButton(
-                action: {},
-                text: "Short Title"
-            )
-            .padding(10)
-            EmptyButton(
-                action: {},
-                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-            )
-            .padding(10)
-            Text("<< Disabled >>")
-            EmptyButton(
-                action: {},
-                text: "Short Title",
-                style: .emptyPrimary(isDisabled: Binding<Bool>.constant(true))
-            )
-            .padding(10)
-            EmptyButton(
-                action: {},
-                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-                style: .emptyPrimary(isDisabled: Binding<Bool>.constant(true))
-            )
-            .padding(10)
-        }
-        .preferredColorScheme(.light)
-        .previewLayout(.sizeThatFits)
-    }
-}
+//
+// struct EmptyButton_Previews: PreviewProvider {
+//    static var previews: some View {
+//        VStack(alignment: .center, spacing: 10) {
+//            Text("<< Enabled >>")
+//            EmptyButton(
+//                action: {},
+//                text: "Short Title"
+//            )
+//            .padding(10)
+//            EmptyButton(
+//                action: {},
+//                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+//            )
+//            .padding(10)
+//            Text("<< Disabled >>")
+//            EmptyButton(
+//                action: {},
+//                text: "Short Title",
+//                style: .emptyPrimary(isDisabled: Binding<Bool>.constant(true))
+//            )
+//            .padding(10)
+//            EmptyButton(
+//                action: {},
+//                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+//                style: .emptyPrimary(isDisabled: Binding<Bool>.constant(true))
+//            )
+//            .padding(10)
+//        }
+//        .preferredColorScheme(.dark)
+//        .previewLayout(.sizeThatFits)
+//        VStack(alignment: .center, spacing: 10) {
+//            Text("<< Enabled >>")
+//            EmptyButton(
+//                action: {},
+//                text: "Short Title"
+//            )
+//            .padding(10)
+//            EmptyButton(
+//                action: {},
+//                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+//            )
+//            .padding(10)
+//            Text("<< Disabled >>")
+//            EmptyButton(
+//                action: {},
+//                text: "Short Title",
+//                style: .emptyPrimary(isDisabled: Binding<Bool>.constant(true))
+//            )
+//            .padding(10)
+//            EmptyButton(
+//                action: {},
+//                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+//                style: .emptyPrimary(isDisabled: Binding<Bool>.constant(true))
+//            )
+//            .padding(10)
+//        }
+//        .preferredColorScheme(.light)
+//        .previewLayout(.sizeThatFits)
+//    }
+// }

--- a/ios/NativeSigner/Components/Buttons/EmptyButton.swift
+++ b/ios/NativeSigner/Components/Buttons/EmptyButton.swift
@@ -10,91 +10,84 @@ import SwiftUI
 struct EmptyButton: View {
     private let action: () -> Void
     private let text: LocalizedStringKey
-    private let foregroundColor: Color
-    @State var isDisabled: Bool
+    private let style: ActionButtonStyle
 
     init(
         action: @escaping () -> Void,
         text: LocalizedStringKey,
-        isDisabled: Bool = false,
-        foregroundColor: Color = Asset.textAndIconsPrimary.swiftUIColor
+        style: ActionButtonStyle = .emptyPrimary()
     ) {
         self.action = action
         self.text = text
-        self.isDisabled = isDisabled
-        self.foregroundColor = foregroundColor
+        self.style = style
     }
 
     var body: some View {
         ActionButton(
-            action: action,
+            action: action(),
             text: text,
-            style: ActionButtonStyle(
-                backgroundColor: .clear,
-                foregroundColor: foregroundColor
-            ),
-            isDisabled: $isDisabled
+            style: style
         )
     }
 }
 
-// struct EmptyButton_Previews: PreviewProvider {
-//    static var previews: some View {
-//        VStack(alignment: .center, spacing: 10) {
-//            Text("<< Enabled >>")
-//            EmptyButton(
-//                action: {},
-//                text: "Short Title"
-//            )
-//            .padding(10)
-//            EmptyButton(
-//                action: {},
-//                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-//            )
-//            .padding(10)
-//            Text("<< Disabled >>")
-//            EmptyButton(
-//                action: {},
-//                text: "Short Title",
-//                isDisabled: true
-//            )
-//            .padding(10)
-//            EmptyButton(
-//                action: {},
-//                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-//                isDisabled: true
-//            )
-//            .padding(10)
-//        }
-//        .preferredColorScheme(.dark)
-//        .previewLayout(.sizeThatFits)
-//        VStack(alignment: .center, spacing: 10) {
-//            Text("<< Enabled >>")
-//            EmptyButton(
-//                action: {},
-//                text: "Short Title"
-//            )
-//            .padding(10)
-//            EmptyButton(
-//                action: {},
-//                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-//            )
-//            .padding(10)
-//            Text("<< Disabled >>")
-//            EmptyButton(
-//                action: {},
-//                text: "Short Title",
-//                isDisabled: true
-//            )
-//            .padding(10)
-//            EmptyButton(
-//                action: {},
-//                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-//                isDisabled: true
-//            )
-//            .padding(10)
-//        }
-//        .preferredColorScheme(.light)
-//        .previewLayout(.sizeThatFits)
-//    }
-// }
+struct EmptyButton_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack(alignment: .center, spacing: 10) {
+            Text("<< Enabled >>")
+            EmptyButton(
+                action: {},
+                text: "Short Title"
+            )
+            .padding(10)
+            EmptyButton(
+                action: {},
+                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+            )
+            .padding(10)
+            Text("<< Disabled >>")
+            EmptyButton(
+                action: {},
+                text: "Short Title",
+                style: .emptyPrimary(isDisabled: Binding<Bool>.constant(true))
+            )
+            .padding(10)
+            EmptyButton(
+                action: {},
+                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+                style: .emptyPrimary(isDisabled: Binding<Bool>.constant(true))
+            )
+            .padding(10)
+        }
+        .preferredColorScheme(.dark)
+        .previewLayout(.sizeThatFits)
+        VStack(alignment: .center, spacing: 10) {
+            Text("<< Enabled >>")
+            EmptyButton(
+                action: {},
+                text: "Short Title"
+            )
+            .padding(10)
+            EmptyButton(
+                action: {},
+                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+            )
+            .padding(10)
+            Text("<< Disabled >>")
+            EmptyButton(
+                action: {},
+                text: "Short Title",
+                style: .emptyPrimary(isDisabled: Binding<Bool>.constant(true))
+            )
+            .padding(10)
+            EmptyButton(
+                action: {},
+                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+                style: .emptyPrimary(isDisabled: Binding<Bool>.constant(true))
+            )
+            .padding(10)
+        }
+        .preferredColorScheme(.light)
+        .previewLayout(.sizeThatFits)
+    }
+}

--- a/ios/NativeSigner/Components/Buttons/PrimaryButton.swift
+++ b/ios/NativeSigner/Components/Buttons/PrimaryButton.swift
@@ -10,90 +10,108 @@ import SwiftUI
 struct PrimaryButton: View {
     private let action: () -> Void
     private let text: LocalizedStringKey
-
-    @State var isDisabled: Bool
+    private let style: ActionButtonStyle
 
     init(
         action: @escaping () -> Void,
         text: LocalizedStringKey,
-        isDisabled: Bool = false
+        style: ActionButtonStyle = .primary()
     ) {
         self.action = action
         self.text = text
-        self.isDisabled = isDisabled
+        self.style = style
     }
 
     var body: some View {
         ActionButton(
-            action: action,
+            action: action(),
             text: text,
-            style: ActionButtonStyle(
-                backgroundColor: Asset.accentPink500.swiftUIColor,
-                foregroundColor: (isDisabled ? Asset.accentForegroundTextDisabled : Asset.accentForegroundText)
-                    .swiftUIColor
-            ),
-            isDisabled: $isDisabled
+            style: style
         )
     }
 }
 
-// struct PrimaryButton_Previews: PreviewProvider {
-//    static var previews: some View {
-//        VStack(alignment: .center, spacing: 30) {
-//            Text("<< Enabled >>")
-//            PrimaryButton(
-//                action: {},
-//                text: "Short Title"
-//            )
-//            .padding(10)
-//            PrimaryButton(
-//                action: {},
-//                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-//            )
-//            .padding(10)
-//            Text("<< Disabled >>")
-//            PrimaryButton(
-//                action: {},
-//                text: "Short Title",
-//                isDisabled: true
-//            )
-//            .padding(10)
-//            PrimaryButton(
-//                action: {},
-//                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-//                isDisabled: true
-//            )
-//            .padding(10)
-//        }
-//        .preferredColorScheme(.dark)
-//        .previewLayout(.sizeThatFits)
-//        VStack(alignment: .center, spacing: 30) {
-//            Text("<< Enabled >>")
-//            PrimaryButton(
-//                action: {},
-//                text: "Short Title"
-//            )
-//            .padding(10)
-//            PrimaryButton(
-//                action: {},
-//                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-//            )
-//            .padding(10)
-//            Text("<< Disabled >>")
-//            PrimaryButton(
-//                action: {},
-//                text: "Short Title",
-//                isDisabled: true
-//            )
-//            .padding(10)
-//            PrimaryButton(
-//                action: {},
-//                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-//                isDisabled: true
-//            )
-//            .padding(10)
-//        }
-//        .preferredColorScheme(.light)
-//        .previewLayout(.sizeThatFits)
-//    }
-// }
+struct PrimaryButton_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack(alignment: .center, spacing: 30) {
+            Text("<< Enabled >>")
+            PrimaryButton(
+                action: {},
+                text: "Short Title"
+            )
+            .padding(10)
+            PrimaryButton(
+                action: {},
+                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+            )
+            .padding(10)
+            PrimaryButton(
+                action: {},
+                text: "Short Title",
+                style: .primaryDestructive()
+            )
+            .padding(10)
+            Text("<< Disabled >>")
+            PrimaryButton(
+                action: {},
+                text: "Short Title",
+                style: .primary(isDisabled: Binding<Bool>.constant(true))
+            )
+            .padding(10)
+            PrimaryButton(
+                action: {},
+                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+                style: .primary(isDisabled: Binding<Bool>.constant(true))
+            )
+            .padding(10)
+            PrimaryButton(
+                action: {},
+                text: "Short Title",
+                style: .primaryDestructive(isDisabled: Binding<Bool>.constant(true))
+            )
+            .padding(10)
+        }
+        .preferredColorScheme(.dark)
+        .previewLayout(.sizeThatFits)
+        VStack(alignment: .center, spacing: 30) {
+            Text("<< Enabled >>")
+            PrimaryButton(
+                action: {},
+                text: "Short Title"
+            )
+            .padding(10)
+            PrimaryButton(
+                action: {},
+                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+            )
+            .padding(10)
+            PrimaryButton(
+                action: {},
+                text: "Short Title",
+                style: .primaryDestructive()
+            )
+            .padding(10)
+            Text("<< Disabled >>")
+            PrimaryButton(
+                action: {},
+                text: "Short Title",
+                style: .primary(isDisabled: Binding<Bool>.constant(true))
+            )
+            .padding(10)
+            PrimaryButton(
+                action: {},
+                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+                style: .primary(isDisabled: Binding<Bool>.constant(true))
+            )
+            .padding(10)
+            PrimaryButton(
+                action: {},
+                text: "Short Title",
+                style: .primaryDestructive(isDisabled: Binding<Bool>.constant(true))
+            )
+            .padding(10)
+        }
+        .preferredColorScheme(.light)
+        .previewLayout(.sizeThatFits)
+    }
+}

--- a/ios/NativeSigner/Components/Buttons/PrimaryButton.swift
+++ b/ios/NativeSigner/Components/Buttons/PrimaryButton.swift
@@ -31,87 +31,88 @@ struct PrimaryButton: View {
     }
 }
 
-struct PrimaryButton_Previews: PreviewProvider {
-    static var previews: some View {
-        VStack(alignment: .center, spacing: 30) {
-            Text("<< Enabled >>")
-            PrimaryButton(
-                action: {},
-                text: "Short Title"
-            )
-            .padding(10)
-            PrimaryButton(
-                action: {},
-                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-            )
-            .padding(10)
-            PrimaryButton(
-                action: {},
-                text: "Short Title",
-                style: .primaryDestructive()
-            )
-            .padding(10)
-            Text("<< Disabled >>")
-            PrimaryButton(
-                action: {},
-                text: "Short Title",
-                style: .primary(isDisabled: Binding<Bool>.constant(true))
-            )
-            .padding(10)
-            PrimaryButton(
-                action: {},
-                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-                style: .primary(isDisabled: Binding<Bool>.constant(true))
-            )
-            .padding(10)
-            PrimaryButton(
-                action: {},
-                text: "Short Title",
-                style: .primaryDestructive(isDisabled: Binding<Bool>.constant(true))
-            )
-            .padding(10)
-        }
-        .preferredColorScheme(.dark)
-        .previewLayout(.sizeThatFits)
-        VStack(alignment: .center, spacing: 30) {
-            Text("<< Enabled >>")
-            PrimaryButton(
-                action: {},
-                text: "Short Title"
-            )
-            .padding(10)
-            PrimaryButton(
-                action: {},
-                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-            )
-            .padding(10)
-            PrimaryButton(
-                action: {},
-                text: "Short Title",
-                style: .primaryDestructive()
-            )
-            .padding(10)
-            Text("<< Disabled >>")
-            PrimaryButton(
-                action: {},
-                text: "Short Title",
-                style: .primary(isDisabled: Binding<Bool>.constant(true))
-            )
-            .padding(10)
-            PrimaryButton(
-                action: {},
-                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-                style: .primary(isDisabled: Binding<Bool>.constant(true))
-            )
-            .padding(10)
-            PrimaryButton(
-                action: {},
-                text: "Short Title",
-                style: .primaryDestructive(isDisabled: Binding<Bool>.constant(true))
-            )
-            .padding(10)
-        }
-        .preferredColorScheme(.light)
-        .previewLayout(.sizeThatFits)
-    }
-}
+//
+// struct PrimaryButton_Previews: PreviewProvider {
+//    static var previews: some View {
+//        VStack(alignment: .center, spacing: 30) {
+//            Text("<< Enabled >>")
+//            PrimaryButton(
+//                action: {},
+//                text: "Short Title"
+//            )
+//            .padding(10)
+//            PrimaryButton(
+//                action: {},
+//                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+//            )
+//            .padding(10)
+//            PrimaryButton(
+//                action: {},
+//                text: "Short Title",
+//                style: .primaryDestructive()
+//            )
+//            .padding(10)
+//            Text("<< Disabled >>")
+//            PrimaryButton(
+//                action: {},
+//                text: "Short Title",
+//                style: .primary(isDisabled: Binding<Bool>.constant(true))
+//            )
+//            .padding(10)
+//            PrimaryButton(
+//                action: {},
+//                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+//                style: .primary(isDisabled: Binding<Bool>.constant(true))
+//            )
+//            .padding(10)
+//            PrimaryButton(
+//                action: {},
+//                text: "Short Title",
+//                style: .primaryDestructive(isDisabled: Binding<Bool>.constant(true))
+//            )
+//            .padding(10)
+//        }
+//        .preferredColorScheme(.dark)
+//        .previewLayout(.sizeThatFits)
+//        VStack(alignment: .center, spacing: 30) {
+//            Text("<< Enabled >>")
+//            PrimaryButton(
+//                action: {},
+//                text: "Short Title"
+//            )
+//            .padding(10)
+//            PrimaryButton(
+//                action: {},
+//                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+//            )
+//            .padding(10)
+//            PrimaryButton(
+//                action: {},
+//                text: "Short Title",
+//                style: .primaryDestructive()
+//            )
+//            .padding(10)
+//            Text("<< Disabled >>")
+//            PrimaryButton(
+//                action: {},
+//                text: "Short Title",
+//                style: .primary(isDisabled: Binding<Bool>.constant(true))
+//            )
+//            .padding(10)
+//            PrimaryButton(
+//                action: {},
+//                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+//                style: .primary(isDisabled: Binding<Bool>.constant(true))
+//            )
+//            .padding(10)
+//            PrimaryButton(
+//                action: {},
+//                text: "Short Title",
+//                style: .primaryDestructive(isDisabled: Binding<Bool>.constant(true))
+//            )
+//            .padding(10)
+//        }
+//        .preferredColorScheme(.light)
+//        .previewLayout(.sizeThatFits)
+//    }
+// }

--- a/ios/NativeSigner/Components/Buttons/SecondaryButton.swift
+++ b/ios/NativeSigner/Components/Buttons/SecondaryButton.swift
@@ -31,63 +31,64 @@ struct SecondaryButton: View {
     }
 }
 
-struct SecondaryButton_Previews: PreviewProvider {
-    static var previews: some View {
-        VStack(alignment: .center, spacing: 10) {
-            Text("<< Enabled >>")
-            SecondaryButton(
-                action: {}(),
-                text: "Short Title"
-            )
-            .padding(10)
-            SecondaryButton(
-                action: {}(),
-                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-            )
-            .padding(10)
-            Text("<< Disabled >>")
-            SecondaryButton(
-                action: {}(),
-                text: "Short Title",
-                style: .secondary(isDisabled: Binding<Bool>.constant(true))
-            )
-            .padding(10)
-            SecondaryButton(
-                action: {}(),
-                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-                style: .secondary(isDisabled: Binding<Bool>.constant(true))
-            )
-            .padding(10)
-        }
-        .preferredColorScheme(.dark)
-        .previewLayout(.sizeThatFits)
-        VStack(alignment: .center, spacing: 10) {
-            Text("<< Enabled >>")
-            SecondaryButton(
-                action: {}(),
-                text: "Short Title"
-            )
-            .padding(10)
-            SecondaryButton(
-                action: {}(),
-                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-            )
-            .padding(10)
-            Text("<< Disabled >>")
-            SecondaryButton(
-                action: {}(),
-                text: "Short Title",
-                style: .secondary(isDisabled: Binding<Bool>.constant(true))
-            )
-            .padding(10)
-            SecondaryButton(
-                action: {}(),
-                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-                style: .secondary(isDisabled: Binding<Bool>.constant(true))
-            )
-            .padding(10)
-        }
-        .preferredColorScheme(.light)
-        .previewLayout(.sizeThatFits)
-    }
-}
+//
+// struct SecondaryButton_Previews: PreviewProvider {
+//    static var previews: some View {
+//        VStack(alignment: .center, spacing: 10) {
+//            Text("<< Enabled >>")
+//            SecondaryButton(
+//                action: {}(),
+//                text: "Short Title"
+//            )
+//            .padding(10)
+//            SecondaryButton(
+//                action: {}(),
+//                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+//            )
+//            .padding(10)
+//            Text("<< Disabled >>")
+//            SecondaryButton(
+//                action: {}(),
+//                text: "Short Title",
+//                style: .secondary(isDisabled: Binding<Bool>.constant(true))
+//            )
+//            .padding(10)
+//            SecondaryButton(
+//                action: {}(),
+//                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+//                style: .secondary(isDisabled: Binding<Bool>.constant(true))
+//            )
+//            .padding(10)
+//        }
+//        .preferredColorScheme(.dark)
+//        .previewLayout(.sizeThatFits)
+//        VStack(alignment: .center, spacing: 10) {
+//            Text("<< Enabled >>")
+//            SecondaryButton(
+//                action: {}(),
+//                text: "Short Title"
+//            )
+//            .padding(10)
+//            SecondaryButton(
+//                action: {}(),
+//                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+//            )
+//            .padding(10)
+//            Text("<< Disabled >>")
+//            SecondaryButton(
+//                action: {}(),
+//                text: "Short Title",
+//                style: .secondary(isDisabled: Binding<Bool>.constant(true))
+//            )
+//            .padding(10)
+//            SecondaryButton(
+//                action: {}(),
+//                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+//                style: .secondary(isDisabled: Binding<Bool>.constant(true))
+//            )
+//            .padding(10)
+//        }
+//        .preferredColorScheme(.light)
+//        .previewLayout(.sizeThatFits)
+//    }
+// }

--- a/ios/NativeSigner/Components/Buttons/SecondaryButton.swift
+++ b/ios/NativeSigner/Components/Buttons/SecondaryButton.swift
@@ -10,89 +10,84 @@ import SwiftUI
 struct SecondaryButton: View {
     private let action: () -> Void
     private let text: LocalizedStringKey
-
-    @State var isDisabled: Bool
+    private let style: ActionButtonStyle
 
     init(
-        action: @escaping () -> Void,
+        action: @escaping @autoclosure () -> Void,
         text: LocalizedStringKey,
-        isDisabled: Bool = false
+        style: ActionButtonStyle = .secondary()
     ) {
         self.action = action
         self.text = text
-        self.isDisabled = isDisabled
+        self.style = style
     }
 
     var body: some View {
         ActionButton(
-            action: action,
+            action: action(),
             text: text,
-            style: ActionButtonStyle(
-                backgroundColor: Asset.fill18.swiftUIColor,
-                foregroundColor: (isDisabled ? Asset.textAndIconsDisabled : Asset.textAndIconsPrimary).swiftUIColor
-            ),
-            isDisabled: $isDisabled
+            style: style
         )
     }
 }
 
-// struct SecondaryButton_Previews: PreviewProvider {
-//    static var previews: some View {
-//        VStack(alignment: .center, spacing: 10) {
-//            Text("<< Enabled >>")
-//            SecondaryButton(
-//                action: {},
-//                text: "Short Title"
-//            )
-//            .padding(10)
-//            SecondaryButton(
-//                action: {},
-//                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-//            )
-//            .padding(10)
-//            Text("<< Disabled >>")
-//            SecondaryButton(
-//                action: {},
-//                text: "Short Title",
-//                isDisabled: true
-//            )
-//            .padding(10)
-//            SecondaryButton(
-//                action: {},
-//                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-//                isDisabled: true
-//            )
-//            .padding(10)
-//        }
-//        .preferredColorScheme(.dark)
-//        .previewLayout(.sizeThatFits)
-//        VStack(alignment: .center, spacing: 10) {
-//            Text("<< Enabled >>")
-//            SecondaryButton(
-//                action: {},
-//                text: "Short Title"
-//            )
-//            .padding(10)
-//            SecondaryButton(
-//                action: {},
-//                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-//            )
-//            .padding(10)
-//            Text("<< Disabled >>")
-//            SecondaryButton(
-//                action: {},
-//                text: "Short Title",
-//                isDisabled: true
-//            )
-//            .padding(10)
-//            SecondaryButton(
-//                action: {},
-//                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-//                isDisabled: true
-//            )
-//            .padding(10)
-//        }
-//        .preferredColorScheme(.light)
-//        .previewLayout(.sizeThatFits)
-//    }
-// }
+struct SecondaryButton_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack(alignment: .center, spacing: 10) {
+            Text("<< Enabled >>")
+            SecondaryButton(
+                action: {}(),
+                text: "Short Title"
+            )
+            .padding(10)
+            SecondaryButton(
+                action: {}(),
+                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+            )
+            .padding(10)
+            Text("<< Disabled >>")
+            SecondaryButton(
+                action: {}(),
+                text: "Short Title",
+                style: .secondary(isDisabled: Binding<Bool>.constant(true))
+            )
+            .padding(10)
+            SecondaryButton(
+                action: {}(),
+                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+                style: .secondary(isDisabled: Binding<Bool>.constant(true))
+            )
+            .padding(10)
+        }
+        .preferredColorScheme(.dark)
+        .previewLayout(.sizeThatFits)
+        VStack(alignment: .center, spacing: 10) {
+            Text("<< Enabled >>")
+            SecondaryButton(
+                action: {}(),
+                text: "Short Title"
+            )
+            .padding(10)
+            SecondaryButton(
+                action: {}(),
+                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+            )
+            .padding(10)
+            Text("<< Disabled >>")
+            SecondaryButton(
+                action: {}(),
+                text: "Short Title",
+                style: .secondary(isDisabled: Binding<Bool>.constant(true))
+            )
+            .padding(10)
+            SecondaryButton(
+                action: {}(),
+                text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+                style: .secondary(isDisabled: Binding<Bool>.constant(true))
+            )
+            .padding(10)
+        }
+        .preferredColorScheme(.light)
+        .previewLayout(.sizeThatFits)
+    }
+}

--- a/ios/NativeSigner/Design/Animations.swift
+++ b/ios/NativeSigner/Design/Animations.swift
@@ -1,0 +1,33 @@
+//
+//  Animations.swift
+//  NativeSigner
+//
+//  Created by Krzysztof Rodak on 07/09/2022.
+//
+
+import SwiftUI
+
+enum Animations {
+    /// Convinience method that enables to chain two animations with standard duration and delay.
+    /// Uses `easeIn` for animation curve
+    /// - Parameters:
+    ///   - firstAnimationClosure: closure to be called when first animation is finished
+    ///   - delayedAnimationClosure: closure to be called when second, delayed animation is finished
+    static func chainAnimation(
+        _ firstAnimationClosure: @autoclosure () -> Void,
+        delayedAnimationClosure: @escaping @autoclosure () -> Void
+    ) {
+        withAnimation(
+            Animation.easeIn(duration: AnimationDuration.standard)
+        ) {
+            firstAnimationClosure()
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + AnimationDuration.standard) {
+            withAnimation(
+                Animation.easeIn(duration: AnimationDuration.standard)
+            ) {
+                delayedAnimationClosure()
+            }
+        }
+    }
+}

--- a/ios/NativeSigner/Modals/AddKeySet/AddKeySetModal.swift
+++ b/ios/NativeSigner/Modals/AddKeySet/AddKeySetModal.swift
@@ -72,13 +72,13 @@ struct AddKeySetModal: View {
     }
 }
 
-struct AddKeySetModal_Previews: PreviewProvider {
-    static var previews: some View {
-        AddKeySetModal(
-            isShowingNewSeedMenu: Binding<Bool>.constant(true),
-            navigation: NavigationCoordinator()
-        )
-        .preferredColorScheme(.dark)
-        .previewLayout(.sizeThatFits)
-    }
-}
+// struct AddKeySetModal_Previews: PreviewProvider {
+//    static var previews: some View {
+//        AddKeySetModal(
+//            isShowingNewSeedMenu: Binding<Bool>.constant(true),
+//            navigation: NavigationCoordinator()
+//        )
+//        .preferredColorScheme(.dark)
+//        .previewLayout(.sizeThatFits)
+//    }
+// }

--- a/ios/NativeSigner/Modals/AddKeySet/AddKeySetModal.swift
+++ b/ios/NativeSigner/Modals/AddKeySet/AddKeySetModal.swift
@@ -52,7 +52,7 @@ struct AddKeySetModal: View {
                             }
                         },
                         text: Localizable.AddKeySet.Button.cancel.key,
-                        foregroundColor: Asset.textAndIconsSecondary.swiftUIColor
+                        style: .emptySecondary()
                     )
                 }
                 .padding([.leading, .trailing], Spacing.large)
@@ -62,19 +62,13 @@ struct AddKeySetModal: View {
     }
 
     private func animateDismissal(_ completion: @escaping () -> Void = {}) {
-        withAnimation(
-            Animation.easeIn(duration: AnimationDuration.standard)
-        ) {
-            animateBackground.toggle()
-        }
-        DispatchQueue.main.asyncAfter(deadline: .now() + AnimationDuration.standard) {
-            withAnimation(
-                Animation.easeIn(duration: AnimationDuration.standard)
-            ) {
+        Animations.chainAnimation(
+            animateBackground.toggle(),
+            delayedAnimationClosure: {
                 isShowingNewSeedMenu.toggle()
                 completion()
-            }
-        }
+            }()
+        )
     }
 }
 

--- a/ios/NativeSigner/Modals/Alerts/HorizontalActionsBottomModal.swift
+++ b/ios/NativeSigner/Modals/Alerts/HorizontalActionsBottomModal.swift
@@ -1,0 +1,110 @@
+//
+//  HorizontalActionsBottomModal.swift
+//  NativeSigner
+//
+//  Created by Krzysztof Rodak on 07/09/2022.
+//
+
+import SwiftUI
+
+struct HorizontalActionsBottomModalViewModel {
+    let title: String
+    let content: String
+    let dismissActionLabel: LocalizedStringKey
+    let mainActionLabel: LocalizedStringKey
+
+    static let forgetKeySet = HorizontalActionsBottomModalViewModel(
+        title: Localizable.KeySetsModal.Confirmation.Label.title.string,
+        content: Localizable.KeySetsModal.Confirmation.Label.content.string,
+        dismissActionLabel: Localizable.KeySetsModal.Confirmation.Action.cancel.key,
+        mainActionLabel: Localizable.KeySetsModal.Confirmation.Action.remove.key
+    )
+}
+
+struct HorizontalActionsBottomModal: View {
+    private var viewModel: HorizontalActionsBottomModalViewModel
+    private let mainAction: () -> Void
+    private let dismissAction: () -> Void
+    @State private var animateBackground: Bool = false
+    @Binding private var isShowingBottomAlert: Bool
+
+    init(
+        viewModel: HorizontalActionsBottomModalViewModel,
+        mainAction: @escaping () -> Void,
+        dismissAction: @escaping () -> Void = {},
+        isShowingBottomAlert: Binding<Bool> = Binding<Bool>.constant(false)
+    ) {
+        self.viewModel = viewModel
+        self.mainAction = mainAction
+        self.dismissAction = dismissAction
+        _isShowingBottomAlert = isShowingBottomAlert
+    }
+
+    var body: some View {
+        FullScreenRoundedModal(
+            backgroundTapAction: { animateDismissal(dismissAction()) },
+            animateBackground: $animateBackground,
+            content: {
+                VStack(alignment: .center, spacing: Spacing.medium) {
+                    Text(viewModel.title)
+                        .font(Fontstyle.titleL.base)
+                    Text(viewModel.content)
+                        .font(Fontstyle.bodyL.base)
+                        .lineSpacing(4)
+                        .multilineTextAlignment(.center)
+                        .padding([.leading, .trailing], Spacing.large)
+                        .foregroundColor(Asset.textAndIconsSecondary.swiftUIColor)
+                    HStack {
+                        SecondaryButton(
+                            action: animateDismissal(dismissAction()),
+                            text: viewModel.dismissActionLabel
+                        )
+                        PrimaryButton(
+                            action: { animateDismissal(mainAction()) },
+                            text: viewModel.mainActionLabel,
+                            style: .primaryDestructive()
+                        )
+                    }
+                    .padding(.top, Spacing.medium)
+                }
+                .padding([.leading, .trailing], Spacing.large)
+                .padding(.top, Spacing.medium)
+                .padding(.bottom, Spacing.extraSmall)
+            }
+        )
+    }
+
+    private func animateDismissal(_ completion: @escaping @autoclosure () -> Void = {}()) {
+        Animations.chainAnimation(
+            animateBackground.toggle(),
+            delayedAnimationClosure: {
+                isShowingBottomAlert.toggle()
+                completion()
+            }()
+        )
+    }
+}
+
+struct HorizontalActionsBottomModal_Previews: PreviewProvider {
+    static var previews: some View {
+        HorizontalActionsBottomModal(
+            viewModel: .forgetKeySet,
+            mainAction: {},
+            isShowingBottomAlert: Binding<Bool>.constant(true)
+        )
+        .preferredColorScheme(.dark)
+        .previewLayout(.sizeThatFits)
+        VStack {
+            HorizontalActionsBottomModal(
+                viewModel: .forgetKeySet,
+                mainAction: {},
+                isShowingBottomAlert: Binding<Bool>.constant(true)
+            )
+            .preferredColorScheme(.light)
+            .previewLayout(.sizeThatFits)
+        }
+        .background(.black)
+        .preferredColorScheme(.light)
+        .previewLayout(.sizeThatFits)
+    }
+}

--- a/ios/NativeSigner/Modals/Alerts/HorizontalActionsBottomModal.swift
+++ b/ios/NativeSigner/Modals/Alerts/HorizontalActionsBottomModal.swift
@@ -85,26 +85,27 @@ struct HorizontalActionsBottomModal: View {
     }
 }
 
-struct HorizontalActionsBottomModal_Previews: PreviewProvider {
-    static var previews: some View {
-        HorizontalActionsBottomModal(
-            viewModel: .forgetKeySet,
-            mainAction: {},
-            isShowingBottomAlert: Binding<Bool>.constant(true)
-        )
-        .preferredColorScheme(.dark)
-        .previewLayout(.sizeThatFits)
-        VStack {
-            HorizontalActionsBottomModal(
-                viewModel: .forgetKeySet,
-                mainAction: {},
-                isShowingBottomAlert: Binding<Bool>.constant(true)
-            )
-            .preferredColorScheme(.light)
-            .previewLayout(.sizeThatFits)
-        }
-        .background(.black)
-        .preferredColorScheme(.light)
-        .previewLayout(.sizeThatFits)
-    }
-}
+//
+// struct HorizontalActionsBottomModal_Previews: PreviewProvider {
+//    static var previews: some View {
+//        HorizontalActionsBottomModal(
+//            viewModel: .forgetKeySet,
+//            mainAction: {},
+//            isShowingBottomAlert: Binding<Bool>.constant(true)
+//        )
+//        .preferredColorScheme(.dark)
+//        .previewLayout(.sizeThatFits)
+//        VStack {
+//            HorizontalActionsBottomModal(
+//                viewModel: .forgetKeySet,
+//                mainAction: {},
+//                isShowingBottomAlert: Binding<Bool>.constant(true)
+//            )
+//            .preferredColorScheme(.light)
+//            .previewLayout(.sizeThatFits)
+//        }
+//        .background(.black)
+//        .preferredColorScheme(.light)
+//        .previewLayout(.sizeThatFits)
+//    }
+// }

--- a/ios/NativeSigner/Resources/en.lproj/Localizable.strings
+++ b/ios/NativeSigner/Resources/en.lproj/Localizable.strings
@@ -282,6 +282,11 @@
 "KeySetsModal.Action.Backup" = "Backup Key Set";
 "KeySetsModal.Action.Delete" = "Delete";
 
+"KeySetsModal.Confirmation.Label.Title" = "Forget this Key Set?";
+"KeySetsModal.Confirmation.Label.Content" = "This Key Set will be removed for all networks. This is not reversible.\nAre you sure?";
+"KeySetsModal.Confirmation.Action.Cancel" = "Cancel";
+"KeySetsModal.Confirmation.Action.Remove" = "Remove";
+
 "AddKeySet.Title" = "Add Key Set";
 "AddKeySet.Button.Cancel" = "Cancel";
 "AddKeySet.Button.Add" = "Add new Key Set";

--- a/ios/NativeSigner/Screens/KeyDetails/KeyDetailsView.swift
+++ b/ios/NativeSigner/Screens/KeyDetails/KeyDetailsView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct KeyDetailsView: View {
     @State private var isShowingActionSheet = false
+    @State private var isShowingRemoveConfirmation: Bool = false
     @ObservedObject private var navigation: NavigationCoordinator
     private var seedsMediator: SeedsMediating!
 
@@ -115,10 +116,24 @@ struct KeyDetailsView: View {
         .fullScreenCover(isPresented: $isShowingActionSheet) {
             KeyDetailsActionsModal(
                 isShowingActionSheet: $isShowingActionSheet,
-                navigation: navigation,
-                removeSeed: {
+                isShowingRemoveConfirmation: $isShowingRemoveConfirmation,
+                navigation: navigation
+            )
+            .clearModalBackground()
+        }
+        .fullScreenCover(isPresented: $isShowingRemoveConfirmation) {
+            HorizontalActionsBottomModal(
+                viewModel: .forgetKeySet,
+                mainAction: {
                     seedsMediator?.removeSeed(seedName: actionModel.removeSeed)
-                }
+                },
+                dismissAction: {
+                    // We need to fake right button action here or Rust machine will break
+                    // In old UI, if you dismiss equivalent of this modal, underlying modal would still be there,
+                    // so we need to inform Rust we actually hid it
+                    navigation.perform(navigation: .init(action: .rightButtonAction))
+                },
+                isShowingBottomAlert: $isShowingRemoveConfirmation
             )
             .clearModalBackground()
         }


### PR DESCRIPTION
## Purpose
This PR adds redesign confirmation when choosing `Delete` action.
It does not cover additional confirmation toast, as currently Rust navigation takes user to Logs screen 🤷🏻 
I'll issue separate PR with some design component that looks like toast notification and will add ability to trigger multiple Rust actions to properly move user back to `Keys` screen, not to `Logs

## Scope
- `HorizontalActionsBottomModal` that adds universal bottom sheet with main action and cancel action, customisable via dedicated view model
- addition of `HorizontalActionsBottomModal` as another full screen cover in `KeyDetailsView` to be presented after `Delete`
- small refactor to `ActionButton` styling
- small refactor to chained animation to make it DRY
- adding custom fake calls to Rust, to be able to replicate old behaviour with new UI flow

## Screenshots

KeyDetailsActionsModal
| Light | Dark |
|-|-|
|<img src="https://user-images.githubusercontent.com/1955364/189121511-585c967b-f14a-4e2f-b5da-0eda1816068d.png" width="320px">|<img src="https://user-images.githubusercontent.com/1955364/189121480-963138ad-7466-4d30-a9d2-c891551566b9.png" width="320px">|

| Interaction flow |
|-|
|<img src="https://user-images.githubusercontent.com/1955364/189121376-517c9204-6942-40ba-9cf1-664db2486af6.gif" width="320px">|
