### PR TITLE
fix: no panics on not found keys

### DIFF
--- a/rust/db_handling/src/identities.rs
+++ b/rust/db_handling/src/identities.rs
@@ -122,6 +122,12 @@ pub fn get_multisigner_by_address<P: AsRef<Path>>(
     use definitions::helpers::ecdsa_public_to_eth_address;
 
     Ok(get_all_addresses(db_path)?.into_iter().find_map(|(m, a)| {
+        // TODO: Keys in the system should have disambiguous addressing
+        // the current state of events has to do with the fact
+        // that some parts of UI may be addressing eth keys by
+        // Ethereum addresses and other parts by public keys
+
+        // First check if an etherum address is being requested
         if a.encryption == Encryption::Ethereum {
             if let MultiSigner::Ecdsa(ref public) = m {
                 if let Ok(addr) = ecdsa_public_to_eth_address(public) {
@@ -130,11 +136,12 @@ pub fn get_multisigner_by_address<P: AsRef<Path>>(
                     }
                 }
             }
-        } else {
-            // TODO: for ecdsa address is not simply a public key
-            if address.key() == m.encode() {
-                return Some(m);
-            }
+        }
+
+        // TODO: for ecdsa address is not simply a public key
+        // Do a general check after Ethereum-specific one
+        if address.key() == m.encode() {
+            return Some(m);
         }
         None
     }))

--- a/rust/navigator/src/navstate.rs
+++ b/rust/navigator/src/navstate.rs
@@ -2133,7 +2133,8 @@ fn process_hex_address_key_address_details(
     dbname: &str,
 ) -> Result<(MultiSigner, AddressDetails)> {
     let address_key = AddressKey::from_hex(hex_address_key)?;
-    let multisigner = get_multisigner_by_address(dbname, &address_key)?.unwrap();
+    let multisigner = get_multisigner_by_address(dbname, &address_key)?
+        .ok_or(Error::KeyNotFound(format!("0x{}", hex_address_key)))?;
     let address_details = db_handling::helpers::get_address_details(dbname, &address_key)?;
     Ok((multisigner, address_details))
 }

--- a/rust/navigator/src/navstate.rs
+++ b/rust/navigator/src/navstate.rs
@@ -2134,7 +2134,7 @@ fn process_hex_address_key_address_details(
 ) -> Result<(MultiSigner, AddressDetails)> {
     let address_key = AddressKey::from_hex(hex_address_key)?;
     let multisigner = get_multisigner_by_address(dbname, &address_key)?
-        .ok_or(Error::KeyNotFound(format!("0x{}", hex_address_key)))?;
+        .ok_or_else(|| Error::KeyNotFound(format!("0x{}", hex_address_key)))?;
     let address_details = db_handling::helpers::get_address_details(dbname, &address_key)?;
     Ok((multisigner, address_details))
 }


### PR DESCRIPTION
## Purpose

The code unwraps unnecessarily on not found keys. Also some parts of the
UI use public keys for addressing instead of addresses. Untils the addressing
issue is fixed, support both:
 * Search for an Ethereum addr
 * Search for public addr

In the future this has to be replaced with typed addresses instead of byte blobs or `String`s.
