### PR TITLE
fix: iOS: Don't send calls to database before initialisation and delete all keychain items on first app run

### DIFF
--- a/ios/NativeSigner/Core/Connectivity/ConnectivityMediator.swift
+++ b/ios/NativeSigner/Core/Connectivity/ConnectivityMediator.swift
@@ -27,7 +27,7 @@ private extension ConnectivityMediator {
     func setUpConnectivityMonitoring() {
         connectivityMonitor.startMonitoring { [weak self] isConnected in
             guard let self = self else { return }
-            if isConnected {
+            if isConnected, self.databaseMediator.isDatabaseAvailable() {
                 try? historyDeviceWasOnline(dbname: self.databaseMediator.databaseName)
             }
             self.isConnectivityOn = isConnected

--- a/ios/NativeSigner/Core/Database/DatabaseMediator.swift
+++ b/ios/NativeSigner/Core/Database/DatabaseMediator.swift
@@ -39,7 +39,8 @@ final class DatabaseMediator: DatabaseMediating {
             for: .documentDirectory,
             in: .userDomainMask,
             appropriateFor: nil,
-            create: false)
+            create: false
+        )
         return documentsURL?.appendingPathComponent(Constants.resource).path ?? ""
     }
 
@@ -51,10 +52,8 @@ final class DatabaseMediator: DatabaseMediating {
         self.fileManager = fileManager
     }
 
-
     func isDatabaseAvailable() -> Bool {
         fileManager.fileExists(atPath: databasePath)
-        FileManager.default.isReadableFile(atPath: databasePath)
     }
 
     func recreateDatabaseFile() -> Bool {

--- a/ios/NativeSigner/Core/Database/DatabaseMediator.swift
+++ b/ios/NativeSigner/Core/Database/DatabaseMediator.swift
@@ -84,7 +84,6 @@ final class DatabaseMediator: DatabaseMediating {
 
     @discardableResult
     func wipeDatabase() -> Bool {
-        guard isDatabaseAvailable() else { return true }
         do {
             try fileManager.removeItem(atPath: databasePath)
             return true

--- a/ios/NativeSigner/Core/Protocols/FileManagingProtocol.swift
+++ b/ios/NativeSigner/Core/Protocols/FileManagingProtocol.swift
@@ -20,6 +20,8 @@ protocol FileManagingProtocol: AnyObject {
     /// - Parameter URL: A file URL specifying the file or directory to remove. If the URL specifies a directory, the
     // contents of that directory are recursively removed.
     func removeItem(at URL: URL) throws
+    /// Removes the file or directory at the specified path.
+    func removeItem(atPath path: String) throws
 
     /// Copies the file at the specified URL to a new location synchronously.
     /// - Parameters:


### PR DESCRIPTION
## Purpose
This fixes few smaller issues:
- if user opens the app first time in online mode, they can't go pass initial screen, which is fine - but when they run app second time, application will have invalid database state. This is because app was calling `historyDeviceWasOnline` when device was online and before first call to `initNavigation` was called
- in above scenario user would see old seed names from keychain even if app was deleted, because app was calling `updateSeedNames` with seed names from old keychain - this is addressed by wiping keychain on first install
- also minor semantix when to comes to database path is fixed, we shouldn't use `NSHomeDirectory` if in some places we use `fileManager.url(for: .documentDirectory, in: .userDomainMask)` as these could be different in some iOS version