### PR TITLE
fix: iOS: bottom safe insets on devices without home button

### DIFF
--- a/ios/NativeSigner/Components/Modals/FullScreenRoundedModal.swift
+++ b/ios/NativeSigner/Components/Modals/FullScreenRoundedModal.swift
@@ -8,7 +8,26 @@
 import SwiftUI
 
 struct FullScreenRoundedModal<Content: View>: View {
+    enum BottomSafeInsets {
+        case full
+        case partial
+        case none
+
+        func inset(_ value: CGFloat) -> CGFloat {
+            switch self {
+            case .full:
+                return value
+            case .partial:
+                return value / 2.0
+            case .none:
+                return 0.0
+            }
+        }
+    }
+
     @Binding private var animateBackground: Bool
+    @Environment(\.safeAreaInsets) private var safeAreaInsets
+    private let safeAreaInsetsMode: BottomSafeInsets
     private let backgroundTapAction: () -> Void
     private let content: () -> Content
     private let ignoredEdges: Edge.Set
@@ -17,11 +36,13 @@ struct FullScreenRoundedModal<Content: View>: View {
         backgroundTapAction: @escaping () -> Void = {},
         animateBackground: Binding<Bool> = Binding<Bool>.constant(false),
         ignoredEdges: Edge.Set = .all,
+        safeAreaInsetsMode: BottomSafeInsets = .partial,
         @ViewBuilder content: @escaping () -> Content
     ) {
         self.backgroundTapAction = backgroundTapAction
         self.ignoredEdges = ignoredEdges
         _animateBackground = animateBackground
+        self.safeAreaInsetsMode = safeAreaInsetsMode
         self.content = content
     }
 
@@ -48,6 +69,7 @@ struct FullScreenRoundedModal<Content: View>: View {
                 VStack(alignment: .leading, spacing: Spacing.medium, content: content)
                     .padding(.top, Spacing.medium)
                     .padding([.leading, .trailing], 0)
+                    .padding(.bottom, safeAreaInsetsMode.inset(safeAreaInsets.bottom))
                     .background(Asset.backgroundTertiary.swiftUIColor)
                     .cornerRadius(radius: CornerRadius.medium, corners: [.topLeft, .topRight])
             }

--- a/ios/NativeSigner/Modals/Alerts/HorizontalActionsBottomModal.swift
+++ b/ios/NativeSigner/Modals/Alerts/HorizontalActionsBottomModal.swift
@@ -79,6 +79,7 @@ struct HorizontalActionsBottomModal: View {
         FullScreenRoundedModal(
             backgroundTapAction: { animateDismissal(dismissAction()) },
             animateBackground: $animateBackground,
+            safeAreaInsetsMode: .full,
             content: {
                 VStack(alignment: .center, spacing: Spacing.medium) {
                     Text(viewModel.title)

--- a/ios/NativeSigner/Modals/Alerts/VerticalActionsBottomModal.swift
+++ b/ios/NativeSigner/Modals/Alerts/VerticalActionsBottomModal.swift
@@ -44,6 +44,7 @@ struct VerticalActionsBottomModal: View {
         FullScreenRoundedModal(
             backgroundTapAction: { animateDismissal(dismissAction()) },
             animateBackground: $animateBackground,
+            safeAreaInsetsMode: .full,
             content: {
                 VStack(alignment: .leading, spacing: Spacing.medium) {
                     Text(viewModel.title)

--- a/ios/NativeSigner/Modals/Backup/BackupModal.swift
+++ b/ios/NativeSigner/Modals/Backup/BackupModal.swift
@@ -40,6 +40,7 @@ struct BackupModal: View {
             },
             animateBackground: $animateBackground,
             ignoredEdges: .bottom,
+            safeAreaInsetsMode: .full,
             content: {
                 VStack(alignment: .center, spacing: 0) {
                     // Header with X button

--- a/ios/NativeSigner/Modals/ExportPrivateKey/ExportPrivateKeyModal.swift
+++ b/ios/NativeSigner/Modals/ExportPrivateKey/ExportPrivateKeyModal.swift
@@ -25,6 +25,7 @@ struct ExportPrivateKeyModal: View {
                 animateDismissal()
             },
             animateBackground: $animateBackground,
+            safeAreaInsetsMode: .full,
             content: {
                 VStack(alignment: .center) {
                     // Header with X button


### PR DESCRIPTION
## Purpose
For devices without `Home` button, fullscreen modals have additional safe area insets that weren't taken into account. This PR fixes that

## Scope
- add ability to `FullScreenModal` to include different behaviour to accommodate for bottom insets
- add proper settings for calculating bottom insets based on modal type

## Screenshots
| Before | After |
|-|-|
|<img src="https://user-images.githubusercontent.com/1955364/209632488-35cfff13-fb95-43b8-a9bd-6e6effd57cb5.png" width="320px">|<img src="https://user-images.githubusercontent.com/1955364/209632442-a05676ae-45c7-4cd2-86ba-471521ca6525.png" width="320px">|
|<img src="https://user-images.githubusercontent.com/1955364/209632493-0981f85c-bcf6-4589-b861-812b13886b37.png" width="320px">|<img src="https://user-images.githubusercontent.com/1955364/209632453-f1936066-e1f8-485c-8156-4fff222dd7e7.png" width="320px">|
|<img src="https://user-images.githubusercontent.com/1955364/209632522-27ccf786-ed41-4199-b060-d75837bc1d46.png" width="320px">|<img src="https://user-images.githubusercontent.com/1955364/209632546-be5dccd6-1c35-442e-bc2e-544749be6c2d.png" width="320px">|
