### PR TITLE
fix: clippy on rust 1.66

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,7 +1,6 @@
 name:                         E2E Test
 
 on:
-on:
   pull_request:
   push:
     branches:

--- a/rust/db_handling/tests/tests.rs
+++ b/rust/db_handling/tests/tests.rs
@@ -2300,13 +2300,13 @@ fn remove_all_westend() {
         let database: Db = open(dbname).unwrap();
         let chainspecs: Tree = database.open_tree(SPECSTREE).unwrap();
         assert!(
-            chainspecs.get(&network_specs_key.key()).unwrap().is_none(),
+            chainspecs.get(network_specs_key.key()).unwrap().is_none(),
             "Westend network specs were not deleted"
         );
         let metadata: Tree = database.open_tree(METATREE).unwrap();
         let prefix_meta = MetaKeyPrefix::from_name("westend");
         assert!(
-            metadata.scan_prefix(&prefix_meta.prefix()).next().is_none(),
+            metadata.scan_prefix(prefix_meta.prefix()).next().is_none(),
             "Some westend metadata was not deleted"
         );
         let identities: Tree = database.open_tree(ADDRTREE).unwrap();

--- a/rust/definitions/src/metadata.rs
+++ b/rust/definitions/src/metadata.rs
@@ -544,7 +544,7 @@ mod tests {
     #[test]
     fn westend9070() {
         let filename = String::from("for_tests/westend9070");
-        let meta = read_to_string(&filename).unwrap();
+        let meta = read_to_string(filename).unwrap();
         let meta_values = MetaValues::from_str_metadata(meta.trim()).unwrap();
         assert!(
             meta_values.name == *"westend",
@@ -561,7 +561,7 @@ mod tests {
     #[test]
     fn westend9033() {
         let filename = String::from("for_tests/westend9033");
-        let meta = read_to_string(&filename).unwrap();
+        let meta = read_to_string(filename).unwrap();
         let meta_values = MetaValues::from_str_metadata(meta.trim()).unwrap();
         assert!(
             meta_values.name == *"westend",
@@ -578,7 +578,7 @@ mod tests {
     #[test]
     fn westend9030() {
         let filename = String::from("for_tests/westend9030");
-        let meta = read_to_string(&filename).unwrap();
+        let meta = read_to_string(filename).unwrap();
         let meta_values = MetaValues::from_str_metadata(meta.trim()).unwrap();
         assert!(
             meta_values.name == *"westend",
@@ -595,7 +595,7 @@ mod tests {
     #[test]
     fn rococo9004() {
         let filename = String::from("for_tests/rococo9004");
-        let meta = read_to_string(&filename).unwrap();
+        let meta = read_to_string(filename).unwrap();
         let meta_values = MetaValues::from_str_metadata(meta.trim()).unwrap();
         assert!(
             meta_values.name == *"rococo",
@@ -612,7 +612,7 @@ mod tests {
     #[test]
     fn rococo9002() {
         let filename = String::from("for_tests/rococo9002");
-        let meta = read_to_string(&filename).unwrap();
+        let meta = read_to_string(filename).unwrap();
         let meta_values = MetaValues::from_str_metadata(meta.trim()).unwrap();
         assert!(
             meta_values.name == *"rococo",
@@ -629,7 +629,7 @@ mod tests {
     #[test]
     fn polkadot9080() {
         let filename = String::from("for_tests/polkadot9080");
-        let meta = read_to_string(&filename).unwrap();
+        let meta = read_to_string(filename).unwrap();
         let meta_values = MetaValues::from_str_metadata(meta.trim()).unwrap();
         assert!(
             meta_values.name == *"polkadot",
@@ -646,7 +646,7 @@ mod tests {
     #[test]
     fn polkadot30() {
         let filename = String::from("for_tests/polkadot30");
-        let meta = read_to_string(&filename).unwrap();
+        let meta = read_to_string(filename).unwrap();
         let meta_values = MetaValues::from_str_metadata(meta.trim()).unwrap();
         assert!(
             meta_values.name == *"polkadot",
@@ -663,7 +663,7 @@ mod tests {
     #[test]
     fn polkadot29() {
         let filename = String::from("for_tests/polkadot29");
-        let meta = read_to_string(&filename).unwrap();
+        let meta = read_to_string(filename).unwrap();
         let meta_values = MetaValues::from_str_metadata(meta.trim()).unwrap();
         assert!(
             meta_values.name == *"polkadot",
@@ -680,7 +680,7 @@ mod tests {
     #[test]
     fn kusama9040() {
         let filename = String::from("for_tests/kusama9040");
-        let meta = read_to_string(&filename).unwrap();
+        let meta = read_to_string(filename).unwrap();
         let meta_values = MetaValues::from_str_metadata(meta.trim()).unwrap();
         assert!(
             meta_values.name == *"kusama",
@@ -697,7 +697,7 @@ mod tests {
     #[test]
     fn kusama9010() {
         let filename = String::from("for_tests/kusama9010");
-        let meta = read_to_string(&filename).unwrap();
+        let meta = read_to_string(filename).unwrap();
         let meta_values = MetaValues::from_str_metadata(meta.trim()).unwrap();
         assert!(
             meta_values.name == *"kusama",
@@ -714,7 +714,7 @@ mod tests {
     #[test]
     fn edgeware() {
         let filename = String::from("for_tests/edgeware");
-        let meta = read_to_string(&filename).unwrap();
+        let meta = read_to_string(filename).unwrap();
 
         match MetaValues::from_str_metadata(meta.trim()) {
             Ok(x) => panic!("Unexpectedly decoded as {} version {}", x.name, x.version),
@@ -730,7 +730,7 @@ mod tests {
     #[test]
     fn centrifuge_amber() {
         let filename = String::from("for_tests/centrifugeAmber");
-        let meta = read_to_string(&filename).unwrap();
+        let meta = read_to_string(filename).unwrap();
 
         match MetaValues::from_str_metadata(meta.trim()) {
             Ok(x) => panic!("Unexpectedly decoded as {} version {}", x.name, x.version),
@@ -746,7 +746,7 @@ mod tests {
     #[test]
     fn westend9150() {
         let filename = String::from("for_tests/westend9150");
-        let meta = read_to_string(&filename).unwrap();
+        let meta = read_to_string(filename).unwrap();
         let meta_values = MetaValues::from_str_metadata(meta.trim()).unwrap();
         assert!(
             meta_values.name == *"westend",
@@ -767,7 +767,7 @@ mod tests {
     #[test]
     fn shell200() {
         let filename = String::from("for_tests/shell200");
-        let meta = read_to_string(&filename).unwrap();
+        let meta = read_to_string(filename).unwrap();
         let meta_values = MetaValues::from_str_metadata(meta.trim()).unwrap();
         assert!(
             meta_values.name == *"shell",

--- a/rust/definitions/src/qr_transfers.rs
+++ b/rust/definitions/src/qr_transfers.rs
@@ -87,7 +87,7 @@ impl ContentLoadMeta {
     where
         P: AsRef<Path>,
     {
-        Ok(std::fs::write(filename, &self.to_sign())?)
+        Ok(std::fs::write(filename, self.to_sign())?)
     }
 
     /// Transform [`ContentLoadMeta`] into `Vec<u8>` that could be signed by the verifier.
@@ -142,7 +142,7 @@ impl ContentAddSpecs {
     where
         P: AsRef<Path>,
     {
-        Ok(std::fs::write(file_path, &self.to_sign())?)
+        Ok(std::fs::write(file_path, self.to_sign())?)
     }
 
     /// Transform [`ContentAddSpecs`] into `Vec<u8>` that could be signed by the verifier.
@@ -206,7 +206,7 @@ impl ContentLoadTypes {
     where
         P: AsRef<Path>,
     {
-        Ok(std::fs::write(path, &self.to_sign())?)
+        Ok(std::fs::write(path, self.to_sign())?)
     }
 
     /// Transform [`ContentLoadTypes`] into `Vec<u8>` to be put in the database.  

--- a/rust/generate_message/src/derivations.rs
+++ b/rust/generate_message/src/derivations.rs
@@ -60,13 +60,13 @@ pub fn process_derivations(x: Derivations) -> Result<()> {
     match x.goal {
         Goal::Qr => make_pretty_qr(&complete_message, &output_name).map_err(Error::Qr)?,
         Goal::Text => std::fs::write(
-            &format!("{}.txt", output_name),
-            &hex::encode(&complete_message),
+            format!("{}.txt", output_name),
+            hex::encode(&complete_message),
         )?,
         Goal::Both => {
             std::fs::write(
-                &format!("{}.txt", output_name),
-                &hex::encode(&complete_message),
+                format!("{}.txt", output_name),
+                hex::encode(&complete_message),
             )?;
             make_pretty_qr(&complete_message, &output_name).map_err(Error::Qr)?
         }

--- a/rust/generate_message/src/make_message.rs
+++ b/rust/generate_message/src/make_message.rs
@@ -195,11 +195,11 @@ pub fn make_message(make: Make) -> Result<()> {
         }
         Goal::Text => {
             output_name.set_extension("txt");
-            std::fs::write(&output_name, &hex::encode(&complete_message))?;
+            std::fs::write(&output_name, hex::encode(&complete_message))?;
         }
         Goal::Both => {
             output_name.set_extension("txt");
-            std::fs::write(&output_name, &hex::encode(&complete_message))?;
+            std::fs::write(&output_name, hex::encode(&complete_message))?;
             make_pretty_qr(&complete_message, &output_name).map_err(Error::Qr)?;
         }
     }

--- a/rust/generate_message/src/parser.rs
+++ b/rust/generate_message/src/parser.rs
@@ -572,7 +572,7 @@ pub struct Make {
 
 impl Make {
     pub fn payload(&self) -> Result<Vec<u8>> {
-        Ok(std::fs::read(&self.files_dir.join(&self.payload))?)
+        Ok(std::fs::read(self.files_dir.join(&self.payload))?)
     }
 
     pub fn crypto(&self) -> Result<Crypto> {

--- a/rust/generate_message/src/show.rs
+++ b/rust/generate_message/src/show.rs
@@ -146,7 +146,7 @@ pub fn check_file<P>(path: String, db_path: P) -> Result<()>
 where
     P: AsRef<Path>,
 {
-    let meta_str = std::fs::read_to_string(&path)?;
+    let meta_str = std::fs::read_to_string(path)?;
 
     // `MetaValues` from metadata in file
     let from_file = MetaValues::from_str_metadata(meta_str.trim())?;

--- a/rust/navigator/src/lib.rs
+++ b/rust/navigator/src/lib.rs
@@ -100,7 +100,7 @@ pub fn export_signatures_bulk(
         make_data_packs(&data, 128).map_err(|e| Error::DataPacking(e.to_string()))?
     } else {
         let encoded = match signatures[0].1 {
-            SignatureType::Transaction => hex::encode(&signatures[0].0.encode()),
+            SignatureType::Transaction => hex::encode(signatures[0].0.encode()),
             SignatureType::Message => match &signatures[0].0 {
                 MultiSignature::Ed25519(a) => hex::encode(a),
                 MultiSignature::Sr25519(a) => hex::encode(a),

--- a/rust/navigator/src/tests.rs
+++ b/rust/navigator/src/tests.rs
@@ -131,7 +131,7 @@ fn signature_is_good(transaction_hex: &str, signature_hex: &str) -> bool {
                     message
                 }
             };
-            sp_core::ed25519::Pair::verify(&signature, &message, &public)
+            sp_core::ed25519::Pair::verify(&signature, message, &public)
         }
         "5301" => {
             let into_signature: [u8; 64] = match &transaction_hex[4..6] {
@@ -170,7 +170,7 @@ fn signature_is_good(transaction_hex: &str, signature_hex: &str) -> bool {
                     message
                 }
             };
-            sp_core::sr25519::Pair::verify(&signature, &message, &public)
+            sp_core::sr25519::Pair::verify(&signature, message, &public)
         }
         "5302" => {
             assert!(
@@ -203,7 +203,7 @@ fn signature_is_good(transaction_hex: &str, signature_hex: &str) -> bool {
                     message
                 }
             };
-            sp_core::ecdsa::Pair::verify(&signature, &message, &public)
+            sp_core::ecdsa::Pair::verify(&signature, message, &public)
         }
         _ => panic!("Transaction has bad format"),
     }
@@ -418,8 +418,8 @@ fn bulk_signing_test_passworded() {
 
     let encoded_transactions = vec![
         hex::decode(&tx_passworded_123_1).unwrap(),
-        hex::decode(&tx_passworded_123_2).unwrap(),
-        hex::decode(&tx_passworded_345_1).unwrap(),
+        hex::decode(tx_passworded_123_2).unwrap(),
+        hex::decode(tx_passworded_345_1).unwrap(),
     ];
 
     // Another bulk in format that is digestible by verification
@@ -5497,7 +5497,7 @@ fn flow_test_1() {
             action.modal_data
         );
     };
-    let sufficient_hex = hex::encode(&sufficient);
+    let sufficient_hex = hex::encode(sufficient);
 
     let mut new_log_with_modal = expected_action.clone();
     assert_eq!(
@@ -5794,7 +5794,7 @@ fn flow_test_1() {
             action.modal_data
         );
     };
-    let sufficient_hex = hex::encode(&sufficient);
+    let sufficient_hex = hex::encode(sufficient);
 
     assert_eq!(
         action, expected_action,
@@ -5884,7 +5884,7 @@ fn flow_test_1() {
         );
     };
 
-    let sufficient_hex = hex::encode(&sufficient);
+    let sufficient_hex = hex::encode(sufficient);
 
     new_log_with_modal.modal_data = Some(ModalData::SufficientCryptoReady {
         f: MSufficientCryptoReady {

--- a/rust/qr_reader_pc/src/lib.rs
+++ b/rust/qr_reader_pc/src/lib.rs
@@ -69,7 +69,7 @@ pub fn run_with_camera(camera_settings: CameraSettings) -> anyhow::Result<String
                 };
             }
             Ready::Yes(a) => {
-                line.push_str(&hex::encode(&a));
+                line.push_str(&hex::encode(a));
                 break;
             }
         }

--- a/rust/qr_reader_pc/tests/integration_test.rs
+++ b/rust/qr_reader_pc/tests/integration_test.rs
@@ -20,7 +20,7 @@ fn check_single_qr_hex() -> Result<(), String> {
 
     match process_qr_image(&gray_img, InProgress::None) {
         Ok(x) => match x {
-            Ready::Yes(a) => result.push_str(&hex::encode(&a)),
+            Ready::Yes(a) => result.push_str(&hex::encode(a)),
             Ready::NotYet(_) => return Err(String::from("Waiting animated QR.")),
         },
         Err(_) => return Err(String::from("QR image processing error.")),

--- a/rust/qr_reader_phone/src/lib.rs
+++ b/rust/qr_reader_phone/src/lib.rs
@@ -38,7 +38,7 @@ pub fn decode_sequence(set: &[String], cleaned: bool) -> Result<String> {
         if let Ready::NotYet(decoding) = out {
             out = process_decoded_payload(payload, decoding)?;
             if let Ready::Yes(v) = out {
-                final_result = Some(hex::encode(&v));
+                final_result = Some(hex::encode(v));
                 break;
             }
         }

--- a/rust/qrcode_rtx/src/lib.rs
+++ b/rust/qrcode_rtx/src/lib.rs
@@ -126,7 +126,7 @@ where
 {
     if input.len() <= 2953 {
         let qr = png_qr(input, DataType::Regular)?;
-        match std::fs::write(output_name, &qr) {
+        match std::fs::write(output_name, qr) {
             Ok(_) => Ok(()),
             Err(e) => Err(Box::from(format!("Output error {}", e))),
         }


### PR DESCRIPTION
## Purpose

Fix `clippy` on rust 1.66.
