### PR TITLE
style: iOS: allow for multiline snackbar

### DIFF
--- a/ios/NativeSigner/Components/Modals/Snackbar.swift
+++ b/ios/NativeSigner/Components/Modals/Snackbar.swift
@@ -59,23 +59,27 @@ struct Snackbar: View {
     }
 
     var body: some View {
-        VStack {
+        HStack {
+            Text(viewModel.title)
+                .font(Fontstyle.bodyL.base)
+                .foregroundColor(Asset.accentForegroundText.swiftUIColor)
+                .padding(Spacing.large)
+                .multilineTextAlignment(.leading)
+                .fixedSize(horizontal: false, vertical: true)
             Spacer()
-            HStack {
-                Text(viewModel.title)
-                    .font(Fontstyle.bodyL.base)
-                    .foregroundColor(Asset.accentForegroundText.swiftUIColor)
-                    .padding(Spacing.large)
-                Spacer()
-                if let countdown = viewModel.countdown {
-                    CircularProgressView(countdown)
-                        .padding(.trailing, Spacing.medium)
-                }
+            if let countdown = viewModel.countdown {
+                CircularProgressView(countdown)
+                    .padding(.trailing, Spacing.medium)
             }
-            .frame(height: Heights.snackbarHeight, alignment: .center)
-            .background(viewModel.style.tintColor)
-            .cornerRadius(CornerRadius.small)
         }
+        .frame(
+            minHeight: Heights.snackbarHeight,
+            idealHeight: Heights.snackbarHeight,
+            maxHeight: Heights.snackbarMaxHeight,
+            alignment: .center
+        )
+        .background(viewModel.style.tintColor)
+        .cornerRadius(CornerRadius.small)
         .padding([.top, .bottom])
         .padding([.leading, .trailing], Spacing.extraSmall)
     }

--- a/ios/NativeSigner/Design/Heights.swift
+++ b/ios/NativeSigner/Design/Heights.swift
@@ -13,6 +13,8 @@ enum Heights {
     static let actionButton: CGFloat = 56
     /// All variants of `Snackbar`, 56 pt
     static let snackbarHeight: CGFloat = 56
+    /// Max height variant of `Snackbar`, 72 pt
+    static let snackbarMaxHeight: CGFloat = 72
     /// All variants of `NavigationBarView`, 64 pt
     static let navigationBarHeight: CGFloat = 64
     /// All variants of `NavbarButton`, 40 pt


### PR DESCRIPTION
## Purpose
Currently Snackbar content is limited to single line, this change allows it to differ in height between 56-72pt and allow to accommodate  1-3 lines