### PR TITLE
fix: iOS: background on Key Sets on devices with notch

### DIFF
--- a/ios/NativeSigner/Screens/KeySetsList/KeySetList.swift
+++ b/ios/NativeSigner/Screens/KeySetsList/KeySetList.swift
@@ -21,6 +21,7 @@ struct KeySetList: View {
         ZStack(alignment: .bottom) {
             // Background color
             Asset.backgroundSystem.swiftUIColor
+                .ignoresSafeArea()
             // Main screen
             VStack(spacing: 0) {
                 // Navigation Bar


### PR DESCRIPTION
## Purpose
Simple fix for updated background colour on Key Sets, to go over safe area insets on devices with notch

## Screenshots

| Before | After |
|-|-|
|<img src="https://user-images.githubusercontent.com/1955364/209763720-65a1c3a1-b185-450a-906e-53555af51b2c.png" width="320px">|<img src="https://user-images.githubusercontent.com/1955364/209763746-7e297334-0b3b-4d41-8c4d-85d0cd14ba81.png" width="320px">|
