### PR TITLE
fix: fix touch space over Spacer elements within UI components

### DIFF
--- a/ios/NativeSigner/Components/Buttons/ActionSheetButton.swift
+++ b/ios/NativeSigner/Components/Buttons/ActionSheetButton.swift
@@ -55,6 +55,7 @@ struct ActionSheetButton: View {
                 Spacer()
             }
             .frame(maxWidth: .infinity)
+            .contentShape(Rectangle())
         }
         .buttonStyle(style)
         .disabled(isDisabled)

--- a/ios/NativeSigner/Screens/KeyDetails/KeyDetailsView.swift
+++ b/ios/NativeSigner/Screens/KeyDetails/KeyDetailsView.swift
@@ -60,6 +60,7 @@ struct KeyDetailsView: View {
                     Asset.chevronRight.swiftUIImage
                 }
                 .padding(Padding.detailsCell)
+                .contentShape(Rectangle())
                 .onTapGesture {
                     navigation.perform(navigation: actionModel.addressKeyNavigation)
                 }
@@ -88,6 +89,7 @@ struct KeyDetailsView: View {
                             .listRowBackground(Asset.backgroundSystem.swiftUIColor)
                             .listRowSeparator(.hidden)
                             .listRowInsets(EdgeInsets())
+                            .contentShape(Rectangle())
                             .onTapGesture {
                                 navigation.perform(navigation: deriveKey.actionModel.tapAction)
                             }


### PR DESCRIPTION
## Purpose
This PR fixes issues with non-touchable areas between visible components in some elements of the UI

## Scope
- add `.contentShape(Rectangle())` in touchable components with `Spacer()`

## Screenshots
| Key Details elements | Key Details menu |
|-|-|
|<img src="https://user-images.githubusercontent.com/1955364/189342610-1281b3b7-18b7-44b4-bf88-8c0e304ddce8.png" width="320px">|<img src="https://user-images.githubusercontent.com/1955364/189342670-a44496b4-440b-48ee-9ba5-bb0d0551d6a0.png" width="320px">|

| Interactions |
|-|
|<img src="https://user-images.githubusercontent.com/1955364/189342833-7397f8b6-874c-42f0-914d-8d39bded85c8.gif" width="320px">|
