### PR TITLE
fix: ios: ask for pincode only when needed

### DIFF
--- a/ios/NativeSigner.xcodeproj/project.pbxproj
+++ b/ios/NativeSigner.xcodeproj/project.pbxproj
@@ -201,6 +201,7 @@
 		6DBD2200289A8C74005D539B /* URL+Generate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DBD21FF289A8C74005D539B /* URL+Generate.swift */; };
 		6DBD2202289A8E1F005D539B /* ErrorMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DBD2201289A8E1F005D539B /* ErrorMock.swift */; };
 		6DBE12D828B3A80A005F3CCC /* KeySetList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DBE12D728B3A80A005F3CCC /* KeySetList.swift */; };
+		6DBF6E2228E1FB6F00CC959F /* PreviewData+Rust.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DBF6E2128E1FB6F00CC959F /* PreviewData+Rust.swift */; };
 		6DC5642E28B652DE003D540B /* AddKeySetModal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DC5642D28B652DE003D540B /* AddKeySetModal.swift */; };
 		6DC5643028B65B9C003D540B /* AnimationDuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DC5642F28B65B9C003D540B /* AnimationDuration.swift */; };
 		6DC5643328B68FC5003D540B /* AccessControlProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DC5643228B68FC5003D540B /* AccessControlProvider.swift */; };
@@ -466,6 +467,7 @@
 		6DBD21FF289A8C74005D539B /* URL+Generate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Generate.swift"; sourceTree = "<group>"; };
 		6DBD2201289A8E1F005D539B /* ErrorMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorMock.swift; sourceTree = "<group>"; };
 		6DBE12D728B3A80A005F3CCC /* KeySetList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeySetList.swift; sourceTree = "<group>"; };
+		6DBF6E2128E1FB6F00CC959F /* PreviewData+Rust.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PreviewData+Rust.swift"; sourceTree = "<group>"; };
 		6DC5642D28B652DE003D540B /* AddKeySetModal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddKeySetModal.swift; sourceTree = "<group>"; };
 		6DC5642F28B65B9C003D540B /* AnimationDuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationDuration.swift; sourceTree = "<group>"; };
 		6DC5643228B68FC5003D540B /* AccessControlProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessControlProvider.swift; sourceTree = "<group>"; };
@@ -1313,6 +1315,7 @@
 			children = (
 				6DFAF36D28AF846C0048763B /* PreviewData.swift */,
 				6D8045D628D06E6B00237F8C /* PreviewData+Components.swift */,
+				6DBF6E2128E1FB6F00CC959F /* PreviewData+Rust.swift */,
 			);
 			path = Previews;
 			sourceTree = "<group>";
@@ -1619,6 +1622,7 @@
 				2D7A7BD626C1126C0053C1E0 /* Utils.swift in Sources */,
 				6DC5643028B65B9C003D540B /* AnimationDuration.swift in Sources */,
 				2DA5F88A2757692F00D8DD29 /* NewSeedScreen.swift in Sources */,
+				6DBF6E2228E1FB6F00CC959F /* PreviewData+Rust.swift in Sources */,
 				2DA5F86727566C3600D8DD29 /* TCVerifier.swift in Sources */,
 				2DA5F8392756666C00D8DD29 /* EventDetails.swift in Sources */,
 				6DBD21F4289A77DE005D539B /* BundleProtocol.swift in Sources */,

--- a/ios/NativeSigner/Backend/ExportPrivateKeyService.swift
+++ b/ios/NativeSigner/Backend/ExportPrivateKeyService.swift
@@ -10,16 +10,19 @@ import Foundation
 final class ExportPrivateKeyService {
     private let databaseMediator: DatabaseMediating
     private let seedsMediator: SeedsMediating
+    private let keyDetails: MKeyDetails
 
     init(
         databaseMediator: DatabaseMediating = DatabaseMediator(),
-        seedsMediator: SeedsMediating = ServiceLocator.seedsMediator
+        seedsMediator: SeedsMediating = ServiceLocator.seedsMediator,
+        keyDetails: MKeyDetails
     ) {
         self.databaseMediator = databaseMediator
         self.seedsMediator = seedsMediator
+        self.keyDetails = keyDetails
     }
 
-    func exportPrivateKey(from keyDetails: MKeyDetails) -> ExportPrivateKeyViewModel? {
+    func exportPrivateKey() -> ExportPrivateKeyViewModel? {
         guard let qrCode = try? generateSecretKeyQr(
             dbname: databaseMediator.databaseName,
             publicKey: keyDetails.pubkey,

--- a/ios/NativeSigner/Previews/PreviewData+Rust.swift
+++ b/ios/NativeSigner/Previews/PreviewData+Rust.swift
@@ -1,0 +1,40 @@
+//
+//  PreviewData+Rust.swift
+//  NativeSigner
+//
+//  Created by Krzysztof Rodak on 26/09/2022.
+//
+
+import Foundation
+
+extension PreviewData {
+    static let mkeys = MKeys(
+        set: [],
+        root: .init(
+            seedName: "",
+            identicon: [],
+            addressKey: "",
+            base58: "",
+            swiped: false,
+            multiselect: false,
+            secretExposed: false
+        ),
+        network: .init(title: "", logo: ""),
+        multiselectMode: false,
+        multiselectCount: ""
+    )
+    static let mkeyDetails = MKeyDetails(
+        qr: [],
+        pubkey: "",
+        networkInfo: .init(networkTitle: "", networkLogo: "", networkSpecsKey: ""),
+        address: .init(
+            base58: "",
+            path: "",
+            hasPwd: false,
+            identicon: [],
+            seedName: "",
+            multiselect: nil,
+            secretExposed: false
+        )
+    )
+}

--- a/ios/NativeSigner/Screens/ScreenSelector.swift
+++ b/ios/NativeSigner/Screens/ScreenSelector.swift
@@ -70,7 +70,7 @@ struct ScreenSelector: View {
                 forgetKeyActionHandler: ForgetSingleKeyAction(navigation: navigation),
                 viewModel: KeyDetailsPublicKeyViewModel(value),
                 actionModel: KeyDetailsPublicKeyActionModel(value),
-                exportPrivateKeyViewModel: ExportPrivateKeyService().exportPrivateKey(from: value)
+                exportPrivateKeyService: ExportPrivateKeyService(keyDetails: value)
             )
         case let .newSeed(value):
             NewSeedScreen(


### PR DESCRIPTION
## Purpose
This PR fixes issues with pincode being triggered on views presentation instead just before it was needed.

## Scope
- I tried to follow proper approach, generating view model on View's instance right before presentation, but as Rust navigation refreshes the view, needed to add `static` references for view models within views for now
