### PR TITLE
fix: fix clippy on new stable

### DIFF
--- a/rust/db_handling/src/helpers.rs
+++ b/rust/db_handling/src/helpers.rs
@@ -608,11 +608,7 @@ where
                         network_specs.genesis_hash,
                     );
                     events.push(Event::IdentityRemoved { identity_history });
-                    address_details.network_id = address_details
-                        .network_id
-                        .into_iter()
-                        .filter(|id| id != key)
-                        .collect();
+                    address_details.network_id.retain(|id| id != key);
                 }
             }
             if address_details.network_id.is_empty() {

--- a/rust/db_handling/src/identities.rs
+++ b/rust/db_handling/src/identities.rs
@@ -685,11 +685,9 @@ where
             network_specs.genesis_hash,
         );
         events.push(Event::IdentityRemoved { identity_history });
-        address_details.network_id = address_details
+        address_details
             .network_id
-            .into_iter()
-            .filter(|id| id != network_specs_key)
-            .collect();
+            .retain(|id| id != network_specs_key);
         if address_details.network_id.is_empty() {
             id_batch.remove(address_key.key())
         } else {

--- a/rust/defaults/src/lib.rs
+++ b/rust/defaults/src/lib.rs
@@ -362,13 +362,13 @@ pub fn default_types_vec() -> Result<Vec<TypeEntry>> {
     let mut types_prep: Vec<TypeEntry> = Vec::new();
 
     for caps1 in REG_STRUCTS_WITH_NAMES.captures_iter(&type_info) {
-        let struct_name = (&caps1["name"]).to_string();
-        let struct_description = (&caps1["description"]).to_string();
+        let struct_name = (caps1["name"]).to_string();
+        let struct_description = (caps1["description"]).to_string();
         let mut struct_fields: Vec<StructField> = Vec::new();
         for caps2 in REG_STRUCT_FIELDS.captures_iter(&struct_description) {
             let new = StructField {
-                field_name: Some((&caps2["field_name"]).to_string()),
-                field_type: (&caps2["field_type"]).to_string(),
+                field_name: Some((caps2["field_name"]).to_string()),
+                field_type: (caps2["field_type"]).to_string(),
             };
             struct_fields.push(new);
         }
@@ -381,17 +381,17 @@ pub fn default_types_vec() -> Result<Vec<TypeEntry>> {
     for caps in REG_STRUCTS_NO_NAMES.captures_iter(&type_info) {
         let only_field = StructField {
             field_name: None,
-            field_type: (&caps["description"]).to_string(),
+            field_type: (caps["description"]).to_string(),
         };
         let new_entry = TypeEntry {
-            name: (&caps["name"]).to_string(),
+            name: (caps["name"]).to_string(),
             description: Description::Struct(vec![only_field]),
         };
         types_prep.push(new_entry);
     }
     for caps1 in REG_ENUM.captures_iter(&type_info) {
-        let enum_name = (&caps1["name"]).to_string();
-        let enum_description = (&caps1["description"]).to_string();
+        let enum_name = (caps1["name"]).to_string();
+        let enum_description = (caps1["description"]).to_string();
         let enum_variants = enum_description
             .lines()
             .filter(|line| REG_ENUM_VARIANTS.is_match(line))
@@ -399,7 +399,7 @@ pub fn default_types_vec() -> Result<Vec<TypeEntry>> {
                 let caps2 = REG_ENUM_VARIANTS
                     .captures(line)
                     .expect("just checked it is match");
-                let variant_name = (&caps2["variant_name"]).to_string();
+                let variant_name = (caps2["variant_name"]).to_string();
                 let variant_type = match caps2.name("variant_type") {
                     None => EnumVariantType::None,
                     Some(a) => {
@@ -408,7 +408,7 @@ pub fn default_types_vec() -> Result<Vec<TypeEntry>> {
                             // either a single type or a tuple
                             match REG_ENUM_SIMPLE.captures(&x[1..x.len() - 1]) {
                                 // single type
-                                Some(b) => EnumVariantType::Type((&b["simple_type"]).to_string()),
+                                Some(b) => EnumVariantType::Type((b["simple_type"]).to_string()),
                                 // tuple
                                 None => EnumVariantType::Type(x),
                             }
@@ -417,8 +417,8 @@ pub fn default_types_vec() -> Result<Vec<TypeEntry>> {
                             let mut type_is_struct: Vec<StructField> = Vec::new();
                             for caps3 in REG_ENUM_STRUCT.captures_iter(&x) {
                                 let new = StructField {
-                                    field_name: Some((&caps3["field_name"]).to_string()),
-                                    field_type: (&caps3["field_type"]).to_string(),
+                                    field_name: Some((caps3["field_name"]).to_string()),
+                                    field_type: (caps3["field_type"]).to_string(),
                                 };
                                 type_is_struct.push(new);
                             }
@@ -440,8 +440,8 @@ pub fn default_types_vec() -> Result<Vec<TypeEntry>> {
     }
     for caps in REG_TYPES.captures_iter(&type_info) {
         let new_entry = TypeEntry {
-            name: (&caps["name"]).to_string(),
-            description: Description::Type((&caps["description"]).to_string()),
+            name: (caps["name"]).to_string(),
+            description: Description::Type((caps["description"]).to_string()),
         };
         types_prep.push(new_entry);
     }

--- a/rust/navigator/src/screens.rs
+++ b/rust/navigator/src/screens.rs
@@ -177,10 +177,7 @@ impl KeysState {
             SpecialtyKeysState::MultiSelect(multiselect) => {
                 let mut new_multiselect = multiselect.to_owned();
                 if multiselect.contains(multisigner) {
-                    new_multiselect = new_multiselect
-                        .into_iter()
-                        .filter(|a| a != multisigner)
-                        .collect();
+                    new_multiselect.retain(|a| a != multisigner);
                 } else {
                     new_multiselect.push(multisigner.to_owned());
                 }

--- a/rust/parser/src/decoding_older.rs
+++ b/rust/parser/src/decoding_older.rs
@@ -365,7 +365,7 @@ fn deal_with_option(
         };
         let remaining_vector = {
             if data.len() > 1 {
-                (&data[1..]).to_vec()
+                data[1..].to_vec()
             } else {
                 Vec::new()
             }
@@ -379,7 +379,7 @@ fn deal_with_option(
             0 => {
                 let remaining_vector = {
                     if data.len() > 1 {
-                        (&data[1..]).to_vec()
+                        data[1..].to_vec()
                     } else {
                         Vec::new()
                     }
@@ -597,7 +597,7 @@ fn special_case_bitvec(data: Vec<u8>, indent: u32) -> Result<DecodedOut> {
     // the data is preluded by compact indicating the number of `BitVec` elements - info from js documentation, decode not implemented for `BitVec` as is
     let pre_bitvec = get_compact::<u32>(&data)?;
     let actual_length = match pre_bitvec.compact_found % 8 {
-        0 => (pre_bitvec.compact_found / 8),
+        0 => pre_bitvec.compact_found / 8,
         _ => (pre_bitvec.compact_found / 8) + 1,
     };
     match pre_bitvec.start_next_unit {
@@ -793,7 +793,7 @@ fn deal_with_enum(
         EnumVariantType::None => {
             let remaining_vector = {
                 if data.len() > 1 {
-                    (&data[1..]).to_vec()
+                    data[1..].to_vec()
                 } else {
                     Vec::new()
                 }

--- a/rust/parser/src/decoding_sci.rs
+++ b/rust/parser/src/decoding_sci.rs
@@ -1001,7 +1001,7 @@ fn decode_type_def_bit_sequence(
 ) -> Result<DecodedOut> {
     let pre_bitvec = get_compact::<u32>(&data)?;
     let actual_length = match pre_bitvec.compact_found % 8 {
-        0 => (pre_bitvec.compact_found / 8),
+        0 => pre_bitvec.compact_found / 8,
         _ => (pre_bitvec.compact_found / 8) + 1,
     };
     match pre_bitvec.start_next_unit {

--- a/rust/transaction_parsing/src/check_signature.rs
+++ b/rust/transaction_parsing/src/check_signature.rs
@@ -32,7 +32,7 @@ pub fn pass_crypto(data_hex: &str, content: TransferContent) -> Result<InfoPasse
                 tail[64..].to_vec(),
             );
             ed25519::Pair::verify(&signature, &message, &pubkey)
-                .then(|| ())
+                .then_some(())
                 .ok_or(Error::BadSignature)?;
             let verifier = Verifier {
                 v: Some(VerifierValue::Standard {
@@ -58,7 +58,7 @@ pub fn pass_crypto(data_hex: &str, content: TransferContent) -> Result<InfoPasse
                 tail[64..].to_vec(),
             );
             sr25519::Pair::verify(&signature, &message, &pubkey)
-                .then(|| ())
+                .then_some(())
                 .ok_or(Error::BadSignature)?;
             let verifier = Verifier {
                 v: Some(VerifierValue::Standard {
@@ -84,7 +84,7 @@ pub fn pass_crypto(data_hex: &str, content: TransferContent) -> Result<InfoPasse
                 tail[65..].to_vec(),
             );
             ecdsa::Pair::verify(&signature, &message, &pubkey)
-                .then(|| ())
+                .then_some(())
                 .ok_or(Error::BadSignature)?;
             let verifier = Verifier {
                 v: Some(VerifierValue::Standard {


### PR DESCRIPTION
## Purpose

A new rustc version `1.64.0` has new `clippy` lints. This fixes them.
