### PR TITLE
fix: android bulk signing seed passed

### DIFF
--- a/android/src/main/java/io/parity/signer/screens/scan/transaction/TransactionPreviewEdited.kt
+++ b/android/src/main/java/io/parity/signer/screens/scan/transaction/TransactionPreviewEdited.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.platform.LocalFocusManager
 import io.parity.signer.components.*
 import io.parity.signer.models.Callback
 import io.parity.signer.ui.theme.Text400
-import io.parity.signer.uniffi.Action
 import io.parity.signer.uniffi.MTransaction
 import io.parity.signer.uniffi.TransactionType
 
@@ -72,8 +71,9 @@ fun TransactionPreviewEdited(
 					text = "Unlock key and sign",
 					action = {
 						signTransaction(
-							comment.value, transactions.firstOrNull()
-								?.authorInfo?.address?.seedName ?: ""
+							comment.value,
+							transactions.mapNotNull { it.authorInfo?.address?.seedName }
+								.joinToString(separator = "/n")
 						)
 					}
 				)


### PR DESCRIPTION
## Purpose
passe all seeds for signing multitransactions.

FYI @montekki this will pass the same seed multiple times if it's the same for multiple transactions. Is it ok?