### PR TITLE
fix: ios: Banana Split fixes - avoiding empty seed name and conditional navigation based on number of seeds

### DIFF
--- a/ios/NativeSigner/Core/Keychain/SeedsMediator.swift
+++ b/ios/NativeSigner/Core/Keychain/SeedsMediator.swift
@@ -111,7 +111,7 @@ final class SeedsMediator: SeedsMediating {
 
     @discardableResult
     func restoreSeed(seedName: String, seedPhrase: String, navigate: Bool = true) -> Bool {
-        guard let finalSeedPhrase = seedPhrase.data(using: .utf8) else { return false }
+        guard !seedName.isEmpty, let finalSeedPhrase = seedPhrase.data(using: .utf8) else { return false }
         if navigate, checkSeedPhraseCollision(seedPhrase: seedPhrase) {
             return false
         }

--- a/ios/NativeSigner/Modifiers/SecuredTextField.swift
+++ b/ios/NativeSigner/Modifiers/SecuredTextField.swift
@@ -27,12 +27,14 @@ struct SecurePrimaryTextField: View {
                 SecureField("", text: $text, onCommit: {
                     onCommit()
                 })
+                .autocorrectionDisabled()
                 .transaction { $0.animation = nil }
                 .focused($focusedField, equals: .secure)
                 .opacity(isSecured ? 1 : 0)
                 TextField("", text: $text, onCommit: {
                     onCommit()
                 })
+                .autocorrectionDisabled()
                 .transaction { $0.animation = nil }
                 .focused($focusedField, equals: .plain)
                 .opacity(isSecured ? 0 : 1)

--- a/ios/NativeSigner/Resources/en.lproj/Localizable.strings
+++ b/ios/NativeSigner/Resources/en.lproj/Localizable.strings
@@ -542,6 +542,7 @@
 "EnterBananaSplitPasswordModal.Error.Label.InvalidSeedName" = "Given display name already exists.\nPlease try again.";
 "EnterBananaSplitPasswordModal.Error.SeedPhraseExists.Title" = "Seed phrase already exists";
 "EnterBananaSplitPasswordModal.Error.SeedPhraseExists.Message" = "Seed phrase that you are trying to recover already exists in the app.";
+"EnterBananaSplitPasswordModal.Error.LocalRestoreFailed.Message" = "Given combination of seed phrase and seed name couldn't be saved.";
 
 "CreateDerivedKey.Label.Title" = "Create Derived Key";
 "CreateDerivedKey.Label.Header.Network" = "Choose Network";

--- a/ios/NativeSigner/Screens/Scan/EnterBananaSplitPasswordModal.swift
+++ b/ios/NativeSigner/Screens/Scan/EnterBananaSplitPasswordModal.swift
@@ -145,6 +145,9 @@ extension EnterBananaSplitPasswordModal {
         }
 
         func onDoneTap() {
+            // If user uses 'return' on password field, we should confirm that `isActionDisable` is false, meaning we
+            // have all required data to properly resotre seed
+            guard !isActionDisabled else { return }
             do {
                 let result = try qrparserTryDecodeQrSequence(data: qrCodeData, password: password, cleaned: false)
                 if case let .bBananaSplitRecoveryResult(b: bananaResult) = result,
@@ -154,9 +157,25 @@ extension EnterBananaSplitPasswordModal {
                         return
                     }
                     navigation.performFake(navigation: .init(action: .navbarKeys))
+                    // Key Set List state has different "modalData" state depending on whether user has at least one key
+                    // or not
+                    // So we need to check whether we should actually "pretend" to open "more" navigation bar menu by
+                    // calling
+                    // .rightButtonAction
+                    if !seedsMediator.seedNames.isEmpty {
+                        navigation.performFake(navigation: .init(action: .rightButtonAction))
+                    }
                     navigation.performFake(navigation: .init(action: .recoverSeed))
                     navigation.performFake(navigation: .init(action: .goForward, details: seedName))
-                    seedsMediator.restoreSeed(seedName: seedName, seedPhrase: seedPhrase, navigate: false)
+                    // We should do additional check on whether seed can be successfully saved and not call navigation
+                    // further if there are any issues (i.e. somehow seedname is still empty, etc)
+                    guard seedsMediator.restoreSeed(seedName: seedName, seedPhrase: seedPhrase, navigate: false) else {
+                        dismissWithError(.alertError(
+                            message: Localizable.EnterBananaSplitPasswordModal.Error
+                                .LocalRestoreFailed.message.string
+                        ))
+                        return
+                    }
                     navigation.performFake(navigation: .init(action: .goBack))
                     navigation.overrideQRScannerDismissalNavigation = .init(action: .selectSeed, details: seedName)
                     isKeyRecovered = true


### PR DESCRIPTION
## Purpose
This PR fixes:
- ability to trigger seed recovery by tapping "return" on keyboard for password textfield when seed name textfield is empty
- additional check and error if somehow keychain operation would fail (or somehow seed name is still empty)
- conditional logic as Rust navigation expects different steps depending on whether we already have at least 1 key set or not (old app was expanding modal menu if there are no Key Sets, hence difference in navigation)
