### PR TITLE
feat: make android not crash when private key exported for passworded keys

### DIFF
--- a/android/src/main/java/io/parity/signer/models/Navigation.kt
+++ b/android/src/main/java/io/parity/signer/models/Navigation.kt
@@ -72,14 +72,25 @@ class SignerNavigator(private val singleton: SignerDataModel) : Navigator {
 					if (BuildConfig.DEBUG) throw RuntimeException("Invalid navigation state - cannot export key. You should never see it. ${keyDetails == null}")
 					return
 				}
-				val secretKeyDetailsQR = generateSecretKeyQr(
-					dbname = singleton.dbName,
-					publicKey = action.publicKey,
-					expectedSeedName = keyDetails.address.seedName,
-					networkSpecsKey = keyDetails.networkInfo.networkSpecsKey,
-					seedPhrase = singleton.getSeed(keyDetails.address.seedName),
-					keyPassword = null
-				)
+				val secretKeyDetailsQR = try {
+					generateSecretKeyQr(
+						dbname = singleton.dbName,
+						publicKey = action.publicKey,
+						expectedSeedName = keyDetails.address.seedName,
+						networkSpecsKey = keyDetails.networkInfo.networkSpecsKey,
+						seedPhrase = singleton.getSeed(keyDetails.address.seedName),
+						keyPassword = null
+					)
+				} catch (e: Exception) {
+					//todo issue #1533
+					Toast.makeText(
+						singleton.context,
+						"For passworded keys not yet supported",
+						Toast.LENGTH_LONG
+					).show()
+					navigate(Action.GO_BACK) // close bottom sheet from rust stack
+					return
+				}
 				val model = PrivateKeyExportModel(
 					qrData = secretKeyDetailsQR.qr.getData(),
 					keyCard = KeyCardModel(


### PR DESCRIPTION
Just show toast but don't crash when unneccessary