### PR TITLE
feat: Snackbar component and finalised Forget Keys flow

### DIFF
--- a/ios/NativeSigner.xcodeproj/project.pbxproj
+++ b/ios/NativeSigner.xcodeproj/project.pbxproj
@@ -163,6 +163,11 @@
 		6D5801E1289924AD006C41D8 /* ConnectivityMonitoringAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D5801E0289924AD006C41D8 /* ConnectivityMonitoringAdapterTests.swift */; };
 		6D5801E5289937BA006C41D8 /* ConnectivityMonitoringAssemblerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D5801E4289937BA006C41D8 /* ConnectivityMonitoringAssemblerTests.swift */; };
 		6D5801E7289937C0006C41D8 /* ConnectivityMonitoringAssembler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D5801E6289937C0006C41D8 /* ConnectivityMonitoringAssembler.swift */; };
+		6D6430EC28CB2FDF00342E37 /* TapAndDelayDismissAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D6430EB28CB2FDF00342E37 /* TapAndDelayDismissAnimator.swift */; };
+		6D6430EF28CB30A000342E37 /* BottoEdgeOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D6430EE28CB30A000342E37 /* BottoEdgeOverlay.swift */; };
+		6D6430F128CB32CC00342E37 /* Snackbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D6430F028CB32CC00342E37 /* Snackbar.swift */; };
+		6D6430F428CB447900342E37 /* ForgetKeySetAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D6430F328CB447900342E37 /* ForgetKeySetAction.swift */; };
+		6D6430F628CB460A00342E37 /* ServiceLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D6430F528CB460A00342E37 /* ServiceLocator.swift */; };
 		6D88CFF028C60815001FB0A1 /* CloseModalButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D88CFEF28C60815001FB0A1 /* CloseModalButton.swift */; };
 		6D88CFF228C60AED001FB0A1 /* FullScreenRoundedModal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D88CFF128C60AED001FB0A1 /* FullScreenRoundedModal.swift */; };
 		6D88CFF828C634CA001FB0A1 /* KeyDetailsActionsModal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D88CFF728C634CA001FB0A1 /* KeyDetailsActionsModal.swift */; };
@@ -408,6 +413,11 @@
 		6D5801E0289924AD006C41D8 /* ConnectivityMonitoringAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityMonitoringAdapterTests.swift; sourceTree = "<group>"; };
 		6D5801E4289937BA006C41D8 /* ConnectivityMonitoringAssemblerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityMonitoringAssemblerTests.swift; sourceTree = "<group>"; };
 		6D5801E6289937C0006C41D8 /* ConnectivityMonitoringAssembler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityMonitoringAssembler.swift; sourceTree = "<group>"; };
+		6D6430EB28CB2FDF00342E37 /* TapAndDelayDismissAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapAndDelayDismissAnimator.swift; sourceTree = "<group>"; };
+		6D6430EE28CB30A000342E37 /* BottoEdgeOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottoEdgeOverlay.swift; sourceTree = "<group>"; };
+		6D6430F028CB32CC00342E37 /* Snackbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Snackbar.swift; sourceTree = "<group>"; };
+		6D6430F328CB447900342E37 /* ForgetKeySetAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForgetKeySetAction.swift; sourceTree = "<group>"; };
+		6D6430F528CB460A00342E37 /* ServiceLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceLocator.swift; sourceTree = "<group>"; };
 		6D88CFEF28C60815001FB0A1 /* CloseModalButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseModalButton.swift; sourceTree = "<group>"; };
 		6D88CFF128C60AED001FB0A1 /* FullScreenRoundedModal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenRoundedModal.swift; sourceTree = "<group>"; };
 		6D88CFF728C634CA001FB0A1 /* KeyDetailsActionsModal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyDetailsActionsModal.swift; sourceTree = "<group>"; };
@@ -570,6 +580,8 @@
 		2D7A7BC826BA97AE0053C1E0 /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				6D6430ED28CB309500342E37 /* Overlays */,
+				6D6430EA28CB2FD300342E37 /* Animators */,
 				6D95E97628B624FF00E28A11 /* Modals */,
 				6DDEF13D28AE7C4B004CA2FD /* Buttons */,
 				6DDEF11928AE2DD3004CA2FD /* TabBar */,
