### PR TITLE
fix: ios: fix navigation during banana split

### DIFF
--- a/ios/NativeSigner/Screens/Scan/EnterBananaSplitPasswordModal.swift
+++ b/ios/NativeSigner/Screens/Scan/EnterBananaSplitPasswordModal.swift
@@ -154,7 +154,6 @@ extension EnterBananaSplitPasswordModal {
                         return
                     }
                     navigation.performFake(navigation: .init(action: .navbarKeys))
-                    navigation.performFake(navigation: .init(action: .rightButtonAction))
                     navigation.performFake(navigation: .init(action: .recoverSeed))
                     navigation.performFake(navigation: .init(action: .goForward, details: seedName))
                     seedsMediator.restoreSeed(seedName: seedName, seedPhrase: seedPhrase, navigate: false)


### PR DESCRIPTION
## Purpose
Fix navigation calls in Banana Split to allow `goForward` to recover keys
