### PR TITLE
iOS: improving redesigned screens based on feedback

### DIFF
--- a/ios/NativeSigner/Components/Modals/FullScreenRoundedModal.swift
+++ b/ios/NativeSigner/Components/Modals/FullScreenRoundedModal.swift
@@ -48,7 +48,7 @@ struct FullScreenRoundedModal<Content: View>: View {
                 VStack(alignment: .leading, spacing: Spacing.medium, content: content)
                     .padding([.bottom, .top], Spacing.medium)
                     .padding([.leading, .trailing], 0)
-                    .background(Asset.backgroundSecondary.swiftUIColor)
+                    .background(Asset.backgroundTertiary.swiftUIColor)
                     .cornerRadius(radius: CornerRadius.medium, corners: [.topLeft, .topRight])
             }
         }

--- a/ios/NativeSigner/Components/NavigationBarView.swift
+++ b/ios/NativeSigner/Components/NavigationBarView.swift
@@ -24,17 +24,20 @@ struct NavigationBarViewModel: Equatable {
     let subtitle: String?
     let leftButton: NavigationLeftButton
     let rightButton: NavigationRightButton
+    let backgroundColor: Color
 
     init(
         title: String? = nil,
         subtitle: String? = nil,
         leftButton: NavigationLeftButton = .empty,
-        rightButton: NavigationRightButton = .empty
+        rightButton: NavigationRightButton = .empty,
+        backgroundColor: Color = Asset.backgroundPrimary.swiftUIColor
     ) {
         self.title = title
         self.subtitle = subtitle
         self.leftButton = leftButton
         self.rightButton = rightButton
+        self.backgroundColor = backgroundColor
     }
 }
 
@@ -108,7 +111,7 @@ struct NavigationBarView: View {
         .padding([.leading, .trailing], Spacing.extraExtraSmall)
         .frame(maxWidth: .infinity)
         .frame(height: Heights.navigationBarHeight)
-        .background(Asset.backgroundSystem.swiftUIColor)
+        .background(viewModel.backgroundColor)
     }
 }
 

--- a/ios/NativeSigner/Components/TabBar/TabBarView.swift
+++ b/ios/NativeSigner/Components/TabBar/TabBarView.swift
@@ -11,6 +11,8 @@ import SwiftUI
 ///
 /// `body` should rely on system `TabView` or its subclass, when navigation is moved to native system
 struct TabBarView: View {
+    @Environment(\.colorScheme) var deviceColorScheme: ColorScheme
+
     /// Handles navigation when `Tab` is selected
     @ObservedObject var navigation: NavigationCoordinator
     /// View model reflecting selected tab in bottom navigation
@@ -30,8 +32,12 @@ struct TabBarView: View {
                 )
             }
         }
-        .frame(height: 49)
-        .background(Asset.backgroundPrimary.swiftUIColor)
+        .frame(height: Heights.tabbarHeight)
+        .background(Asset.backgroundSecondary.swiftUIColor)
+        .overlay(
+            Divider().background(deviceColorScheme == .dark ? Asset.fill30LightOnly.swiftUIColor : Color.clear),
+            alignment: .top
+        )
     }
 }
 

--- a/ios/NativeSigner/Design/Heights.swift
+++ b/ios/NativeSigner/Design/Heights.swift
@@ -25,6 +25,7 @@ enum Heights {
     static let keyCellContainer: CGFloat = 72
     /// Height for `Identicon` when used in list collections
     static let identiconInCell: CGFloat = 36
+    static let tabbarHeight: CGFloat = 49
 }
 
 enum Sizes {

--- a/ios/NativeSigner/Modals/Backup/BackupModal.swift
+++ b/ios/NativeSigner/Modals/Backup/BackupModal.swift
@@ -96,6 +96,10 @@ struct BackupModal: View {
                             }
                             QRCodeContainerView(viewModel: viewModel.qrCode)
                                 .fixedSize(horizontal: false, vertical: true)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: CornerRadius.medium)
