### PR TITLE
style: iOS fix spacing and icons color for Key Details screen

### DIFF
--- a/ios/NativeSigner/Screens/KeyDetails/DerivedKeyRow.swift
+++ b/ios/NativeSigner/Screens/KeyDetails/DerivedKeyRow.swift
@@ -16,10 +16,9 @@ struct DerivedKeyRow: View {
 
     var body: some View {
         HStack(alignment: .top, spacing: Spacing.small) {
-            VStack {
-                Identicon(identicon: viewModel.identicon, rowHeight: Heights.identiconInCell)
-                    .padding(.top, Spacing.extraExtraSmall)
-            }
+            Identicon(identicon: viewModel.identicon, rowHeight: Heights.identiconInCell)
+                .padding(.top, Spacing.extraExtraSmall)
+                .padding(.leading, Spacing.medium)
             VStack(alignment: .leading) {
                 HStack(alignment: .top, spacing: 0) {
                     Text(viewModel.path)
@@ -42,11 +41,12 @@ struct DerivedKeyRow: View {
             Spacer()
             VStack(alignment: .center) {
                 Asset.chevronRight.swiftUIImage
-                    .foregroundColor(Asset.textAndIconsTertiary.swiftUIColor)
+                    .foregroundColor(Asset.textAndIconsSecondary.swiftUIColor)
+                    .padding(.trailing, Spacing.large)
             }
             .frame(minHeight: .zero, maxHeight: .infinity)
         }
-        .padding(Spacing.medium)
+        .padding([.top, .bottom], Spacing.medium)
         .fixedSize(horizontal: false, vertical: true)
     }
 }

--- a/ios/NativeSigner/Screens/KeyDetails/KeyDetailsView.swift
+++ b/ios/NativeSigner/Screens/KeyDetails/KeyDetailsView.swift
@@ -58,6 +58,7 @@ struct KeyDetailsView: View {
                     }
                     Spacer().frame(maxWidth: .infinity)
                     Asset.chevronRight.swiftUIImage
+                        .foregroundColor(Asset.textAndIconsSecondary.swiftUIColor)
                 }
                 .padding(Padding.detailsCell)
                 .contentShape(Rectangle())


### PR DESCRIPTION
## Purpose
Fixing UI issue reported by @tetekinandrey 

## Screenshots

| Current | Fix |
|-|-|
|<img src="https://user-images.githubusercontent.com/1955364/190173685-aaf8020e-3631-4758-81fe-25eb8eb68012.png" width="320px">|<img src="https://user-images.githubusercontent.com/1955364/190173600-fdb13c01-9383-43b5-addb-1e2bed875735.png" width="320px">|
