### PR TITLE
fix: iOS: fix updated styles for old screens using new design color system

### DIFF
--- a/ios/NativeSigner/Components/Deprecated/Buttons.swift
+++ b/ios/NativeSigner/Components/Deprecated/Buttons.swift
@@ -29,16 +29,6 @@ struct BigButton: View {
     var isDisabled: Bool = false
 
     var body: some View {
-        let accentColor = isCrypto ? Asset.textAndIconsPrimary.swiftUIColor : Asset.textAndIconsPrimary.swiftUIColor
-        let bgColor = isDisabled
-            ? Asset.backgroundSecondary.swiftUIColor
-            : isShaded ? Asset.backgroundTertiary.swiftUIColor : accentColor
-        let fgColor = isDisabled
-            ? Asset.textAndIconsTertiary.swiftUIColor
-            : isShaded
-            ? isDangerous ? Asset.accentRed400.swiftUIColor : Asset.textAndIconsPrimary.swiftUIColor
-            : Asset.accentForegroundText.swiftUIColor
-
         Button(action: action) {
             HStack {
                 Spacer()
@@ -46,7 +36,34 @@ struct BigButton: View {
                 Spacer()
             }
         }
-        .buttonStyle(BigButtonStyle(bgColor: bgColor, fgColor: fgColor))
+        .buttonStyle(style())
         .disabled(isDisabled)
+    }
+
+    func style() -> BigButtonStyle {
+        let bgColor: Color
+        let fgColor: Color
+
+        switch (isCrypto, isDisabled, isShaded) {
+        case (true, true, _):
+            bgColor = Asset.backgroundTertiary.swiftUIColor
+            fgColor = Asset.textAndIconsTertiary.swiftUIColor
+        case (true, false, true):
+            bgColor = Asset.backgroundTertiary.swiftUIColor
+            fgColor = isDangerous ? Asset.accentRed300.swiftUIColor : Asset.accentPink300.swiftUIColor
+        case (true, false, false):
+            bgColor = Asset.backgroundPrimary.swiftUIColor
+            fgColor = Asset.textAndIconsPrimary.swiftUIColor
+        case (false, true, _):
+            bgColor = Asset.backgroundTertiary.swiftUIColor
+            fgColor = Asset.textAndIconsTertiary.swiftUIColor
+        case (false, false, true):
+            bgColor = Asset.backgroundTertiary.swiftUIColor
+            fgColor = isDangerous ? Asset.accentRed300.swiftUIColor : Asset.textAndIconsPrimary.swiftUIColor
+        case (false, false, false):
+            bgColor = Asset.accentPink500.swiftUIColor
+            fgColor = Asset.accentForegroundText.swiftUIColor
+        }
+        return BigButtonStyle(bgColor: bgColor, fgColor: fgColor)
     }
 }

--- a/ios/NativeSigner/Modals/Deprecated/NewSeedBackupModal.swift
+++ b/ios/NativeSigner/Modals/Deprecated/NewSeedBackupModal.swift
@@ -24,7 +24,7 @@ struct NewSeedBackupModal: View {
                         .foregroundColor(Asset.accentPink300.swiftUIColor)
                         .padding(8)
                 }
-                .background(RoundedRectangle(cornerRadius: 8).foregroundColor(Asset.accentPink300.swiftUIColor))
+                .background(RoundedRectangle(cornerRadius: 8).foregroundColor(Asset.backgroundSecondary.swiftUIColor))
                 VStack(spacing: 16) {
                     Button(
                         action: {


### PR DESCRIPTION
## Purpose
After removing old color schemes, there are some issues with new colors used that lead to broken UI elements, this PR addresses that

## Scope
- refactor old button style calculation
- fix seed phrase background for new phrase