+                                        .stroke(Asset.fill12.swiftUIColor, lineWidth: 0.5)
+                                )
                             Spacer()
                                 .frame(height: Spacing.componentSpacer)
                         }

--- a/ios/NativeSigner/Modals/ExportPrivateKey/ExportPrivateKeyModal.swift
+++ b/ios/NativeSigner/Modals/ExportPrivateKey/ExportPrivateKeyModal.swift
@@ -40,6 +40,7 @@ struct ExportPrivateKeyModal: View {
                     // QR Code container
                     VStack(spacing: 0) {
                         QRCodeContainerView(viewModel: viewModel.qrCode)
+                            .padding(0.5)
                         QRCodeAddressFooterView(viewModel: viewModel.addressFooter)
                     }
                     .fixedSize(horizontal: false, vertical: true)
@@ -96,39 +97,39 @@ private struct ExportPrivateKeyAddressFooter: View {
     }
 }
 
-// struct ExportPrivateKeyModal_Previews: PreviewProvider {
-//    static var previews: some View {
-//        Group {
-//            VStack {
-//                ExportPrivateKeyModal(
-//                    isPresentingExportKeysModal: Binding<Bool>.constant(true),
-//                    navigation: NavigationCoordinator(),
-//                    viewModel: PreviewData.exampleExportPrivateKey
-//                )
-//            }
-//            .previewDevice("iPhone 11 Pro")
-//            .background(.gray)
-//            .preferredColorScheme(.dark)
-//            VStack {
-//                ExportPrivateKeyModal(
-//                    isPresentingExportKeysModal: Binding<Bool>.constant(true),
-//                    navigation: NavigationCoordinator(),
-//                    viewModel: PreviewData.exampleExportPrivateKey
-//                )
-//            }
-//            .previewDevice("iPod touch (7th generation)")
-//            .background(.gray)
-//            .preferredColorScheme(.dark)
-//            VStack {
-//                ExportPrivateKeyModal(
-//                    isPresentingExportKeysModal: Binding<Bool>.constant(true),
-//                    navigation: NavigationCoordinator(),
-//                    viewModel: PreviewData.exampleExportPrivateKey
-//                )
-//            }
-//            .previewDevice("iPhone 8")
-//            .background(.gray)
-//            .preferredColorScheme(.dark)
-//        }
-//    }
-// }
+struct ExportPrivateKeyModal_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            VStack {
+                ExportPrivateKeyModal(
+                    isPresentingExportKeysModal: Binding<Bool>.constant(true),
+                    navigation: NavigationCoordinator(),
+                    viewModel: PreviewData.exampleExportPrivateKey
+                )
+            }
+            .previewDevice("iPhone 11 Pro")
+            .background(.gray)
+            .preferredColorScheme(.dark)
+            VStack {
+                ExportPrivateKeyModal(
+                    isPresentingExportKeysModal: Binding<Bool>.constant(true),
+                    navigation: NavigationCoordinator(),
+                    viewModel: PreviewData.exampleExportPrivateKey
+                )
+            }
+            .previewDevice("iPod touch (7th generation)")
+            .background(.gray)
+            .preferredColorScheme(.dark)
+            VStack {
+                ExportPrivateKeyModal(
+                    isPresentingExportKeysModal: Binding<Bool>.constant(true),
+                    navigation: NavigationCoordinator(),
+                    viewModel: PreviewData.exampleExportPrivateKey
+                )
+            }
+            .previewDevice("iPhone 8")
+            .background(.gray)
+            .preferredColorScheme(.dark)
+        }
+    }
+}

--- a/ios/NativeSigner/Resources/Assets.xcassets/background_secondary.colorset/Contents.json
+++ b/ios/NativeSigner/Resources/Assets.xcassets/background_secondary.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x30",
-          "green" : "0x2C",
-          "red" : "0x2C"
+          "blue" : "0x23",
+          "green" : "0x1E",
+          "red" : "0x1E"
         }
       },
       "idiom" : "universal"

