### PR TITLE
fix: ios: fix Network Selection on Key Details broken by refactor for keys export

### DIFF
--- a/ios/NativeSigner/Screens/KeyDetails/Views/KeyDetails+SelectionOverlay.swift
+++ b/ios/NativeSigner/Screens/KeyDetails/Views/KeyDetails+SelectionOverlay.swift
@@ -59,6 +59,6 @@ extension KeyDetailsView {
     }
 
     func selectAll() {
-        viewModel.selectedSeeds = viewModel.dataModel.derivedKeys.map(\.viewModel.path)
+        viewModel.selectedSeeds = dataModel.derivedKeys.map(\.viewModel.path)
     }
 }

--- a/ios/NativeSigner/Screens/KeyDetails/Views/KeyDetails+ViewModel.swift
+++ b/ios/NativeSigner/Screens/KeyDetails/Views/KeyDetails+ViewModel.swift
@@ -9,7 +9,6 @@ import Foundation
 
 extension KeyDetailsView {
     final class ViewModel: ObservableObject {
-        let dataModel: KeyDetailsDataModel
         let keyDetailsService: KeyDetailsService
         let exportPrivateKeyService: PrivateKeyQRCodeService
 
@@ -29,12 +28,10 @@ extension KeyDetailsView {
         @Published var selectedSeeds: [String] = []
 
         init(
-            dataModel: KeyDetailsDataModel,
             keysData: MKeysNew?,
             exportPrivateKeyService: PrivateKeyQRCodeService,
             keyDetailsService: KeyDetailsService = KeyDetailsService()
         ) {
-            self.dataModel = dataModel
             self.keysData = keysData
             self.exportPrivateKeyService = exportPrivateKeyService
             self.keyDetailsService = keyDetailsService
@@ -44,7 +41,7 @@ extension KeyDetailsView {
             self.appState = appState
         }
 
-        func keyExportModel() -> ExportMultipleKeysModalViewModel {
+        func keyExportModel(dataModel: KeyDetailsDataModel) -> ExportMultipleKeysModalViewModel {
             let derivedKeys: [DerivedKeyExportModel] = dataModel.derivedKeys
                 .filter { selectedSeeds.contains($0.viewModel.path) }
                 .compactMap {
@@ -60,7 +57,7 @@ extension KeyDetailsView {
             )
         }
 
-        func refreshData() {
+        func refreshData(dataModel: KeyDetailsDataModel) {
             keyDetailsService.getKeys(for: dataModel.keySummary.keyName) { result in
                 if case let .success(keysData) = result {
                     self.appState.userData.keysData = keysData

--- a/ios/NativeSigner/Screens/KeyDetails/Views/KeyDetailsView.swift
+++ b/ios/NativeSigner/Screens/KeyDetails/Views/KeyDetailsView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct KeyDetailsView: View {
+    let dataModel: KeyDetailsDataModel
     @StateObject var viewModel: ViewModel
     @EnvironmentObject private var navigation: NavigationCoordinator
     @EnvironmentObject private var connectivityMediator: ConnectivityMediator
@@ -42,7 +43,7 @@ struct KeyDetailsView: View {
             } else {
                 PrimaryButton(
                     action: {
-                        navigation.perform(navigation: viewModel.dataModel.createDerivedKey)
+                        navigation.perform(navigation: dataModel.createDerivedKey)
                     },
                     text: Localizable.KeyDetails.Action.create.key
                 )
@@ -51,7 +52,7 @@ struct KeyDetailsView: View {
         }
         .onAppear {
             viewModel.set(appState: appState)
-            viewModel.refreshData()
+            viewModel.refreshData(dataModel: dataModel)
         }
         .fullScreenCover(
             isPresented: $viewModel.isShowingActionSheet,
@@ -68,7 +69,7 @@ struct KeyDetailsView: View {
         .fullScreenCover(isPresented: $viewModel.isShowingRemoveConfirmation) {
             HorizontalActionsBottomModal(
                 viewModel: .forgetKeySet,
-                mainAction: forgetKeyActionHandler.forgetKeySet(viewModel.dataModel.removeSeed),
+                mainAction: forgetKeyActionHandler.forgetKeySet(dataModel.removeSeed),
                 // We need to fake right button action here or Rust machine will break
                 // In old UI, if you dismiss equivalent of this modal, underlying modal would still be there,
                 // so we need to inform Rust we actually hid it
@@ -104,7 +105,7 @@ struct KeyDetailsView: View {
         ) {
             ExportMultipleKeysModal(
                 viewModel: .init(
-                    viewModel: viewModel.keyExportModel(),
+                    viewModel: viewModel.keyExportModel(dataModel: dataModel),
                     isPresented: $viewModel.isShowingKeysExportModal
                 )
             )
@@ -120,14 +121,14 @@ struct KeyDetailsView: View {
         List {
             // Main key cell
             KeySummaryView(
-                viewModel: viewModel.dataModel.keySummary,
+                viewModel: dataModel.keySummary,
                 isPresentingSelectionOverlay: $viewModel.isPresentingSelectionOverlay
             )
             .padding(Padding.detailsCell)
             .keyDetailsListElement()
             .onTapGesture {
                 if !viewModel.isPresentingSelectionOverlay {
-                    navigation.perform(navigation: viewModel.dataModel.addressKeyNavigation)
+                    navigation.perform(navigation: dataModel.addressKeyNavigation)
                 }
             }
             // Header
@@ -146,7 +147,7 @@ struct KeyDetailsView: View {
             .keyDetailsListElement()
             // List of derived keys
             ForEach(
-                viewModel.dataModel.derivedKeys,
+                dataModel.derivedKeys,
                 id: \.viewModel.addressKey
             ) { deriveKey in
                 DerivedKeyRow(
@@ -228,92 +229,92 @@ private struct KeySummaryView: View {
         static var previews: some View {
             VStack {
                 KeyDetailsView(
-                    viewModel: .init(
-                        dataModel: .init(
-                            keySummary: KeySummaryViewModel(
-                                keyName: "Main Polkadot",
-                                base58: "15Gsc678...0HA04H0A"
-                            ),
-                            derivedKeys: [
-                                DerivedKeyRowModel(
-                                    viewModel: DerivedKeyRowViewModel(
-                                        identicon: PreviewData.exampleIdenticon,
-                                        path: "// polkadot",
-                                        hasPassword: false,
-                                        base58: "15Gsc678654FDSG0HA04H0A"
-                                    ),
-                                    actionModel: DerivedKeyActionModel(
-                                        tapAction: .init(action: .rightButtonAction)
-                                    )
-                                ),
-                                DerivedKeyRowModel(
-                                    viewModel: DerivedKeyRowViewModel(
-                                        identicon: PreviewData.exampleIdenticon,
-                                        path: "// polkadot",
-                                        hasPassword: false,
-                                        base58: "15Gsc678654FDSG0HA04H0A"
-                                    ),
-                                    actionModel: DerivedKeyActionModel(
-                                        tapAction: .init(action: .rightButtonAction)
-                                    )
-                                ),
-                                DerivedKeyRowModel(
-                                    viewModel: DerivedKeyRowViewModel(
-                                        identicon: PreviewData.exampleIdenticon,
-                                        path: "//astar//verylongpathsolongitrequirestwolinesoftextormaybeevenmore",
-                                        hasPassword: true,
-                                        base58: "15Gsc678654FDSG0HA04H0A"
-                                    ),
-                                    actionModel: DerivedKeyActionModel(
-                                        tapAction: .init(action: .rightButtonAction)
-                                    )
-                                ),
-                                DerivedKeyRowModel(
-                                    viewModel: DerivedKeyRowViewModel(
-                                        identicon: PreviewData.exampleIdenticon,
-                                        path: "//verylongpathsolongitrequirestwolinesoftextormaybeevenmore",
-                                        hasPassword: false,
-                                        base58: "15Gsc678654FDSG0HA04H0A"
-                                    ),
-                                    actionModel: DerivedKeyActionModel(
-                                        tapAction: .init(action: .rightButtonAction)
-                                    )
-                                ),
-                                DerivedKeyRowModel(
-                                    viewModel: DerivedKeyRowViewModel(
-                                        identicon: PreviewData.exampleIdenticon,
-                                        path: "// acala",
-                                        hasPassword: true,
-                                        base58: "15Gsc678654FDSG0HA04H0A"
-                                    ),
-                                    actionModel: DerivedKeyActionModel(
-                                        tapAction: .init(action: .rightButtonAction)
-                                    )
-                                ),
-                                DerivedKeyRowModel(
-                                    viewModel: DerivedKeyRowViewModel(
-                                        identicon: PreviewData.exampleIdenticon,
-                                        path: "// moonbeam",
-                                        hasPassword: true,
-                                        base58: "15Gsc678654FDSG0HA04H0A"
-                                    ),
-                                    actionModel: DerivedKeyActionModel(
-                                        tapAction: .init(action: .rightButtonAction)
-                                    )
-                                ),
-                                DerivedKeyRowModel(
-                                    viewModel: DerivedKeyRowViewModel(
-                                        identicon: PreviewData.exampleIdenticon,
-                                        path: "// kilt",
-                                        hasPassword: true,
-                                        base58: "15Gsc6786546423FDSG0HA04H0A"
-                                    ),
-                                    actionModel: DerivedKeyActionModel(
-                                        tapAction: .init(action: .rightButtonAction)
-                                    )
-                                )
-                            ]
+                    dataModel: .init(
+                        keySummary: KeySummaryViewModel(
+                            keyName: "Main Polkadot",
+                            base58: "15Gsc678...0HA04H0A"
                         ),
+                        derivedKeys: [
+                            DerivedKeyRowModel(
+                                viewModel: DerivedKeyRowViewModel(
+                                    identicon: PreviewData.exampleIdenticon,
+                                    path: "// polkadot",
+                                    hasPassword: false,
+                                    base58: "15Gsc678654FDSG0HA04H0A"
+                                ),
+                                actionModel: DerivedKeyActionModel(
+                                    tapAction: .init(action: .rightButtonAction)
+                                )
+                            ),
+                            DerivedKeyRowModel(
+                                viewModel: DerivedKeyRowViewModel(
+                                    identicon: PreviewData.exampleIdenticon,
+                                    path: "// polkadot",
+                                    hasPassword: false,
+                                    base58: "15Gsc678654FDSG0HA04H0A"
+                                ),
+                                actionModel: DerivedKeyActionModel(
+                                    tapAction: .init(action: .rightButtonAction)
+                                )
+                            ),
+                            DerivedKeyRowModel(
+                                viewModel: DerivedKeyRowViewModel(
+                                    identicon: PreviewData.exampleIdenticon,
+                                    path: "//astar//verylongpathsolongitrequirestwolinesoftextormaybeevenmore",
+                                    hasPassword: true,
+                                    base58: "15Gsc678654FDSG0HA04H0A"
+                                ),
+                                actionModel: DerivedKeyActionModel(
+                                    tapAction: .init(action: .rightButtonAction)
+                                )
+                            ),
+                            DerivedKeyRowModel(
+                                viewModel: DerivedKeyRowViewModel(
+                                    identicon: PreviewData.exampleIdenticon,
+                                    path: "//verylongpathsolongitrequirestwolinesoftextormaybeevenmore",
+                                    hasPassword: false,
+                                    base58: "15Gsc678654FDSG0HA04H0A"
+                                ),
+                                actionModel: DerivedKeyActionModel(
+                                    tapAction: .init(action: .rightButtonAction)
+                                )
+                            ),
+                            DerivedKeyRowModel(
+                                viewModel: DerivedKeyRowViewModel(
+                                    identicon: PreviewData.exampleIdenticon,
+                                    path: "// acala",
+                                    hasPassword: true,
+                                    base58: "15Gsc678654FDSG0HA04H0A"
+                                ),
+                                actionModel: DerivedKeyActionModel(
+                                    tapAction: .init(action: .rightButtonAction)
+                                )
+                            ),
+                            DerivedKeyRowModel(
+                                viewModel: DerivedKeyRowViewModel(
+                                    identicon: PreviewData.exampleIdenticon,
+                                    path: "// moonbeam",
+                                    hasPassword: true,
+                                    base58: "15Gsc678654FDSG0HA04H0A"
+                                ),
+                                actionModel: DerivedKeyActionModel(
+                                    tapAction: .init(action: .rightButtonAction)
+                                )
+                            ),
+                            DerivedKeyRowModel(
+                                viewModel: DerivedKeyRowViewModel(
+                                    identicon: PreviewData.exampleIdenticon,
+                                    path: "// kilt",
+                                    hasPassword: true,
+                                    base58: "15Gsc6786546423FDSG0HA04H0A"
+                                ),
+                                actionModel: DerivedKeyActionModel(
+                                    tapAction: .init(action: .rightButtonAction)
+                                )
+                            )
+                        ]
+                    ),
+                    viewModel: .init(
                         keysData: PreviewData.mKeyNew,
                         exportPrivateKeyService: PrivateKeyQRCodeService(
                             navigation: NavigationCoordinator(),

--- a/ios/NativeSigner/Screens/ScreenSelector.swift
+++ b/ios/NativeSigner/Screens/ScreenSelector.swift
@@ -33,8 +33,8 @@ struct ScreenSelector: View {
             )
         case let .keys(value):
             KeyDetailsView(
+                dataModel: KeyDetailsDataModel(value),
                 viewModel: .init(
-                    dataModel: KeyDetailsDataModel(value),
                     keysData: appState.userData.keysData,
                     exportPrivateKeyService: PrivateKeyQRCodeService(navigation: navigation, keys: value)
                 ),


### PR DESCRIPTION
## Purpose
Refactor around `@StateObject viewModel: ViewModel` for `KeyDetailsView` broke not refactored network selection, this PR fixes this by moving changeable view model for given network back to view level

## Screenshots

| Before | After |
|-|-|
|<img src="https://user-images.githubusercontent.com/1955364/199731686-71a4a7fd-9012-4330-895d-29f7f1037673.gif" width="320px">|<img src="https://user-images.githubusercontent.com/1955364/199731659-b82eb04c-bb5f-4d12-86d0-2e67791c7f37.gif" width="320px">|