@@ -668,7 +680,6 @@
 				2DE72BD226A588C9002BB752 /* NativeSignerTests */,
 				2DE72BBF26A588C7002BB752 /* Products */,
 				2DE72C0B26A992D9002BB752 /* Frameworks */,
-				6DBE12D628B3A292005F3CCC /* Recovered References */,
 			);
 			sourceTree = "<group>";
 		};
@@ -879,6 +890,7 @@
 				6D5801D528991DA4006C41D8 /* Runtime */,
 				6D5801D22899132C006C41D8 /* Connectivity */,
 				6D5801CF28991306006C41D8 /* Protocols */,
+				6D6430F528CB460A00342E37 /* ServiceLocator.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -941,6 +953,30 @@
 			path = Connectivity;
 			sourceTree = "<group>";
 		};
+		6D6430EA28CB2FD300342E37 /* Animators */ = {
+			isa = PBXGroup;
+			children = (
+				6D6430EB28CB2FDF00342E37 /* TapAndDelayDismissAnimator.swift */,
+			);
+			path = Animators;
+			sourceTree = "<group>";
+		};
+		6D6430ED28CB309500342E37 /* Overlays */ = {
+			isa = PBXGroup;
+			children = (
+				6D6430EE28CB30A000342E37 /* BottoEdgeOverlay.swift */,
+			);
+			path = Overlays;
+			sourceTree = "<group>";
+		};
+		6D6430F228CB447100342E37 /* Actions */ = {
+			isa = PBXGroup;
+			children = (
+				6D6430F328CB447900342E37 /* ForgetKeySetAction.swift */,
+			);
+			path = Actions;
+			sourceTree = "<group>";
+		};
 		6D88CFF628C634BC001FB0A1 /* KeySet */ = {
 			isa = PBXGroup;
 			children = (
@@ -981,6 +1017,7 @@
 			children = (
 				6D95E97728B6250B00E28A11 /* ClearBackgroundView.swift */,
 				6D88CFF128C60AED001FB0A1 /* FullScreenRoundedModal.swift */,
+				6D6430F028CB32CC00342E37 /* Snackbar.swift */,
 			);
 			path = Modals;
 			sourceTree = "<group>";
@@ -1019,13 +1056,6 @@
 			path = Helpers;
 			sourceTree = "<group>";
 		};
-		6DBE12D628B3A292005F3CCC /* Recovered References */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = "Recovered References";
-			sourceTree = "<group>";
-		};
 		6DC5642C28B652D0003D540B /* AddKeySet */ = {
 			isa = PBXGroup;
 			children = (
@@ -1049,6 +1079,7 @@
 		6DC5643E28B929E0003D540B /* KeyDetails */ = {
 			isa = PBXGroup;
 			children = (
+				6D6430F228CB447100342E37 /* Actions */,
 				6DE8466828BF6E9B0051346A /* Models */,
 				6DC5643F28B929EA003D540B /* KeyDetailsView.swift */,
 				6DF7257728BE0E08007CD9B6 /* DerivedKeyRow.swift */,
@@ -1409,10 +1440,12 @@
 				6D5801D728991F11006C41D8 /* RuntimePropertiesProvider.swift in Sources */,
 				2DA5F8252756624000D8DD29 /* NavbarShield.swift in Sources */,
 				6DDEF11428AD12FA004CA2FD /* Tab.swift in Sources */,
+				6D6430F628CB460A00342E37 /* ServiceLocator.swift in Sources */,
 				6DC5642E28B652DE003D540B /* AddKeySetModal.swift in Sources */,
 				2D48F3572760BBEC004B27BE /* RecoverSeedName.swift in Sources */,
 				6DBD21FA289A7A26005D539B /* DatabaseMediator.swift in Sources */,
 				2D48F3D6277B94C4004B27BE /* Identicon.swift in Sources */,
+				6D6430EF28CB30A000342E37 /* BottoEdgeOverlay.swift in Sources */,
 				6D88CFF828C634CA001FB0A1 /* KeyDetailsActionsModal.swift in Sources */,
 				2D48F3532760A2D8004B27BE /* Fontstyle.swift in Sources */,
 				6D57DC75289E525F00005C63 /* ModalSelectorView.swift in Sources */,
@@ -1435,6 +1468,7 @@
 				6D57DC74289E525F00005C63 /* ScreenSelectorView.swift in Sources */,
 				04197D2B276BA40C003485D2 /* MenuElements.swift in Sources */,
 				6DF7751B28B399AC0040012E /* CornerRadius.swift in Sources */,
+				6D6430EC28CB2FDF00342E37 /* TapAndDelayDismissAnimator.swift in Sources */,
 				2DA5F86927566C3600D8DD29 /* TCEraImmortal.swift in Sources */,
 				2D7A7BD626C1126C0053C1E0 /* Utils.swift in Sources */,
 				6DC5643028B65B9C003D540B /* AnimationDuration.swift in Sources */,
@@ -1535,6 +1569,8 @@
 				2D48F36127620F49004B27BE /* SeedKeyCard.swift in Sources */,
 				2D48F38327691C0A004B27BE /* ConfirmAlert.swift in Sources */,
 				2DAA82912786FA4B002917C0 /* KeyDetailsMulti.swift in Sources */,
+				6D6430F128CB32CC00342E37 /* Snackbar.swift in Sources */,
+				6D6430F428CB447900342E37 /* ForgetKeySetAction.swift in Sources */,
 				2D48F3BE27720345004B27BE /* KeyMenu.swift in Sources */,
 				6DC5643928B7DED8003D540B /* KeychainQueryProvider.swift in Sources */,
 				6D4C0758289BD95500B2EE48 /* SFSymbols.swift in Sources */,

--- a/ios/NativeSigner/Components/Animators/TapAndDelayDismissAnimator.swift
+++ b/ios/NativeSigner/Components/Animators/TapAndDelayDismissAnimator.swift
@@ -1,0 +1,63 @@
+//
+//  TapAndDelayDismissAnimator.swift
+//  NativeSigner
+//
+//  Created by Krzysztof Rodak on 09/09/2022.
+//
+
+import SwiftUI
+
+struct TapAndDelayDismissAnimator: ViewModifier {
+    @State private var timer = Timer
+        .publish(every: 1, on: .main, in: .common)
+        .autoconnect()
+
+    @State var autodismissCounter: TimeInterval
+    private var retainedAutodismissCounter: TimeInterval
+    @Binding var isPresented: Bool
+
+    init(
+        autodismissCounter: TimeInterval,
+        isPresented: Binding<Bool>
+    ) {
+        retainedAutodismissCounter = autodismissCounter
+        self.autodismissCounter = autodismissCounter
+        _isPresented = isPresented
+    }
+
+    func body(content: Content) -> some View {
+        content
+            .onTapGesture {
+                withAnimation {
+                    self.isPresented = false
+                }
+            }
+            .onReceive(timer) { _ in
+                autodismissCounter -= 1
+                if autodismissCounter <= 0 {
+                    self.isPresented = false
+                }
+            }
+            .onChange(of: isPresented, perform: { $0 ? start() : stop() })
+    }
+
+    private func stop() {
+        timer.upstream.connect().cancel()
+    }
+
+    private func start() {
+        autodismissCounter = retainedAutodismissCounter
+        timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+    }
+}
+
+extension View {
+    /// Adds `tap to dismiss` behaviour and allows for automatic dismiss after given delay
+    /// - Parameters:
+    ///   - autodismissCounter: after how many seconds view should autodismiss. Default to 3
+    ///   - isPresented: action controller in form of `Bool`
+    /// - Returns: view that modifier is applied to
+    func tapAndDelayDismiss(autodismissCounter: TimeInterval = 3, isPresented: Binding<Bool>) -> some View {
+        modifier(TapAndDelayDismissAnimator(autodismissCounter: autodismissCounter, isPresented: isPresented))
+    }
+}

--- a/ios/NativeSigner/Components/Modals/Snackbar.swift
+++ b/ios/NativeSigner/Components/Modals/Snackbar.swift
@@ -1,0 +1,108 @@
+//
+//  Snackbar.swift
+//  NativeSigner
+//
+//  Created by Krzysztof Rodak on 08/09/2022.
+//
+
+import SwiftUI
+
+final class BottomSnackbarPresentation: ObservableObject {
+    @Published var viewModel: SnackbarViewModel = .init(title: "")
+    @Published var isSnackbarPresented: Bool = false
+}
+
+struct SnackbarViewModel {
+    let title: String
+    let style: Snackbar.Style
+
+    init(
+        title: String,
+        style: Snackbar.Style = .info
+    ) {
+        self.title = title
+        self.style = style
+    }
+}
+
+struct Snackbar: View {
+    enum Style {
+        case info
+        case warning
+
+        var tintColor: Color {
+            switch self {
+            case .info:
+                return Asset.fill12Solid.swiftUIColor
+            case .warning:
+                return Asset.accentRed400.swiftUIColor
+            }
+        }
+    }
+
+    private let viewModel: SnackbarViewModel
+
+    init(
+        viewModel: SnackbarViewModel
+    ) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        VStack {
+            Spacer()
+            HStack {
+                Text(viewModel.title)
+                    .font(Fontstyle.bodyL.base)
+                    .foregroundColor(Asset.accentForegroundText.swiftUIColor)
+                    .padding(Spacing.large)
+                Spacer()
+            }
+            .frame(height: Heights.snackbarHeight, alignment: .center)
+            .background(viewModel.style.tintColor)
+            .cornerRadius(CornerRadius.small)
+        }
+        .padding()
+    }
+}
+
+extension View {
+    /// Presents given `overlayView` over bottom edge with opacity transition. Dismiss view with bottom edge transition
+    /// - Parameters:
+    ///   - overlayView: view to be presented as overlay
+    ///   - isPresented: action controller in form of `Bool`
+    /// - Returns: view that modifier is applied to
+    func bottomSnackbar(_ viewModel: SnackbarViewModel, isPresented: Binding<Bool>) -> some View {
+        bottomEdgeOverlay(overlayView: Snackbar(viewModel: viewModel), isPresented: isPresented)
+            .tapAndDelayDismiss(isPresented: isPresented)
+    }
+}
+
+//struct SnackbarDemo: View {
+//    @State private var showInfo = false
+//    @State private var showWarning = false
+//
+//    var body: some View {
+//        VStack {
+//            Text("Present info snackbar")
+//                .onTapGesture {
+//                    showInfo = true
+//                }
+//            Spacer()
+//        }.bottomSnackbar(
+//            SnackbarViewModel(title: "Metadata has been updated", style: .info),
+//            isPresented: $showInfo
+//        )
+//    }
+//}
+//
+//
+//struct Snackbar_Previews: PreviewProvider {
+//    @State private var showOverlay = false
+//
+//    static var previews: some View {
+//        SnackbarDemo()
+//            .preferredColorScheme(.light)
+//    }
+//}
+//

--- a/ios/NativeSigner/Components/Overlays/BottoEdgeOverlay.swift
+++ b/ios/NativeSigner/Components/Overlays/BottoEdgeOverlay.swift
@@ -1,0 +1,45 @@
+//
+//  BottoEdgeOverlay.swift
+//  NativeSigner
+//
+//  Created by Krzysztof Rodak on 09/09/2022.
+//
+
+import SwiftUI
+
+extension AnyTransition {
+    static var moveFromBottomAndFade: AnyTransition {
+        .asymmetric(
+            insertion: .move(edge: .bottom).combined(with: .opacity),
+            removal: .move(edge: .bottom)
+        )
+    }
+}
+
+struct BottomEdgeOverlay<T: View>: ViewModifier {
+    @Binding var isPresented: Bool
+    let overlayView: T
+
+    func body(content: Content) -> some View {
+        ZStack(alignment: .bottom) {
+            content
+            if isPresented {
+                overlayView
+                    .zIndex(1) // This fixes SwiftUI issue of dismiss animation on Z-axis
+                    .transition(.moveFromBottomAndFade)
+            }
+        }
+        .animation(.easeInOut(duration: AnimationDuration.overlayPresentation), value: isPresented)
+    }
+}
+
+extension View {
+    /// Presents given `overlayView` over bottom edge with opacity transition. Dismiss view with bottom edge transition
+    /// - Parameters:
+    ///   - overlayView: view to be presented as overlay
+    ///   - isPresented: action controller in form of `Bool`
+    /// - Returns: view that modifier is applied to
+    func bottomEdgeOverlay<T: View>(overlayView: T, isPresented: Binding<Bool>) -> some View {
+        modifier(BottomEdgeOverlay(isPresented: isPresented, overlayView: overlayView))
+    }
+}

--- a/ios/NativeSigner/Core/Keychain/SeedsMediator.swift
+++ b/ios/NativeSigner/Core/Keychain/SeedsMediator.swift
@@ -189,7 +189,7 @@ final class SeedsMediator: SeedsMediating {
                 .filter { $0 != seedName }
                 .sorted()
             updateSeedNames(seedNames: seedNames)
-            signerDataModel.navigation.perform(navigation: .init(action: .removeSeed))
+            signerDataModel.navigation.perform(navigation: .init(action: .removeSeed), skipDebounce: true)
         case .failure: ()
             // We should inform user with some dedicated UI state for that error, maybe just system alert
         }

--- a/ios/NativeSigner/Core/Navigation/NavigationCoordinator.swift
+++ b/ios/NativeSigner/Core/Navigation/NavigationCoordinator.swift
@@ -60,7 +60,7 @@ final class NavigationCoordinator: ObservableObject {
 }
 
 extension NavigationCoordinator {
-    func perform(navigation: Navigation) {
+    func perform(navigation: Navigation, skipDebounce: Bool = false) {
         guard isActionAvailable else { return }
 
         isActionAvailable = false
@@ -87,8 +87,12 @@ extension NavigationCoordinator {
             }
         }
 
-        debounceQueue.asyncAfter(deadline: .now() + Constants.debounceTime, flags: .barrier) {
-            self.isActionAvailable = true
+        if skipDebounce {
+            isActionAvailable = true
+        } else {
+            debounceQueue.asyncAfter(deadline: .now() + Constants.debounceTime, flags: .barrier) {
+                self.isActionAvailable = true
+            }
         }
     }
 }

--- a/ios/NativeSigner/Core/ServiceLocator.swift
+++ b/ios/NativeSigner/Core/ServiceLocator.swift
@@ -1,0 +1,14 @@
+//
+//  ServiceLocator.swift
+//  NativeSigner
+//
+//  Created by Krzysztof Rodak on 09/09/2022.
+//
+
+import Foundation
+
+/// We use this anti-pattern to work around some limitations of both SwiftUI and old architecture in Signer app
+enum ServiceLocator {
+    /// We store this in `ServiceLocator` as singleton, to be able to use it outside SwiftUI views which could use `@EnvironmentalObject`
+    static var bottomSnackbarPresentation: BottomSnackbarPresentation = BottomSnackbarPresentation()
+}

--- a/ios/NativeSigner/Design/AnimationDuration.swift
+++ b/ios/NativeSigner/Design/AnimationDuration.swift
@@ -11,4 +11,6 @@ import UIKit
 enum AnimationDuration {
     /// Standard, 0.3, should align with most system animations
     static let standard: CGFloat = 0.3
+    /// To be used with different `Overlay` presenrtation. 0.8, should allow for smooth transition
+    static let overlayPresentation: CGFloat = 0.8
 }

--- a/ios/NativeSigner/Design/Heights.swift
+++ b/ios/NativeSigner/Design/Heights.swift
@@ -11,6 +11,9 @@ import UIKit
 enum Heights {
     /// All variants of `ActionButton`, 56 pt
     static let actionButton: CGFloat = 56
+    /// All variants of `ActionButton`, 56 pt
+
+    static let snackbarHeight: CGFloat = 56
     /// All variants of `NavbarButton`, 40 pt
     static let navigationButton: CGFloat = 40
     /// All variants of `MenuButton`, 48 pt

--- a/ios/NativeSigner/Modals/Alerts/HorizontalActionsBottomModal.swift
+++ b/ios/NativeSigner/Modals/Alerts/HorizontalActionsBottomModal.swift
@@ -30,8 +30,8 @@ struct HorizontalActionsBottomModal: View {
 
     init(
         viewModel: HorizontalActionsBottomModalViewModel,
-        mainAction: @escaping () -> Void,
-        dismissAction: @escaping () -> Void = {},
+        mainAction: @escaping @autoclosure () -> Void,
+        dismissAction: @escaping @autoclosure () -> Void = {}(),
         isShowingBottomAlert: Binding<Bool> = Binding<Bool>.constant(false)
     ) {
         self.viewModel = viewModel
@@ -50,7 +50,7 @@ struct HorizontalActionsBottomModal: View {
                         .font(Fontstyle.titleL.base)
                     Text(viewModel.content)
                         .font(Fontstyle.bodyL.base)
-                        .lineSpacing(4)
+                        .lineSpacing(Spacing.extraExtraSmall)
                         .multilineTextAlignment(.center)
                         .padding([.leading, .trailing], Spacing.large)
                         .foregroundColor(Asset.textAndIconsSecondary.swiftUIColor)

--- a/ios/NativeSigner/Resources/Assets.xcassets/fill_12_solid.colorset/Contents.json
+++ b/ios/NativeSigner/Resources/Assets.xcassets/fill_12_solid.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x49",
+          "green" : "0x45",
+          "red" : "0x45"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/NativeSigner/Resources/en.lproj/Localizable.strings
+++ b/ios/NativeSigner/Resources/en.lproj/Localizable.strings
@@ -286,6 +286,7 @@
 "KeySetsModal.Confirmation.Label.Content" = "This Key Set will be removed for all networks. This is not reversible.\nAre you sure?";
 "KeySetsModal.Confirmation.Action.Cancel" = "Cancel";
 "KeySetsModal.Confirmation.Action.Remove" = "Remove";
+"KeySetsModal.Confirmation.Snackbar" = "Key Set Has Been Removed";
 
 "AddKeySet.Title" = "Add Key Set";
 "AddKeySet.Button.Cancel" = "Cancel";

--- a/ios/NativeSigner/Screens/Containers/AuthenticatedScreenContainer.swift
+++ b/ios/NativeSigner/Screens/Containers/AuthenticatedScreenContainer.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct AuthenticatedScreenContainer: View {
     @ObservedObject var data: SignerDataModel
     @ObservedObject var navigation: NavigationCoordinator
+
+    @StateObject var snackBarPresentation = ServiceLocator.bottomSnackbarPresentation
     @GestureState private var dragOffset = CGSize.zero
 
     var body: some View {
@@ -61,6 +63,8 @@ struct AuthenticatedScreenContainer: View {
                 }
             }
         )
+        .environmentObject(snackBarPresentation)
         .alert(Localizable.navigationError.text, isPresented: $data.parsingAlert, actions: {})
+        .bottomSnackbar(snackBarPresentation.viewModel, isPresented: $snackBarPresentation.isSnackbarPresented)
     }
 }

--- a/ios/NativeSigner/Screens/KeyDetails/Actions/ForgetKeySetAction.swift
+++ b/ios/NativeSigner/Screens/KeyDetails/Actions/ForgetKeySetAction.swift
@@ -1,0 +1,39 @@
+//
+//  ForgetKeySetAction.swift
+//  NativeSigner
+//
+//  Created by Krzysztof Rodak on 09/09/2022.
+//
+
+import SwiftUI
+
+final class ForgetKeySetAction {
+    private weak var seedsMediator: SeedsMediating!
+    @ObservedObject private var navigation: NavigationCoordinator
+    private var snackbarPresentation: BottomSnackbarPresentation
+
+    init(
+        navigation: NavigationCoordinator,
+        snackbarPresentation: BottomSnackbarPresentation = ServiceLocator.bottomSnackbarPresentation,
+        seedsMediator: SeedsMediating? = nil
+    ) {
+        self.navigation = navigation
+        self.snackbarPresentation = snackbarPresentation
+        self.seedsMediator = seedsMediator
+    }
+
+    func forgetKeySet(_ keySet: String) {
+        // This calls `navigation.perform(navigation: .init(action: .removeSeed), skipDebounce: true)` underneath,
+        // which will call Rust state machine and user will be taken to Logs tab to see new history card regarding key set removal
+        // I'll move it outside of `seedsMediator` when all removal actions are refactored
+        seedsMediator?.removeSeed(seedName: keySet)
+        // We need this call to Rust state machine to move user manually from Logs to Keys tab as per new design
+        navigation.perform(navigation: .init(action: .navbarKeys))
+        // After moving user to Keys, present snackbar from bottom as action confirmation
+        snackbarPresentation.viewModel = .init(
+            title: Localizable.KeySetsModal.Confirmation.snackbar.string,
+            style: .warning
+        )
+        snackbarPresentation.isSnackbarPresented = true
+    }
+}

--- a/ios/NativeSigner/Screens/KeyDetails/KeyDetailsView.swift
+++ b/ios/NativeSigner/Screens/KeyDetails/KeyDetailsView.swift
@@ -11,21 +11,21 @@ struct KeyDetailsView: View {
     @State private var isShowingActionSheet = false
     @State private var isShowingRemoveConfirmation: Bool = false
     @ObservedObject private var navigation: NavigationCoordinator
-    private var seedsMediator: SeedsMediating!
 
     private let alertClosure: (() -> Void)?
     private let viewModel: KeyDetailsViewModel
     private let actionModel: KeyDetailsActionModel
+    private let forgetKeyActionHandler: ForgetKeySetAction
 
     init(
         navigation: NavigationCoordinator,
-        seedsMediator: SeedsMediating? = nil,
+        forgetKeyActionHandler: ForgetKeySetAction,
         viewModel: KeyDetailsViewModel,
         actionModel: KeyDetailsActionModel,
         alertClosure: (() -> Void)? = nil
     ) {
         self.navigation = navigation
-        self.seedsMediator = seedsMediator
+        self.forgetKeyActionHandler = forgetKeyActionHandler
         self.viewModel = viewModel
         self.actionModel = actionModel
         self.alertClosure = alertClosure
@@ -126,15 +126,11 @@ struct KeyDetailsView: View {
         .fullScreenCover(isPresented: $isShowingRemoveConfirmation) {
             HorizontalActionsBottomModal(
                 viewModel: .forgetKeySet,
-                mainAction: {
-                    seedsMediator?.removeSeed(seedName: actionModel.removeSeed)
-                },
-                dismissAction: {
-                    // We need to fake right button action here or Rust machine will break
-                    // In old UI, if you dismiss equivalent of this modal, underlying modal would still be there,
-                    // so we need to inform Rust we actually hid it
-                    navigation.perform(navigation: .init(action: .rightButtonAction))
-                },
+                mainAction: forgetKeyActionHandler.forgetKeySet(actionModel.removeSeed),
+                // We need to fake right button action here or Rust machine will break
+                // In old UI, if you dismiss equivalent of this modal, underlying modal would still be there,
+                // so we need to inform Rust we actually hid it
+                dismissAction: navigation.perform(navigation: .init(action: .rightButtonAction), skipDebounce: true),
                 isShowingBottomAlert: $isShowingRemoveConfirmation
             )
             .clearModalBackground()

--- a/ios/NativeSigner/Screens/KeySetsList/KeySetList.swift
+++ b/ios/NativeSigner/Screens/KeySetsList/KeySetList.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct KeySetList: View {
     @ObservedObject private var navigation: NavigationCoordinator
     @State private var isShowingNewSeedMenu = false
+
     private let viewModel: KeySetListViewModel
 
     init(

--- a/ios/NativeSigner/Screens/ScreenSelector.swift
+++ b/ios/NativeSigner/Screens/ScreenSelector.swift
@@ -33,7 +33,7 @@ struct ScreenSelector: View {
         case let .keys(value):
             KeyDetailsView(
                 navigation: navigation,
-                seedsMediator: data.seedsMediator,
+                forgetKeyActionHandler: ForgetKeySetAction(navigation: navigation, seedsMediator: data.seedsMediator),
                 viewModel: KeyDetailsViewModel(value),
                 actionModel: KeyDetailsActionModel(value, alert: alert, alertShow: alertShow)
             )


### PR DESCRIPTION
## Purpose
This PR provides custom `Snackbar` component and necessary additional reusable components that enable animation transitions and others 

## Scope
- `Snackbar` UI component
- `BottomEdgeOverlay`, `TapAndDelayDismissAnimator` components that can be used with any View to provide bottom edge animation and autodismiss functonality
- set of ViewModifiers to use any of above and snackbar with both mentioned components through `ViewModifier`
- addition of `.bottomSnackbar` to `AuthenticatedScreenContainer`, to present Snackbar from every view over tab bar (or just bottom edge)

Additionally to update `Forget Key Set` flow:
- possibility to chain calls to Rust without UI debounce that's implemented by default to prevent accidental double taps on UI actionable components
- `ForgetKeySetAction` that wraps all necessary calls to properly remove Key Set and then reroute user to Keys screen (as by default Rust sends user to Logs...)

## Screenshots

| Interaction flow |
|-|
|<img src="https://user-images.githubusercontent.com/1955364/189359350-cd760fff-0d77-490f-93e6-7bd351753bb4.gif" width="320px">|