--- a/ios/NativeSigner/Resources/Assets.xcassets/background_tertiary.colorset/Contents.json
+++ b/ios/NativeSigner/Resources/Assets.xcassets/background_tertiary.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xFF",
-          "green" : "0xFF",
-          "red" : "0xFF"
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x15",
-          "green" : "0x10",
-          "red" : "0x10"
+          "blue" : "0x30",
+          "green" : "0x2C",
+          "red" : "0x2C"
         }
       },
       "idiom" : "universal"

--- a/ios/NativeSigner/Resources/Assets.xcassets/fill_30_light_only.colorset/Contents.json
+++ b/ios/NativeSigner/Resources/Assets.xcassets/fill_30_light_only.colorset/Contents.json
@@ -4,10 +4,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "1.000",
-          "blue" : "0xFF",
-          "green" : "0xFF",
-          "red" : "0xFF"
+          "alpha" : "0.300",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
         }
       },
       "idiom" : "universal"
@@ -22,10 +22,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "1.000",
-          "blue" : "0x15",
-          "green" : "0x10",
-          "red" : "0x10"
+          "alpha" : "0.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
         }
       },
       "idiom" : "universal"

--- a/ios/NativeSigner/Screens/KeyDetails/KeyDetailsView.swift
+++ b/ios/NativeSigner/Screens/KeyDetails/KeyDetailsView.swift
@@ -52,73 +52,52 @@ struct KeyDetailsView: View {
                         isShowingActionSheet.toggle()
                     })
                 )
-                // Main key cell
-                HStack {
-                    VStack(alignment: .leading, spacing: Spacing.extraExtraSmall) {
-                        Text(viewModel.keySummary.keyName)
-                            .foregroundColor(Asset.textAndIconsPrimary.swiftUIColor)
-                            .font(Fontstyle.titleL.base)
-                        Text(viewModel.keySummary.base58)
-                            .foregroundColor(Asset.textAndIconsTertiary.swiftUIColor)
-                            .font(Fontstyle.bodyM.base)
-                            .lineLimit(1)
-                    }
-                    Spacer().frame(maxWidth: .infinity)
-                    Asset.chevronRight.swiftUIImage
-                        .foregroundColor(Asset.textAndIconsSecondary.swiftUIColor)
-                }
-                .padding(Padding.detailsCell)
-                .contentShape(Rectangle())
-                .onTapGesture {
-                    navigation.perform(navigation: actionModel.addressKeyNavigation)
-                }
-                // Header
-                HStack {
-                    Localizable.KeyDetails.Label.derived.text
-                        .font(Fontstyle.bodyM.base)
-                    Spacer().frame(maxWidth: .infinity)
-                    Button(
-                        action: {
-                            navigation.perform(navigation: .init(action: .networkSelector))
-                        }, label: {
-                            Asset.switches.swiftUIImage
-                        }
-                    )
-                }
-                .foregroundColor(Asset.textAndIconsTertiary.swiftUIColor)
-                .padding(Padding.detailsCell)
-                // List of derived keys
                 List {
+                    // Main key cell
+                    KeySummaryView(viewModel: viewModel.keySummary)
+                        .padding(Padding.detailsCell)
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            navigation.perform(navigation: actionModel.addressKeyNavigation)
+                        }
+                        .keyDetailsListElement()
+                    // Header
+                    HStack {
+                        Localizable.KeyDetails.Label.derived.text
+                            .font(Fontstyle.bodyM.base)
+                        Spacer().frame(maxWidth: .infinity)
+                        Asset.switches.swiftUIImage
+                            .frame(width: Heights.actionSheetButton)
+                            .onTapGesture {
+                                navigation.perform(navigation: .init(action: .networkSelector))
+                            }
+                    }
+                    .foregroundColor(Asset.textAndIconsTertiary.swiftUIColor)
+                    .padding(Padding.detailsCell)
+                    .keyDetailsListElement()
+                    // List of derived keys
                     ForEach(
                         viewModel.derivedKeys,
                         id: \.viewModel.path
                     ) { deriveKey in
                         DerivedKeyRow(deriveKey.viewModel)
-                            .listRowBackground(Asset.backgroundSystem.swiftUIColor)
-                            .listRowSeparator(.hidden)
-                            .listRowInsets(EdgeInsets())
-                            .contentShape(Rectangle())
+                            .keyDetailsListElement()
                             .onTapGesture {
                                 navigation.perform(navigation: deriveKey.actionModel.tapAction)
                             }
                     }
                     Spacer()
