### PR TITLE
fix: ios: fix crash on "Forget Key" functionality

### DIFF
--- a/ios/NativeSigner/Core/Navigation/NavigationCoordinator.swift
+++ b/ios/NativeSigner/Core/Navigation/NavigationCoordinator.swift
@@ -70,6 +70,7 @@ final class NavigationCoordinator: ObservableObject {
 }
 
 extension NavigationCoordinator {
+    @discardableResult
     func performFake(navigation: Navigation) -> ActionResult {
         backendActionPerformer.performBackend(
             action: navigation.action,

--- a/ios/NativeSigner/Screens/KeyDetails/Actions/ForgetKeySetAction.swift
+++ b/ios/NativeSigner/Screens/KeyDetails/Actions/ForgetKeySetAction.swift
@@ -10,14 +10,16 @@ import SwiftUI
 final class ForgetKeySetAction {
     private let seedsMediator: SeedsMediating
     private let snackbarPresentation: BottomSnackbarPresentation
-    @EnvironmentObject private var navigation: NavigationCoordinator
+    private let navigation: NavigationCoordinator
 
     init(
         snackbarPresentation: BottomSnackbarPresentation = ServiceLocator.bottomSnackbarPresentation,
-        seedsMediator: SeedsMediating = ServiceLocator.seedsMediator
+        seedsMediator: SeedsMediating = ServiceLocator.seedsMediator,
+        navigation: NavigationCoordinator
     ) {
         self.snackbarPresentation = snackbarPresentation
         self.seedsMediator = seedsMediator
+        self.navigation = navigation
     }
 
     func forgetKeySet(_ keySet: String) {

--- a/ios/NativeSigner/Screens/KeyDetails/Actions/ForgetSingleKeyAction.swift
+++ b/ios/NativeSigner/Screens/KeyDetails/Actions/ForgetSingleKeyAction.swift
@@ -9,12 +9,14 @@ import SwiftUI
 
 final class ForgetSingleKeyAction {
     private let snackbarPresentation: BottomSnackbarPresentation
-    @EnvironmentObject private var navigation: NavigationCoordinator
+    private let navigation: NavigationCoordinator
 
     init(
-        snackbarPresentation: BottomSnackbarPresentation = ServiceLocator.bottomSnackbarPresentation
+        snackbarPresentation: BottomSnackbarPresentation = ServiceLocator.bottomSnackbarPresentation,
+        navigation: NavigationCoordinator
     ) {
         self.snackbarPresentation = snackbarPresentation
+        self.navigation = navigation
     }
 
     func forgetSingleKey(_: String) {

--- a/ios/NativeSigner/Screens/KeyDetails/KeyDetailsView.swift
+++ b/ios/NativeSigner/Screens/KeyDetails/KeyDetailsView.swift
@@ -232,7 +232,7 @@ struct KeyDetailsView_Previews: PreviewProvider {
     static var previews: some View {
         VStack {
             KeyDetailsView(
-                forgetKeyActionHandler: .init(),
+                forgetKeyActionHandler: .init(navigation: NavigationCoordinator()),
                 viewModel: .init(
                     keySummary: KeySummaryViewModel(
                         keyName: "Parity",

--- a/ios/NativeSigner/Screens/PublicKey/KeyDetailsPublicKeyView.swift
+++ b/ios/NativeSigner/Screens/PublicKey/KeyDetailsPublicKeyView.swift
@@ -101,6 +101,9 @@ struct KeyDetailsPublicKeyView: View {
             }
             .background(Asset.backgroundPrimary.swiftUIColor)
         }
+        .onAppear {
+            navigation.performFake(navigation: .init(action: .rightButtonAction))
+        }
         // Action sheet
         .fullScreenCover(
             isPresented: $isShowingActionSheet,

--- a/ios/NativeSigner/Screens/PublicKey/KeyDetailsPublicKeyView.swift
+++ b/ios/NativeSigner/Screens/PublicKey/KeyDetailsPublicKeyView.swift
@@ -33,7 +33,7 @@ struct KeyDetailsPublicKeyView: View {
     @EnvironmentObject private var data: SignerDataModel
 
     init(
-        forgetKeyActionHandler: ForgetSingleKeyAction = ForgetSingleKeyAction(),
+        forgetKeyActionHandler: ForgetSingleKeyAction,
         viewModel: KeyDetailsPublicKeyViewModel,
         actionModel: KeyDetailsPublicKeyActionModel,
         exportPrivateKeyService: ExportPrivateKeyService,
@@ -198,6 +198,7 @@ struct KeyDetailsPublicKeyView_Previews: PreviewProvider {
         HStack {
             VStack {
                 KeyDetailsPublicKeyView(
+                    forgetKeyActionHandler: ForgetSingleKeyAction(navigation: NavigationCoordinator()),
                     viewModel: PreviewData.exampleKeyDetailsPublicKey(),
                     actionModel: KeyDetailsPublicKeyActionModel(removeSeed: ""),
                     exportPrivateKeyService: ExportPrivateKeyService(keyDetails: PreviewData.mkeyDetails),
@@ -206,6 +207,7 @@ struct KeyDetailsPublicKeyView_Previews: PreviewProvider {
             }
             VStack {
                 KeyDetailsPublicKeyView(
+                    forgetKeyActionHandler: ForgetSingleKeyAction(navigation: NavigationCoordinator()),
                     viewModel: PreviewData.exampleKeyDetailsPublicKey(isKeyExposed: false),
                     actionModel: KeyDetailsPublicKeyActionModel(removeSeed: ""),
                     exportPrivateKeyService: ExportPrivateKeyService(keyDetails: PreviewData.mkeyDetails),
@@ -214,6 +216,7 @@ struct KeyDetailsPublicKeyView_Previews: PreviewProvider {
             }
             VStack {
                 KeyDetailsPublicKeyView(
+                    forgetKeyActionHandler: ForgetSingleKeyAction(navigation: NavigationCoordinator()),
                     viewModel: PreviewData.exampleKeyDetailsPublicKey(isRootKey: false),
                     actionModel: KeyDetailsPublicKeyActionModel(removeSeed: ""),
                     exportPrivateKeyService: ExportPrivateKeyService(keyDetails: PreviewData.mkeyDetails),
@@ -222,6 +225,7 @@ struct KeyDetailsPublicKeyView_Previews: PreviewProvider {
             }
             VStack {
                 KeyDetailsPublicKeyView(
+                    forgetKeyActionHandler: ForgetSingleKeyAction(navigation: NavigationCoordinator()),
                     viewModel: PreviewData.exampleKeyDetailsPublicKey(isKeyExposed: false, isRootKey: false),
                     actionModel: KeyDetailsPublicKeyActionModel(removeSeed: ""),
                     exportPrivateKeyService: ExportPrivateKeyService(keyDetails: PreviewData.mkeyDetails),

--- a/ios/NativeSigner/Screens/ScreenSelector.swift
+++ b/ios/NativeSigner/Screens/ScreenSelector.swift
@@ -31,7 +31,7 @@ struct ScreenSelector: View {
             )
         case let .keys(value):
             KeyDetailsView(
-                forgetKeyActionHandler: ForgetKeySetAction(),
+                forgetKeyActionHandler: ForgetKeySetAction(navigation: navigation),
                 viewModel: KeyDetailsViewModel(value),
                 actionModel: KeyDetailsActionModel(value, alert: data.alert, alertShow: alertShow),
                 exportPrivateKeyService: PrivateKeyQRCodeService(navigation: navigation, keys: value),
@@ -62,7 +62,7 @@ struct ScreenSelector: View {
             )
         case let .keyDetails(value):
             KeyDetailsPublicKeyView(
-                forgetKeyActionHandler: ForgetSingleKeyAction(),
+                forgetKeyActionHandler: ForgetSingleKeyAction(navigation: navigation),
                 viewModel: KeyDetailsPublicKeyViewModel(value),
                 actionModel: KeyDetailsPublicKeyActionModel(value),
                 exportPrivateKeyService: ExportPrivateKeyService(keyDetails: value),


### PR DESCRIPTION
## Purpose
This PR fixes issue introduced by this refactor: https://github.com/paritytech/parity-signer/pull/1333 where I tried to move to use of SwiftUI @EnvironmentObject for `SignerDataModel` and `NavigationCoordinator` which encapsulates Rust navigation.
We still can't use it in non-view components and my replace-all approach triggered crash on forget key actions.
Additionally, in second commit, navigation fix was added when removing single derived key (forgot about that fix I had in stash before)
