### PR TITLE
feat: iOS: hide option to not create root key when adding / restoring key set

### DIFF
--- a/ios/NativeSigner/Modals/Deprecated/NewSeedBackupModal.swift
+++ b/ios/NativeSigner/Modals/Deprecated/NewSeedBackupModal.swift
@@ -12,7 +12,6 @@ struct NewSeedBackupModal: View {
     let restoreSeed: (String, String, Bool) -> Void
     let navigationRequest: NavigationRequest
     @State private var confirmBackup = false
-    @State private var createRoots = true
     var body: some View {
         ZStack {
             RoundedRectangle(cornerRadius: 8).foregroundColor(Asset.backgroundSecondary.swiftUIColor)
@@ -41,25 +40,11 @@ struct NewSeedBackupModal: View {
                             }
                         }
                     )
-                    Button(
-                        action: {
-                            createRoots.toggle()
-                        },
-                        label: {
-                            HStack {
-                                (createRoots ? Image(.checkmark, variant: .square) : Image(.square)).imageScale(.large)
-                                Localizable.createRootKeys.text
-                                    .multilineTextAlignment(.leading)
-                                    .foregroundColor(Asset.textAndIconsSecondary.swiftUIColor)
-                                Spacer()
-                            }
-                        }
-                    )
                     Spacer()
                     BigButton(
                         text: Localizable.next.key,
                         action: {
-                            restoreSeed(content.seed, content.seedPhrase, createRoots)
+                            restoreSeed(content.seed, content.seedPhrase, true)
                         },
                         isDisabled: !confirmBackup
                     )

--- a/ios/NativeSigner/Screens/RecoverSeedPhrase.swift
+++ b/ios/NativeSigner/Screens/RecoverSeedPhrase.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct RecoverSeedPhrase: View {
     @State private var userInput: String = " "
-    @State private var createRoots: Bool = true
     @State private var shadowUserInput: String = " "
     @FocusState private var focus: Bool
     let content: MRecoverSeedPhrase
@@ -75,7 +74,7 @@ struct RecoverSeedPhrase: View {
                                             },
                                             label: {
                                                 Text(guess)
-                                                    .foregroundColor(Asset.accentPink300.swiftUIColor)
+                                                    .foregroundColor(Asset.accentForegroundText.swiftUIColor)
                                                     .font(PrimaryFont.captionM.font)
                                                     .padding(.horizontal, 12)
                                                     .padding(.vertical, 4)
@@ -90,30 +89,15 @@ struct RecoverSeedPhrase: View {
                             }
                         }.frame(height: 23)
                         Spacer()
-                        Button(
-                            action: {
-                                createRoots.toggle()
-                            },
-                            label: {
-                                HStack {
-                                    Image(systemName: createRoots ? "checkmark.square" : "square").imageScale(.large)
-                                    Localizable.createRootKeys.text
-                                        .multilineTextAlignment(.leading)
-                                    Spacer()
-                                }
-                            }
-                        )
-                        if !focus {
-                            HStack {
-                                BigButton(
-                                    text: Localizable.next.key,
-                                    action: {
-                                        restoreSeed(content.seedName, content.readySeed ?? "", createRoots)
-                                    },
-                                    isDisabled: content.readySeed == nil
-                                )
-                                .padding(.top, 16.0)
-                            }
+                        HStack {
+                            BigButton(
+                                text: Localizable.next.key,
+                                action: {
+                                    restoreSeed(content.seedName, content.readySeed ?? "", true)
+                                },
+                                isDisabled: content.readySeed == nil
+                            )
+                            .padding(.top, 16.0)
                         }
                     }.padding(.horizontal)
                 }


### PR DESCRIPTION
## Purpose
This option won't be available in new designs, so we should already remove it to allow backend to simplify Rust logic and make sure root is always available

## Scope
- remove root key checkbox from Add Key Set
- remove root key checkbox from Recover Key Set
- fix font color on Recover screen
- make "Next" button always visible on Recover screen