-                        .listRowBackground(Asset.backgroundSystem.swiftUIColor)
-                        .listRowSeparator(.hidden)
+                        .keyDetailsListElement()
                         .frame(height: Heights.actionButton + Spacing.large)
                 }
                 .listStyle(.plain)
                 .hiddenScrollContent()
             }
-            .background(Asset.backgroundSystem.swiftUIColor)
+            .background(Asset.backgroundPrimary.swiftUIColor)
             // Main CTA
             PrimaryButton(
                 action: {
-                    if let alertClosure = actionModel.alertClosure {
-                        alertClosure()
-                    } else {
-                        navigation.perform(navigation: actionModel.createDerivedKey)
-                    }
+                    navigation.perform(navigation: actionModel.createDerivedKey)
                 },
                 text: Localizable.KeyDetails.Action.create.key
             )
@@ -167,6 +146,43 @@ struct KeyDetailsView: View {
             } else {
                 EmptyView()
             }
+        }
+    }
+}
+
+private struct KeyDetailsListElement: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .listRowBackground(Asset.backgroundPrimary.swiftUIColor)
+            .listRowSeparator(.hidden)
+            .listRowInsets(EdgeInsets())
+            .contentShape(Rectangle())
+    }
+}
+
+private extension View {
+    func keyDetailsListElement() -> some View {
+        modifier(KeyDetailsListElement())
+    }
+}
+
+private struct KeySummaryView: View {
+    let viewModel: KeySummaryViewModel
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: Spacing.extraExtraSmall) {
+                Text(viewModel.keyName)
+                    .foregroundColor(Asset.textAndIconsPrimary.swiftUIColor)
+                    .font(Fontstyle.titleL.base)
+                Text(viewModel.base58)
+                    .foregroundColor(Asset.textAndIconsTertiary.swiftUIColor)
+                    .font(Fontstyle.bodyM.base)
+                    .lineLimit(1)
+            }
+            Spacer().frame(maxWidth: .infinity)
+            Asset.chevronRight.swiftUIImage
+                .foregroundColor(Asset.textAndIconsSecondary.swiftUIColor)
         }
     }
 }

