### PR TITLE
fix: raptorq block number

### DIFF
--- a/rust/qr_reader_phone/src/process_payload.rs
+++ b/rust/qr_reader_phone/src/process_payload.rs
@@ -54,7 +54,7 @@ pub fn process_decoded_payload(payload: Vec<u8>, mut decoding: InProgress) -> Re
         let total = frame.total();
         let new_packet = frame.payload;
         let decoded_packet = EncodingPacket::deserialize(&new_packet);
-        let block_number = decoded_packet.payload_id().source_block_number() as usize;
+        let block_number = decoded_packet.payload_id().encoding_symbol_id() as usize;
         match decoding {
             InProgress::None => {
                 let config = raptorq::ObjectTransmissionInformation::with_defaults(


### PR DESCRIPTION
## Purpose
<!-- What is the goal of the proposed change? i.e.
This PR aims to address issue: #1234
This PR adds XYZ feature
This PR adds new GA workflow that runs unit tests
-->
Fix Qr `block_number`, because `source_block_number` always returns `0`.
This breaks progress bar in metadata-portal

## Scope
As a workaround, use `encoding_symbol_id` instead.
