### PR TITLE
feat: iOS: show informative alert when not disconnected completely during onboarding

### DIFF
--- a/ios/NativeSigner/Models/RustNative.swift
+++ b/ios/NativeSigner/Models/RustNative.swift
@@ -65,10 +65,6 @@ final class SignerDataModel: ObservableObject {
     /// Should be called once on factory-new state of the app
     /// Populates database with starting values
     func onboard(jailbreak: Bool = false) {
-        guard !connectivityMediator.isConnectivityOn else {
-            alert = true
-            return
-        }
         wipe()
         guard databaseMediator.recreateDatabaseFile() else {
             print("Database could not be recreated")

--- a/ios/NativeSigner/Screens/LandingView.swift
+++ b/ios/NativeSigner/Screens/LandingView.swift
@@ -11,7 +11,10 @@ struct LandingView: View {
     @State private var tacAccept = false
     @State private var ppAccept = false
     @State private var accept = false
+    @State var presentInitialConnectivityWarning: Bool = false
     @EnvironmentObject private var data: SignerDataModel
+    @EnvironmentObject private var connectivityMediator: ConnectivityMediator
+
     var body: some View {
         VStack {
             DocumentModal()
@@ -45,7 +48,11 @@ struct LandingView: View {
                 BigButton(
                     text: Localizable.next.key,
                     action: {
-                        accept = true
+                        if connectivityMediator.isConnectivityOn {
+                            presentInitialConnectivityWarning = true
+                        } else {
+                            accept = true
+                        }
                     },
                     isDisabled: !(tacAccept && ppAccept)
                 )
@@ -63,6 +70,15 @@ struct LandingView: View {
             }
         }
         .padding()
+        .fullScreenCover(
+            isPresented: $presentInitialConnectivityWarning
+        ) {
+            ErrorBottomModal(
+                viewModel: .connectivityOn(),
+                isShowingBottomAlert: $presentInitialConnectivityWarning
+            )
+            .clearModalBackground()
+        }
     }
 }
 


### PR DESCRIPTION
## Purpose
Currently when onboarding and having any connectivity, user won't be taken to next screen, but also won't see any message regarding the issue.
This PR introduces temporary solution to present new UI on top of old landing page

## Scope
- move dead code path from old state manager class directly to landing page
- present new UI when connectivity is detected during onboarding

## Screenshots

| Before | After |
|-|-|
|<img src="https://user-images.githubusercontent.com/1955364/209898807-501627c0-2a3c-42a1-a130-152e539b20c5.gif" width="320px">|<img src="https://user-images.githubusercontent.com/1955364/209898645-c6a102d4-3132-41b1-91da-450fe1830990.gif" width="320px">|