--- a/ios/NativeSigner/Screens/KeySetsList/KeySetList.swift
+++ b/ios/NativeSigner/Screens/KeySetsList/KeySetList.swift
@@ -23,14 +23,23 @@ struct KeySetList: View {
 
     var body: some View {
         ZStack(alignment: .bottom) {
+            // Background color
+            Asset.backgroundSystem.swiftUIColor
+            // Main screen
             VStack(spacing: 0) {
+                // Navigation Bar
                 NavigationBarView(
                     navigation: navigation,
-                    viewModel: NavigationBarViewModel(title: Localizable.KeySets.title.string)
+                    viewModel: NavigationBarViewModel(
+                        title: Localizable.KeySets.title.string,
+                        backgroundColor: Asset.backgroundSystem.swiftUIColor
+                    )
                 )
+                // Empty state
                 if viewModel.list.isEmpty {
                     KeyListEmptyState()
                 } else {
+                    // List of Key Sets
                     List {
                         ForEach(
                             viewModel.list.sorted(by: { $0.keyName < $1.keyName }),
@@ -57,6 +66,7 @@ struct KeySetList: View {
                     .hiddenScrollContent()
                 }
             }
+            // Add Key Set
             PrimaryButton(
                 action: {
                     // We need to call this conditionally, as if there are no seeds,

--- a/ios/NativeSigner/Screens/KeySetsList/KeySetRow.swift
+++ b/ios/NativeSigner/Screens/KeySetsList/KeySetRow.swift
@@ -17,7 +17,7 @@ struct KeySetRow: View {
     var body: some View {
         ZStack {
             RoundedRectangle(cornerRadius: CornerRadius.small)
-                .foregroundColor(Asset.backgroundPrimary.swiftUIColor)
+                .foregroundColor(Asset.backgroundSecondary.swiftUIColor)
                 .frame(height: Heights.keyCellContainer)
             HStack(alignment: .center, spacing: Spacing.small) {
                 Identicon(identicon: viewModel.identicon, rowHeight: Heights.identiconInCell)
@@ -38,7 +38,6 @@ struct KeySetRow: View {
             }
             .padding(Spacing.medium)
         }
-        .background(Asset.backgroundSystem.swiftUIColor)
     }
 }
 

--- a/ios/NativeSigner/Screens/PublicKey/KeyDetailsPublicKeyView.swift
+++ b/ios/NativeSigner/Screens/PublicKey/KeyDetailsPublicKeyView.swift
@@ -59,6 +59,7 @@ struct KeyDetailsPublicKeyView: View {
                 VStack {
                     VStack(spacing: 0) {
                         QRCodeContainerView(viewModel: viewModel.qrCode)
+                            .padding(0.5)
                         if let addressFooter = viewModel.addressFooter {
                             QRCodeAddressFooterView(viewModel: addressFooter)
                         }
@@ -92,10 +93,10 @@ struct KeyDetailsPublicKeyView: View {
                     }
                 }
                 .padding([.leading, .trailing], Spacing.large)
-                .padding([.top, .bottom], 60)
-                .background(Asset.backgroundSolidSystem.swiftUIColor)
+                .padding([.top, .bottom], Spacing.componentSpacer)
+                .background(Asset.backgroundPrimary.swiftUIColor)
             }
-            .background(Asset.backgroundSolidSystem.swiftUIColor)
+            .background(Asset.backgroundPrimary.swiftUIColor)
         }
         // Action sheet
         .fullScreenCover(

--- a/ios/NativeSigner/Screens/SettingsScreen.swift
+++ b/ios/NativeSigner/Screens/SettingsScreen.swift
@@ -115,6 +115,7 @@ struct SettingsScreen: View {
                 withIcon: false,
                 withBackground: false
             )
+            Spacer().frame(idealHeight: .infinity)
         }
     }
 }


### PR DESCRIPTION
## Purpose
This PR addresses most of Andrey's comments regarding updated designs.

## Scope
- added `background tertiary` color
- update primary / system background color
- updated colors on `Key Set List` and `Key Set Details`
- made whole content of `Key Set Details` scrollable
- added stroke around QR codes, best visible in light mode
- added top border to tab bar, best visible in light mode
- fixed "folded" settings screen 

## Screenshots

| Before | After |
|-|-|
|<img src="https://user-images.githubusercontent.com/1955364/192250057-df5d20a4-2730-4145-8a03-25d8aee8102b.gif" width="320px">|<img src="https://user-images.githubusercontent.com/1955364/192249546-0833cfd8-272f-4f91-aafe-060750f257a1.gif" width="320px">|
|<img src="https://user-images.githubusercontent.com/1955364/192250049-44b6af4c-22a0-4d4c-9454-8913f8fcf427.gif" width="320px">|<img src="https://user-images.githubusercontent.com/1955364/192249581-eccd873f-87e1-43d6-ad16-ca25a8244a6a.gif" width="320px">|
