### PR TITLE
chore: remove TF version from fastlane to avoid selecting beta build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source "https://rubygems.org"
 
 gem 'fastlane'
-gem 'xcode-install'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,9 +196,6 @@ GEM
     unicode-display_width (1.8.0)
     webrick (1.7.0)
     word_wrap (1.0.0)
-    xcode-install (2.8.1)
-      claide (>= 0.9.1)
-      fastlane (>= 2.1.0, < 3.0.0)
     xcodeproj (1.22.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
@@ -217,7 +214,6 @@ PLATFORMS
 
 DEPENDENCIES
   fastlane
-  xcode-install
 
 BUNDLED WITH
    2.3.11

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -1,5 +1,4 @@
 opt_out_usage
-xcversion(version: "~>14.0")
 default_platform(:ios)
 
 ENV["FASTLANE_XCODEBUILD_SETTINGS_RETRIES"] = "5"


### PR DESCRIPTION
## Purpose
Extension of https://github.com/paritytech/parity-signer/pull/1296
Although my last PR fixed TF flow for me locally, there are mutliple Xcode 14.0 instances on GA (beta + official), so I needed to remove Fastlane Xcode selection as it was defaulting to beta build to rely fully on xcode-select call in initial GA setup.

Below build was triggered and successfully distributed using this branch, this confirming that this works
https://github.com/paritytech/parity-signer/actions/runs/3081535731
