### PR TITLE
feat: iOS: hide actions for Public Key Details

### DIFF
--- a/ios/NativeSigner/Modals/KeySet/PublicKeyActionsModal.swift
+++ b/ios/NativeSigner/Modals/KeySet/PublicKeyActionsModal.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct PublicKeyActionsModal: View {
     @State private var animateBackground: Bool = false
-
     @Binding private var shouldPresentExportKeysWarningModal: Bool
     @Binding private var isShowingActionSheet: Bool
     @Binding private var shouldPresentRemoveConfirmationModal: Bool
@@ -31,15 +30,6 @@ struct PublicKeyActionsModal: View {
             animateBackground: $animateBackground,
             content: {
                 VStack(alignment: .leading, spacing: 0) {
-                    ActionSheetButton(
-                        action: {
-                            animateDismissal {
-                                navigation.perform(navigation: .init(action: .newSeed))
-                            }
-                        },
-                        icon: Asset.otherNetworks.swiftUIImage,
-                        text: Localizable.PublicKeyDetailsModal.Action.networks.key
-                    )
                     // Don't show `Export Private Key` if intermediate state is broken or when key is password protected
                     if let currentKeyDetails = navigation.currentKeyDetails,
                        currentKeyDetails.address.hasPwd == false {
@@ -53,15 +43,6 @@ struct PublicKeyActionsModal: View {
                             text: Localizable.PublicKeyDetailsModal.Action.share.key
                         )
                     }
-                    ActionSheetButton(
-                        action: {
-                            animateDismissal {
-                                navigation.perform(navigation: .init(action: .networkSelector))
-                            }
-                        },
-                        icon: Asset.changeNetwork.swiftUIImage,
-                        text: Localizable.PublicKeyDetailsModal.Action.changeNetwork.key
-                    )
                     ActionSheetButton(
                         action: { animateDismissal { shouldPresentRemoveConfirmationModal.toggle() } },
                         icon: Asset.delete.swiftUIImage,


### PR DESCRIPTION
## Purpose
Remove options that are not currently used in Public Key Details

## Screenshots

| After change |
|-|
|<img src="https://user-images.githubusercontent.com/1955364/209897723-ffd250b3-da06-4af0-97b5-8b0dd2950121.png" width="320px">|
