### PR TITLE
fix: ios: fix issue with touch not being received sometimes in main view contexts

### DIFF
--- a/ios/NativeSigner/Components/Modals/Snackbar.swift
+++ b/ios/NativeSigner/Components/Modals/Snackbar.swift
@@ -96,12 +96,15 @@ extension View {
         isPresented: Binding<Bool>,
         autodismissCounter: TimeInterval = 3
     ) -> some View {
-        bottomEdgeOverlay(overlayView: Snackbar(viewModel: viewModel), isPresented: isPresented)
-            .tapAndDelayDismiss(
-                autodismissCounter: autodismissCounter,
-                isTapToDismissActive: viewModel.tapToDismiss,
-                isPresented: isPresented
-            )
+        bottomEdgeOverlay(
+            overlayView: Snackbar(viewModel: viewModel)
+                .tapAndDelayDismiss(
+                    autodismissCounter: autodismissCounter,
+                    isTapToDismissActive: viewModel.tapToDismiss,
+                    isPresented: isPresented
+                ),
+            isPresented: isPresented
+        )
     }
 }
 


### PR DESCRIPTION
## Purpose
Sometimes some buttons required double touch to work - it turns out that Snackbar background overlay sometimes still holds tap gesture handler, hence tap mechanism was behaving weird, this small PR fixes this
