### PR TITLE
fix: iOS: correct valdiation for passworded path

### DIFF
--- a/ios/NativeSigner/Screens/DerivedKey/Subviews/DerivationPathNameView.swift
+++ b/ios/NativeSigner/Screens/DerivedKey/Subviews/DerivationPathNameView.swift
@@ -303,10 +303,7 @@ extension DerivationPathNameView {
                         return (
                             !isPasswordValid ||
                                 passwordConfirmation.isEmpty ||
-                                inputText.components(separatedBy: DerivationPathComponent.passworded.description)
-                                .last == nil ||
-                                inputText.components(separatedBy: DerivationPathComponent.passworded.description)
-                                .last != passwordConfirmation ||
+                                !self.isPasswordConfirmationValid() ||
                                 self.derivationPathError != nil
                         )
                     } else {
@@ -315,6 +312,15 @@ extension DerivationPathNameView {
                 }
                 .assign(to: \.isMainActionDisabled, on: self)
                 .store(in: cancelBag)
+        }
+
+        private func isPasswordConfirmationValid() -> Bool {
+            guard isPassworded else { return true }
+            if let range = inputText.range(of: DerivationPathComponent.passworded.description) {
+                let substring = inputText.suffix(from: range.upperBound)
+                return substring == passwordConfirmation
+            }
+            return false
         }
     }
 }


### PR DESCRIPTION
## Purpose
Fix password validation if there are multiple occurrences of "///" within path

## Screenshots
| Before | After |
|-|-|
|<img src="https://user-images.githubusercontent.com/1955364/212609945-93d53c88-bb26-4fa0-9656-bfa7baee306f.png" width="320px">|<img src="https://user-images.githubusercontent.com/1955364/212609961-5900fe77-45c5-407e-b4c0-d166f7e47400.png" width="320px">|
| |<img src="https://user-images.githubusercontent.com/1955364/212610011-a8f4bc37-7156-47bd-b2a2-e12e647616f0.png" width="320px">|
