### PR TITLE
fix: iOS: Present passworded paths in unified way and fix list display in Export Key Sets

### DIFF
--- a/ios/NativeSigner/Cards/AddressCard.swift
+++ b/ios/NativeSigner/Cards/AddressCard.swift
@@ -41,7 +41,7 @@ struct AddressCard: View {
                             .font(PrimaryFont.labelM.font)
                         Text(card.address.path)
                         if card.address.hasPwd {
-                            Localizable.Path.delimeter.text
+                            Localizable.Shared.Label.passwordedPathDelimeter.text
                                 .foregroundColor(Asset.accentPink300.swiftUIColor)
                                 .font(PrimaryFont.captionM.font)
                             Image(.lock)

--- a/ios/NativeSigner/Components/Rows/DerivedKeyOverviewRow.swift
+++ b/ios/NativeSigner/Components/Rows/DerivedKeyOverviewRow.swift
@@ -54,7 +54,7 @@ struct DerivedKeyOverviewRow: View {
     private var fullPath: Text {
         viewModel.hasPassword ?
             Text(
-                "\(viewModel.path)\(Localizable.Path.delimeter.string)\(Image(.lock))"
+                "\(viewModel.path)\(Localizable.Shared.Label.passwordedPathDelimeter.string)\(Image(.lock))"
             ) :
             Text(viewModel.path)
     }

--- a/ios/NativeSigner/Extensions/Models/Address+DisplayablePath.swift
+++ b/ios/NativeSigner/Extensions/Models/Address+DisplayablePath.swift
@@ -11,7 +11,7 @@ extension Address {
     /// Returns either `path` or if password protected, available path with path delimeter and lock icon
     var displayablePath: String {
         hasPwd ?
-            "\(path)\(Localizable.Address.Label.PasswordProtectedPath.pathDelimeter.string)" :
+            "\(path)\(Localizable.Shared.Label.passwordedPathDelimeter.string)" :
             path
     }
 }

--- a/ios/NativeSigner/Modals/ExportKeys/ExportMultipleKeysModal.swift
+++ b/ios/NativeSigner/Modals/ExportKeys/ExportMultipleKeysModal.swift
@@ -85,14 +85,14 @@ struct ExportMultipleKeysModal: View {
             case let .keySets(keySets):
                 ForEach(
                     keySets.sorted(by: { $0.keyName < $1.keyName }),
-                    id: \.keyName
+                    id: \.id
                 ) { keyItem($0, isLast: $0 == keySets.last) }
             case let .keys(key, derivedKeys):
                 QRCodeRootFooterView(viewModel: .init(key))
                 Divider()
                 ForEach(
                     derivedKeys.sorted(by: { $0.viewModel.path < $1.viewModel.path }),
-                    id: \.viewModel.path
+                    id: \.id
                 ) {
                     QRCodeAddressFooterView(viewModel: .init($0))
                     if $0 != derivedKeys.last {

--- a/ios/NativeSigner/Resources/en.lproj/Localizable.strings
+++ b/ios/NativeSigner/Resources/en.lproj/Localizable.strings
@@ -1,8 +1,7 @@
 
+"Shared.Label.PasswordedPathDelimeter" = "///••••";
 
 "common.ok" = "Ok";
-
-
 "Accept" = "Accept";
 "Accept privacy policy?" = "Accept privacy policy?";
 "accounts" = "accounts";
@@ -436,8 +435,6 @@
 "Transaction.EnterPassword.Label.InvalidPassword" = "The password you entered is incorrect.\nPlease try again.";
 "Transaction.EnterPassword.Error.Title" = "Did you forget your\npassword?";
 "Transaction.EnterPassword.Error.Message" = "Your password was entered incorrectly more than once. Retrieve it and scan the QR code again.";
-"Transaction.EnterPassword.Label.PathDelimeter" = "///••••";
-"Address.Label.PasswordProtectedPath.PathDelimeter" = "///••••";
 "LogsList.Label.Title" = "All Logs";
 "LogsList.More.Action.Add" = "Add Note";
 "LogsList.More.Action.Clear" = "Clear Log";

--- a/ios/NativeSigner/Screens/EnterPasswordModal.swift
+++ b/ios/NativeSigner/Screens/EnterPasswordModal.swift
@@ -112,7 +112,7 @@ struct EnterPasswordModal: View {
     private var renderablePath: Text {
         Text(
             // swiftlint:disable:next line_length
-            "\(viewModel.dataModel.authorInfo.address.path)\(Localizable.Transaction.EnterPassword.Label.pathDelimeter.string)\(Image(.lock))"
+            "\(viewModel.dataModel.authorInfo.address.path)\(Localizable.Shared.Label.passwordedPathDelimeter.string)\(Image(.lock))"
         )
     }
 }

--- a/ios/NativeSigner/Screens/KeyDetails/Models/KeyDetailsDataModel.swift
+++ b/ios/NativeSigner/Screens/KeyDetails/Models/KeyDetailsDataModel.swift
@@ -55,7 +55,8 @@ struct KeyDetailsDataModel: Equatable {
     }
 }
 
-struct DerivedKeyExportModel: Equatable {
+struct DerivedKeyExportModel: Equatable, Identifiable {
+    let id = UUID()
     let viewModel: DerivedKeyRowViewModel
     let keyData: MKeyAndNetworkCard
 }

--- a/ios/NativeSigner/Screens/KeyDetails/Views/DerivedKeyRow.swift
+++ b/ios/NativeSigner/Screens/KeyDetails/Views/DerivedKeyRow.swift
@@ -60,7 +60,7 @@ struct DerivedKeyRow: View {
     private var fullPath: Text {
         viewModel.hasPassword ?
             Text(
-                "\(viewModel.path)\(Localizable.Path.delimeter.string)\(Image(.lock))"
+                "\(viewModel.path)\(Localizable.Shared.Label.passwordedPathDelimeter.string)\(Image(.lock))"
             ) :
             Text(viewModel.path)
     }

--- a/ios/NativeSigner/Screens/KeySetsList/KeySetListViewModelBuilder.swift
+++ b/ios/NativeSigner/Screens/KeySetsList/KeySetListViewModelBuilder.swift
@@ -13,7 +13,8 @@ struct KeySetListViewModel: Equatable {
 }
 
 /// View model to render single row in `KeySetList`
-struct KeySetViewModel: Equatable {
+struct KeySetViewModel: Equatable, Identifiable {
+    let id = UUID()
     let seed: SeedNameCard
     let keyName: String
     let derivedKeys: String?

--- a/ios/NativeSignerTests/Screens/KeySetList/KeySetListViewModelBuilderTests.swift
+++ b/ios/NativeSignerTests/Screens/KeySetList/KeySetListViewModelBuilderTests.swift
@@ -30,7 +30,10 @@ final class KeySetListViewModelBuilderTests: XCTestCase {
         let result = subject.build(for: MSeeds(seedNameCards: [seedNameCard]))
 
         // Then
-        XCTAssertEqual(result, expectedResult)
+        XCTAssertEqual(result.list.first?.seed, seedNameCard)
+        XCTAssertEqual(result.list.first?.keyName, name)
+        XCTAssertEqual(result.list.first?.derivedKeys, derivedKeys)
+        XCTAssertEqual(result.list.first?.identicon, identicon)
     }
 
     func test_build_singleDerivedKey_returnsExpectedModel() {
@@ -47,7 +50,10 @@ final class KeySetListViewModelBuilderTests: XCTestCase {
         let result = subject.build(for: MSeeds(seedNameCards: [seedNameCard]))
 
         // Then
-        XCTAssertEqual(result, expectedResult)
+        XCTAssertEqual(result.list.first?.seed, seedNameCard)
+        XCTAssertEqual(result.list.first?.keyName, name)
+        XCTAssertEqual(result.list.first?.derivedKeys, derivedKeys)
+        XCTAssertEqual(result.list.first?.identicon, identicon)
     }
 
     func test_build_multipleDerivedKeys_returnsExpectedModel() {
@@ -64,6 +70,9 @@ final class KeySetListViewModelBuilderTests: XCTestCase {
         let result = subject.build(for: MSeeds(seedNameCards: [seedNameCard]))
 
         // Then
-        XCTAssertEqual(result, expectedResult)
+        XCTAssertEqual(result.list.first?.seed, seedNameCard)
+        XCTAssertEqual(result.list.first?.keyName, name)
+        XCTAssertEqual(result.list.first?.derivedKeys, derivedKeys)
+        XCTAssertEqual(result.list.first?.identicon, identicon)
     }
 }


### PR DESCRIPTION
## Purpose
Present all passworded paths as `///****<lock_icon>` in unified way
Additionally small fix for value filtering on Export Key Set modal
