### PR TITLE
feat: iOS: Hide Derive New Key from action menu

### DIFF
--- a/ios/NativeSigner/Modals/KeySet/KeyDetailsActionsModal.swift
+++ b/ios/NativeSigner/Modals/KeySet/KeyDetailsActionsModal.swift
@@ -27,16 +27,6 @@ struct KeyDetailsActionsModal: View {
                         icon: Asset.selectUnselected.swiftUIImage,
                         text: Localizable.KeySetsModal.Action.export.key
                     )
-                    // Derive Keys
-                    ActionSheetButton(
-                        action: {
-                            animateDismissal {
-                                navigation.perform(navigation: .init(action: .newKey))
-                            }
-                        },
-                        icon: Asset.deriveKey.swiftUIImage,
-                        text: Localizable.KeySetsModal.Action.derive.key
-                    )
                     ActionSheetButton(
                         action: {
                             animateDismissal {


### PR DESCRIPTION
## Purpose
Hide "Derive New Key" that was supposed to be N+1 option in action menu

## Screenshots
| After the change |
|-|
|<img src="https://user-images.githubusercontent.com/1955364/209900585-43d32c69-8599-4e30-b0bc-d4a159859d85.png" width="320px">|
