### PR TITLE
fix: gitignore temporary signing files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,8 +93,8 @@ rust/db_handling/signer_database
 rust/database/database_cold_release
 rust/database/database_hot
 rust/qrcode_static/*.png
-rust/files/for_signing/*
-rust/files/signed/*
+rust/files/completed/*
+rust/files/in_progress/*
 # development mess
 rust/transaction_parsing/src/main.rs
 rust/transaction_signing/src/main.rs


### PR DESCRIPTION
These paths were updated in https://github.com/paritytech/parity-signer/pull/1067 but the gitignore wasn't.