### PR TITLE
fix: adjusted scan icons according to design feedback

### DIFF
--- a/android/src/main/java/io/parity/signer/screens/scan/camera/CameraExtras.kt
+++ b/android/src/main/java/io/parity/signer/screens/scan/camera/CameraExtras.kt
@@ -20,8 +20,8 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import io.parity.signer.components.base.CloseIcon
 import io.parity.signer.models.Callback
+import io.parity.signer.screens.scan.elements.CameraCloseIcon
 import io.parity.signer.screens.scan.elements.CameraLightIcon
 import io.parity.signer.ui.theme.SignerNewTheme
 import io.parity.signer.ui.theme.forcedFill40
@@ -130,7 +130,7 @@ internal fun ScanHeader(
 			.fillMaxWidth(1f)
 			.padding(horizontal = 16.dp)
 	) {
-		CloseIcon(
+		CameraCloseIcon(
 			onCloseClicked = onClose
 		)
 		Spacer(modifier = Modifier.weight(1f))

--- a/android/src/main/java/io/parity/signer/screens/scan/camera/ScanScreen.kt
+++ b/android/src/main/java/io/parity/signer/screens/scan/camera/ScanScreen.kt
@@ -76,7 +76,7 @@ fun ScanScreen(
 			Spacer(
 				modifier = Modifier
 					.statusBarsPadding()
-					.padding(top = 12.dp)
+					.padding(top = 4.dp)
 			)
 			ScanHeader(onClose = onClose)
 

--- a/android/src/main/java/io/parity/signer/screens/scan/elements/ScanItems.kt
+++ b/android/src/main/java/io/parity/signer/screens/scan/elements/ScanItems.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -17,7 +19,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import io.parity.signer.R
 import io.parity.signer.models.Callback
+import io.parity.signer.ui.theme.fill18
 import io.parity.signer.ui.theme.fill30
+import io.parity.signer.ui.theme.forcedFill30
 import io.parity.signer.ui.theme.pink500
 
 
@@ -29,11 +33,12 @@ fun CameraMultiSignIcon(
 ) {
 	Box(
 		modifier = modifier
-			.size(32.dp)
-			.clickable(onClick = onClick)
-			.background(
-				if (isEnabled) Color.White else MaterialTheme.colors.fill30, CircleShape
-			),
+            .size(32.dp)
+            .clickable(onClick = onClick)
+            .background(
+                if (isEnabled) Color.White else MaterialTheme.colors.fill30,
+                CircleShape
+            ),
 		contentAlignment = Alignment.Center,
 	) {
 		Image(
@@ -49,18 +54,19 @@ fun CameraMultiSignIcon(
 }
 
 @Composable
-fun CameraLightIcon(
+internal fun CameraLightIcon(
 	isEnabled: Boolean,
 	modifier: Modifier = Modifier,
 	onClick: Callback,
 ) {
 	Box(
 		modifier = modifier
-			.size(32.dp)
-			.clickable(onClick = onClick)
-			.background(
-				if (isEnabled) Color.White else MaterialTheme.colors.fill30, CircleShape
-			),
+            .size(40.dp)
+            .clickable(onClick = onClick)
+            .background(
+                if (isEnabled) Color.White else MaterialTheme.colors.forcedFill30,
+                CircleShape
+            ),
 		contentAlignment = Alignment.Center,
 	) {
 		Image(
@@ -68,9 +74,34 @@ fun CameraLightIcon(
 			contentDescription = stringResource(R.string.description_camera_tourch_enable),
 			colorFilter = ColorFilter.tint(
 				if (isEnabled) MaterialTheme.colors.pink500
-				else MaterialTheme.colors.primary
+				else Color.White,
 			),
-			modifier = Modifier.size(20.dp)
+			modifier = Modifier.size(28.dp)
+		)
+	}
+}
+
+
+@Composable
+internal fun CameraCloseIcon(
+	onCloseClicked: Callback
+) {
+	Box(
+		modifier = Modifier
+			.size(40.dp)
+			.clickable(onClick = onCloseClicked)
+			.background(
+				MaterialTheme.colors.forcedFill30,
+				CircleShape
+			),
+		contentAlignment = Alignment.Center,
+	) {
+		Image(
+			imageVector = Icons.Filled.Close,
+			contentDescription = stringResource(R.string.description_close_button),
+			colorFilter = ColorFilter.tint(Color.White),
+			modifier = Modifier
+				.size(28.dp)
 		)
 	}
 }


### PR DESCRIPTION
## Scope
forced colors, updated size as in Figma. Dereased vertical padding

## Screenshots
| Left title, i.e. "Before" | Right title, i.e. "After" |
|-|-|
| ![scan_dark](https://user-images.githubusercontent.com/11879032/214304962-9099e5a5-672e-4137-9894-f5e3a1d53d0b.png) | ![scan_white](https://user-images.githubusercontent.com/11879032/214304972-b1d58d80-0e3e-42c1-9680-410a26dbbb95.png) |
