### PR TITLE
fix: clippy on rust 1.65

### DIFF
--- a/rust/db_handling/src/identities.rs
+++ b/rust/db_handling/src/identities.rs
@@ -1662,7 +1662,7 @@ fn generate_secret_qr(
     let qr = png_qr_from_string(
         &format!(
             "secret:0x{}:{}",
-            hex::encode(&secret),
+            hex::encode(secret),
             hex::encode(genesis_hash)
         ),
         DataType::Sensitive,

--- a/rust/db_handling/src/interface_signer.rs
+++ b/rust/db_handling/src/interface_signer.rs
@@ -483,7 +483,7 @@ where
                     "{}:{}:0x{}",
                     prefix,
                     base58,
-                    hex::encode(&network_specs.genesis_hash)
+                    hex::encode(network_specs.genesis_hash)
                 ),
                 DataType::Regular,
             )

--- a/rust/db_handling/tests/tests.rs
+++ b/rust/db_handling/tests/tests.rs
@@ -947,18 +947,18 @@ fn test_generate_default_addresses_for_alice() {
                 path: "".to_string(),
                 has_pwd: false,
                 network_id: vec![
-                    NetworkSpecsKey::from_hex(&hex::encode(&[
+                    NetworkSpecsKey::from_hex(&hex::encode([
                         1, 145, 177, 113, 187, 21, 142, 45, 56, 72, 250, 35, 169, 241, 194, 81,
                         130, 251, 142, 32, 49, 59, 44, 30, 180, 146, 25, 218, 122, 112, 206, 144,
                         195,
                     ]))
                     .unwrap(),
-                    NetworkSpecsKey::from_hex(&hex::encode(&[
+                    NetworkSpecsKey::from_hex(&hex::encode([
                         1, 176, 168, 212, 147, 40, 92, 45, 247, 50, 144, 223, 183, 230, 31, 135,
                         15, 23, 180, 24, 1, 25, 122, 20, 156, 169, 54, 84, 73, 158, 163, 218, 254,
                     ]))
                     .unwrap(),
-                    NetworkSpecsKey::from_hex(&hex::encode(&[
+                    NetworkSpecsKey::from_hex(&hex::encode([
                         1, 225, 67, 242, 56, 3, 172, 80, 232, 246, 248, 230, 38, 149, 209, 206,
                         158, 78, 29, 104, 170, 54, 193, 205, 44, 253, 21, 52, 2, 19, 243, 66, 62,
                     ]))
@@ -981,7 +981,7 @@ fn test_generate_default_addresses_for_alice() {
                 seed_name: "Alice".to_string(),
                 path: "//kusama".to_string(),
                 has_pwd: false,
-                network_id: vec![NetworkSpecsKey::from_hex(&hex::encode(&[
+                network_id: vec![NetworkSpecsKey::from_hex(&hex::encode([
                     1, 176, 168, 212, 147, 40, 92, 45, 247, 50, 144, 223, 183, 230, 31, 135, 15,
                     23, 180, 24, 1, 25, 122, 20, 156, 169, 54, 84, 73, 158, 163, 218, 254,
                 ]))
@@ -2254,13 +2254,13 @@ fn remove_all_westend() {
         let database: Db = open(dbname).unwrap();
         let chainspecs: Tree = database.open_tree(SPECSTREE).unwrap();
         assert!(
-            chainspecs.get(&network_specs_key.key()).unwrap() == None,
+            chainspecs.get(&network_specs_key.key()).unwrap().is_none(),
             "Westend network specs were not deleted"
         );
         let metadata: Tree = database.open_tree(METATREE).unwrap();
         let prefix_meta = MetaKeyPrefix::from_name("westend");
         assert!(
-            metadata.scan_prefix(&prefix_meta.prefix()).next() == None,
+            metadata.scan_prefix(&prefix_meta.prefix()).next().is_none(),
             "Some westend metadata was not deleted"
         );
         let identities: Tree = database.open_tree(ADDRTREE).unwrap();

--- a/rust/definitions/src/helpers.rs
+++ b/rust/definitions/src/helpers.rs
@@ -96,7 +96,7 @@ pub fn make_identicon_from_multisigner(
 pub fn make_identicon_from_id20(id: &[u8; 20]) -> Vec<u8> {
     use eth_blockies::eth_blockies_png_data;
 
-    let account = format!("0x{}", hex::encode(&id));
+    let account = format!("0x{}", hex::encode(id));
     let dimension = (IDENTICON_IMG_SIZE, IDENTICON_IMG_SIZE);
     let compressed_output = false;
     eth_blockies_png_data(account, dimension, compressed_output)

--- a/rust/generate_message/src/remove.rs
+++ b/rust/generate_message/src/remove.rs
@@ -84,7 +84,7 @@ where
             let mut network_specs_prep_batch = Batch::default();
 
             // get `ADDRESS_BOOK` entry for the title
-            let address_book_entry = get_address_book_entry(&network_title, &db_path.as_ref())?;
+            let address_book_entry = get_address_book_entry(&network_title, db_path.as_ref())?;
 
             // make `NetworkSpecsKey` using data in `ADDRESS_BOOK` entry
             let network_specs_key = NetworkSpecsKey::from_parts(

--- a/rust/navigator/src/tests.rs
+++ b/rust/navigator/src/tests.rs
@@ -147,7 +147,7 @@ fn signature_is_good(transaction_hex: &str, signature_hex: &str) -> bool {
         }
         "5301" => {
             let into_signature: [u8; 64] = match &transaction_hex[4..6] {
-                "03" => hex::decode(&signature_hex).unwrap().try_into().unwrap(), // raw message
+                "03" => hex::decode(signature_hex).unwrap().try_into().unwrap(), // raw message
                 _ => {
                     assert!(
                         signature_hex.starts_with("01"),
@@ -324,7 +324,7 @@ fn export_import_addrs() {
     .unwrap();
 
     let selected = HashMap::from([("Alice".to_owned(), ExportedSet::All)]);
-    let addrs = export_all_addrs(&dbname_from, selected.clone()).unwrap();
+    let addrs = export_all_addrs(dbname_from, selected.clone()).unwrap();
 
     let addrs_expected = ExportAddrs::V1(ExportAddrsV1 {
         addrs: vec![SeedInfo {
@@ -425,7 +425,7 @@ fn export_import_addrs() {
 
     import_all_addrs(dbname_to, alice_hash_map, addrs).unwrap();
 
-    let addrs_new = export_all_addrs(&dbname_to, selected).unwrap();
+    let addrs_new = export_all_addrs(dbname_to, selected).unwrap();
 
     assert_eq!(addrs_new, addrs_expected);
 }

--- a/rust/parser/src/cards.rs
+++ b/rust/parser/src/cards.rs
@@ -78,7 +78,7 @@ impl ParserCard {
             ParserCard::Id20 {
                 id,
                 base58prefix: _,
-            } => readable(indent, "Id", &format!("0x{}", hex::encode(&id))),
+            } => readable(indent, "Id", &format!("0x{}", hex::encode(id))),
             ParserCard::None => readable(indent, "none", ""),
             ParserCard::IdentityField(variant) => readable(indent, "identity_field", variant),
             ParserCard::BitVec(bv) => readable(indent, "bitvec", bv),

--- a/rust/parser/src/tests.rs
+++ b/rust/parser/src/tests.rs
@@ -5,8 +5,8 @@ use parity_scale_codec::Decode;
 use pretty_assertions::assert_eq;
 
 fn metadata(filename: &str) -> RuntimeMetadata {
-    let metadata_hex = std::fs::read_to_string(&filename).unwrap();
-    let metadata_vec = hex::decode(&metadata_hex.trim()).unwrap()[4..].to_vec();
+    let metadata_hex = std::fs::read_to_string(filename).unwrap();
+    let metadata_vec = hex::decode(metadata_hex.trim()).unwrap()[4..].to_vec();
     RuntimeMetadata::decode(&mut &metadata_vec[..]).unwrap()
 }
 

--- a/rust/transaction_parsing/src/cards.rs
+++ b/rust/transaction_parsing/src/cards.rs
@@ -126,7 +126,7 @@ impl<'a> Card<'a> {
                     base58prefix: _,
                 } => NavCard::IdCard {
                     f: MSCId {
-                        base58: format!("0x{}", hex::encode(&id)),
+                        base58: format!("0x{}", hex::encode(id)),
                         identicon: make_identicon_from_id20(id),
                     },
                 },
@@ -227,9 +227,9 @@ impl<'a> Card<'a> {
             Card::AuthorPublicKey(author) => {
                 let identicon = make_identicon_from_multisigner(author, IdenticonStyle::Dots);
                 let (public_key, encryption) = match author {
-                    MultiSigner::Ed25519(p) => (hex::encode(&p), Encryption::Ed25519.show()),
-                    MultiSigner::Sr25519(p) => (hex::encode(&p), Encryption::Sr25519.show()),
-                    MultiSigner::Ecdsa(p) => (hex::encode(&p), Encryption::Ecdsa.show()),
+                    MultiSigner::Ed25519(p) => (hex::encode(p), Encryption::Ed25519.show()),
+                    MultiSigner::Sr25519(p) => (hex::encode(p), Encryption::Sr25519.show()),
+                    MultiSigner::Ecdsa(p) => (hex::encode(p), Encryption::Ecdsa.show()),
                 };
                 NavCard::AuthorPublicKeyCard {
                     f: MVerifierDetails {
@@ -242,9 +242,9 @@ impl<'a> Card<'a> {
             Card::Verifier(x) => match x {
                 VerifierValue::Standard { m } => {
                     let (public_key, encryption) = match m {
-                        MultiSigner::Ed25519(p) => (hex::encode(&p), Encryption::Ed25519.show()),
-                        MultiSigner::Sr25519(p) => (hex::encode(&p), Encryption::Sr25519.show()),
-                        MultiSigner::Ecdsa(p) => (hex::encode(&p), Encryption::Ecdsa.show()),
+                        MultiSigner::Ed25519(p) => (hex::encode(p), Encryption::Ed25519.show()),
+                        MultiSigner::Sr25519(p) => (hex::encode(p), Encryption::Sr25519.show()),
+                        MultiSigner::Ecdsa(p) => (hex::encode(p), Encryption::Ecdsa.show()),
                     };
                     NavCard::VerifierCard {
                         f: MVerifierDetails {
@@ -259,7 +259,7 @@ impl<'a> Card<'a> {
                 f: MMetadataRecord {
                     specname: x.name.clone(),
                     specs_version: x.version.to_string(),
-                    meta_hash: hex::encode(&x.meta_hash),
+                    meta_hash: hex::encode(x.meta_hash),
                     meta_id_pic: pic_meta(x.meta_hash.as_bytes()),
                 },
             },

--- a/rust/transaction_signing/src/tests.rs
+++ b/rust/transaction_signing/src/tests.rs
@@ -125,7 +125,7 @@ fn print_db_content(dbname: &str) -> String {
     }
 
     let settings: Tree = database.open_tree(SETTREE).unwrap();
-    let general_verifier_encoded = settings.get(&GENERALVERIFIER).unwrap().unwrap();
+    let general_verifier_encoded = settings.get(GENERALVERIFIER).unwrap().unwrap();
     let general_verifier = Verifier::decode(&mut &general_verifier_encoded[..]).unwrap();
 
     let mut verifiers_set: Vec<String> = Vec::new();


### PR DESCRIPTION
## Purpose

Fix `clippy` on new rust stable `1.65`. 
