### PR TITLE
feat: iOS empty state for Key Set List

### DIFF
--- a/ios/NativeSigner/Resources/en.lproj/Localizable.strings
+++ b/ios/NativeSigner/Resources/en.lproj/Localizable.strings
@@ -276,6 +276,8 @@
 "KeySets.Action.Add" = "Add Key Set";
 "KeySets.Label.DerivedKeys.single" = "%@ Derived Key";
 "KeySets.Label.DerivedKeys.plural" = "%@ Derived Keys";
+"KeySets.Label.Empty.Title" = "You Don't Have\nAny Key Sets";
+"KeySets.Label.Empty.Subtitle" = "Add a new Key Set to Store Keys and Sign Transactions";
 
 "KeySetsModal.Action.Select" = "Select Keys";
 "KeySetsModal.Action.Derive" = "Derive from Key";

--- a/ios/NativeSigner/Screens/KeySetsList/KeySetList.swift
+++ b/ios/NativeSigner/Screens/KeySetsList/KeySetList.swift
@@ -28,30 +28,34 @@ struct KeySetList: View {
                     navigation: navigation,
                     viewModel: NavigationBarViewModel(title: Localizable.KeySets.title.string)
                 )
-                List {
-                    ForEach(
-                        viewModel.list.sorted(by: { $0.keyName < $1.keyName }),
-                        id: \.keyName
-                    ) { keySet in
-                        KeySetRow(keySet).onTapGesture {
-                            navigation.perform(navigation: .init(action: .selectSeed, details: keySet.keyName))
+                if viewModel.list.isEmpty {
+                    KeyListEmptyState()
+                } else {
+                    List {
+                        ForEach(
+                            viewModel.list.sorted(by: { $0.keyName < $1.keyName }),
+                            id: \.keyName
+                        ) { keySet in
+                            KeySetRow(keySet).onTapGesture {
+                                navigation.perform(navigation: .init(action: .selectSeed, details: keySet.keyName))
+                            }
+                            .listRowBackground(Asset.backgroundSystem.swiftUIColor)
+                            .listRowSeparator(.hidden)
+                            .listRowInsets(.init(
+                                top: Spacing.extraExtraSmall,
+                                leading: Spacing.extraSmall,
+                                bottom: Spacing.extraExtraSmall,
+                                trailing: Spacing.extraSmall
+                            ))
                         }
-                        .listRowBackground(Asset.backgroundSystem.swiftUIColor)
-                        .listRowSeparator(.hidden)
-                        .listRowInsets(.init(
-                            top: Spacing.extraExtraSmall,
-                            leading: Spacing.extraSmall,
-                            bottom: Spacing.extraExtraSmall,
-                            trailing: Spacing.extraSmall
-                        ))
+                        Spacer()
+                            .listRowBackground(Asset.backgroundSystem.swiftUIColor)
+                            .listRowSeparator(.hidden)
+                            .frame(height: Heights.actionButton + Spacing.large)
                     }
-                    Spacer()
-                        .listRowBackground(Asset.backgroundSystem.swiftUIColor)
-                        .listRowSeparator(.hidden)
-                        .frame(height: Heights.actionButton + Spacing.large)
+                    .listStyle(.plain)
+                    .hiddenScrollContent()
                 }
-                .listStyle(.plain)
-                .hiddenScrollContent()
             }
             PrimaryButton(
                 action: {
@@ -76,55 +80,74 @@ struct KeySetList: View {
     }
 }
 
-// struct KeySetListPreview: PreviewProvider {
-//    static var previews: some View {
-//        KeySetList(
-//            navigation: NavigationCoordinator(),
-//            viewModel: KeySetListViewModelBuilder()
-//                .build(
-//                    for:
-//                    MSeeds(
-//                        seedNameCards: [
-//                            SeedNameCard(
-//                                seedName: "aaaa",
-//                                identicon: PreviewData.exampleIdenticon,
-//                                derivedKeysCount: 3
-//                            ),
-//                            SeedNameCard(
-//                                seedName: "bbbb",
-//                                identicon: PreviewData.exampleIdenticon,
-//                                derivedKeysCount: 0
-//                            ),
-//                            SeedNameCard(
-//                                seedName: "cccc",
-//                                identicon: PreviewData.exampleIdenticon,
-//                                derivedKeysCount: 1
-//                            ),
-//                            SeedNameCard(
-//                                seedName: "dddd",
-//                                identicon: PreviewData.exampleIdenticon,
-//                                derivedKeysCount: 4
-//                            ),
-//                            SeedNameCard(
-//                                seedName: "eeee",
-//                                identicon: PreviewData.exampleIdenticon,
-//                                derivedKeysCount: 15
-//                            ),
-//                            SeedNameCard(
-//                                seedName: "ffff",
-//                                identicon: PreviewData.exampleIdenticon,
-//                                derivedKeysCount: 1
-//                            ),
-//                            SeedNameCard(
-//                                seedName: "gggg",
-//                                identicon: PreviewData.exampleIdenticon,
-//                                derivedKeysCount: 0
-//                            )
-//                        ]
-//                    )
-//                )
-//        )
-//        .preferredColorScheme(.dark)
-//        .previewLayout(.sizeThatFits)
-//    }
-// }
+private struct KeyListEmptyState: View {
+    var body: some View {
+        VStack(spacing: Spacing.extraSmall) {
+            Spacer()
+            Text(Localizable.KeySets.Label.Empty.title.key)
+                .font(Fontstyle.titleM.base)
+            Text(Localizable.KeySets.Label.Empty.subtitle.key)
+                .font(Fontstyle.bodyL.base)
+            Spacer()
+                .frame(height: Heights.actionButton + 2 * Spacing.large)
+            Spacer()
+        }
+        .padding(Spacing.componentSpacer)
+        .multilineTextAlignment(.center)
+        .lineSpacing(Spacing.extraExtraSmall)
+        .foregroundColor(Asset.textAndIconsPrimary.swiftUIColor)
+    }
+}
+
+struct KeySetListPreview: PreviewProvider {
+    static var previews: some View {
+        KeySetList(
+            navigation: NavigationCoordinator(),
+            viewModel: KeySetListViewModelBuilder()
+                .build(
+                    for:
+                    MSeeds(
+                        seedNameCards: [
+                            SeedNameCard(
+                                seedName: "aaaa",
+                                identicon: PreviewData.exampleIdenticon,
+                                derivedKeysCount: 3
+                            ),
+                            SeedNameCard(
+                                seedName: "bbbb",
+                                identicon: PreviewData.exampleIdenticon,
+                                derivedKeysCount: 0
+                            ),
+                            SeedNameCard(
+                                seedName: "cccc",
+                                identicon: PreviewData.exampleIdenticon,
+                                derivedKeysCount: 1
+                            ),
+                            SeedNameCard(
+                                seedName: "dddd",
+                                identicon: PreviewData.exampleIdenticon,
+                                derivedKeysCount: 4
+                            ),
+                            SeedNameCard(
+                                seedName: "eeee",
+                                identicon: PreviewData.exampleIdenticon,
+                                derivedKeysCount: 15
+                            ),
+                            SeedNameCard(
+                                seedName: "ffff",
+                                identicon: PreviewData.exampleIdenticon,
+                                derivedKeysCount: 1
+                            ),
+                            SeedNameCard(
+                                seedName: "gggg",
+                                identicon: PreviewData.exampleIdenticon,
+                                derivedKeysCount: 0
+                            )
+                        ]
+                    )
+                )
+        )
+        .preferredColorScheme(.dark)
+        .previewLayout(.sizeThatFits)
+    }
+}


### PR DESCRIPTION
## Purpose
This PR provides empty state for `Key Set List` screen according to new Figma designs

## Screenshots

| Light | Dark |
|-|-|
|<img src="https://user-images.githubusercontent.com/1955364/191051824-018200df-d1cb-4013-93d4-22ca9a94271d.png" width="320px">|<img src="https://user-images.githubusercontent.com/1955364/191051866-05478bc7-a001-4696-868d-dece76e7613b.png" width="320px">|

### Interaction

| Dark |
|-|
|<img src="https://user-images.githubusercontent.com/1955364/191051987-2ab3513b-10ae-4ca4-a39c-d2eebe1671b9.gif" width="320px">|