### PR TITLE
fix: ios: add alert for backup modal if network was connected

### DIFF
--- a/ios/NativeSigner/Core/Keychain/SeedsMediator.swift
+++ b/ios/NativeSigner/Core/Keychain/SeedsMediator.swift
@@ -130,10 +130,6 @@ final class SeedsMediator: SeedsMediating {
     }
 
     func getSeedBackup(seedName: String) -> String {
-        if signerDataModel.alert {
-            signerDataModel.alertShow = true
-            return ""
-        }
         let result = keychainAccessAdapter.retrieveSeed(with: seedName)
         switch result {
         case let .success(resultSeed):

--- a/ios/NativeSigner/Screens/KeyDetails/KeyDetailsView.swift
+++ b/ios/NativeSigner/Screens/KeyDetails/KeyDetailsView.swift
@@ -13,9 +13,12 @@ struct KeyDetailsView: View {
     @State private var isShowingActionSheet = false
     @State private var isShowingRemoveConfirmation: Bool = false
     @State private var isShowingBackupModal: Bool = false
+    @State private var isPresentingConnectivityAlert = false
 
     @ObservedObject private var navigation: NavigationCoordinator
+    @ObservedObject private var data: SignerDataModel
 
+    @State private var backupModalViewModel: BackupModalViewModel?
     private let alertClosure: (() -> Void)?
     private let viewModel: KeyDetailsViewModel
     private let actionModel: KeyDetailsActionModel
@@ -24,6 +27,7 @@ struct KeyDetailsView: View {
 
     init(
         navigation: NavigationCoordinator,
+        data: SignerDataModel,
         forgetKeyActionHandler: ForgetKeySetAction,
         viewModel: KeyDetailsViewModel,
         actionModel: KeyDetailsActionModel,
@@ -31,6 +35,7 @@ struct KeyDetailsView: View {
         alertClosure: (() -> Void)? = nil
     ) {
         self.navigation = navigation
+        self.data = data
         self.forgetKeyActionHandler = forgetKeyActionHandler
         self.viewModel = viewModel
         self.actionModel = actionModel
@@ -124,6 +129,9 @@ struct KeyDetailsView: View {
             )
             .padding(Spacing.large)
         }
+        .onAppear {
+            backupModalViewModel = exportPrivateKeyService.backupViewModel()
+        }
         .fullScreenCover(
             isPresented: $isShowingActionSheet,
             onDismiss: {
@@ -133,7 +141,13 @@ struct KeyDetailsView: View {
                 }
                 if shouldPresentBackupModal == true {
                     shouldPresentBackupModal.toggle()
-                    isShowingBackupModal.toggle()
+                    if data.alert || backupModalViewModel == nil {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                            isPresentingConnectivityAlert.toggle()
+                        }
+                    } else {
+                        isShowingBackupModal.toggle()
+                    }
                 }
             }
         ) {
@@ -152,13 +166,13 @@ struct KeyDetailsView: View {
                 // We need to fake right button action here or Rust machine will break
                 // In old UI, if you dismiss equivalent of this modal, underlying modal would still be there,
                 // so we need to inform Rust we actually hid it
-                dismissAction: navigation.perform(navigation: .init(action: .rightButtonAction), skipDebounce: true),
+                dismissAction: { _ = navigation.performFake(navigation: .init(action: .rightButtonAction)) }(),
                 isShowingBottomAlert: $isShowingRemoveConfirmation
             )
             .clearModalBackground()
         }
         .fullScreenCover(isPresented: $isShowingBackupModal) {
-            if let viewModel = exportPrivateKeyService.backupViewModel() {
+            if let viewModel = backupModalViewModel {
                 BackupModal(
                     isShowingBackupModal: $isShowingBackupModal,
                     viewModel: viewModel
@@ -168,6 +182,18 @@ struct KeyDetailsView: View {
                 EmptyView()
             }
         }
+        .alert(
+            data.canaryDead ? Localizable.Connectivity.Label.title.string : Localizable.PastConnectivity
+                .Label.title.string,
+            isPresented: $isPresentingConnectivityAlert,
+            actions: {
+                Button(Localizable.Connectivity.Action.ok.string) { isPresentingConnectivityAlert.toggle() }
+            },
+            message: {
+                data.canaryDead ? Localizable.Connectivity.Label.content.text : Localizable.PastConnectivity
+                    .Label.content.text
+            }
+        )
     }
 }
 
@@ -176,6 +202,7 @@ struct KeyDetailsView_Previews: PreviewProvider {
         VStack {
             KeyDetailsView(
                 navigation: NavigationCoordinator(),
+                data: SignerDataModel(navigation: NavigationCoordinator()),
                 forgetKeyActionHandler: .init(navigation: NavigationCoordinator()),
                 viewModel: .init(
                     keySummary: KeySummaryViewModel(

--- a/ios/NativeSigner/Screens/PublicKey/KeyDetailsPublicKeyView.swift
+++ b/ios/NativeSigner/Screens/PublicKey/KeyDetailsPublicKeyView.swift
@@ -169,7 +169,7 @@ struct KeyDetailsPublicKeyView: View {
                 // We need to fake right button action here or Rust machine will break
                 // In old UI, if you dismiss equivalent of this modal, underlying modal would still be there,
                 // so we need to inform Rust we actually hid it
-                dismissAction: navigation.perform(navigation: .init(action: .rightButtonAction), skipDebounce: true),
+                dismissAction: { _ = navigation.performFake(navigation: .init(action: .rightButtonAction)) }(),
                 isShowingBottomAlert: $isShowingRemoveConfirmation
             )
             .clearModalBackground()

--- a/ios/NativeSigner/Screens/ScreenSelector.swift
+++ b/ios/NativeSigner/Screens/ScreenSelector.swift
@@ -33,6 +33,7 @@ struct ScreenSelector: View {
         case let .keys(value):
             KeyDetailsView(
                 navigation: navigation,
+                data: data,
                 forgetKeyActionHandler: ForgetKeySetAction(navigation: navigation),
                 viewModel: KeyDetailsViewModel(value),
                 actionModel: KeyDetailsActionModel(value, alert: alert, alertShow: alertShow),


### PR DESCRIPTION
## Purpose
This PR fixes flow on `Backup Modal` when user was or is connected to network

## Discussion
I'll replace system alert with custom one, once it's done and available

## Screenshots

| Example interaction | 
|-|
|<img src="https://user-images.githubusercontent.com/1955364/191984133-dd3c171c-eb0b-42ad-be69-71890408ed24.gif" width="320px">|

