### PR TITLE
feat: android should init viewmodel only when new activity is created

### DIFF
--- a/android/src/main/java/io/parity/signer/MainActivity.kt
+++ b/android/src/main/java/io/parity/signer/MainActivity.kt
@@ -44,7 +44,9 @@ class MainActivity : AppCompatActivity() {
 		signerDataModel.context = applicationContext
 		signerDataModel.activity = this
 
-		signerDataModel.lateInit()
+		if (savedInstanceState == null) {
+			signerDataModel.lateInit()
+		}
 
 		//remove automatic insets so bottom sheet can dimm status bar, other views will add their paddings if needed.
 		WindowCompat.setDecorFitsSystemWindows(window, false)


### PR DESCRIPTION
For example when dark mode is enabled we don't need to ask for password again - viewmodel is already initialized