### PR TITLE
fix: remove git depencency on subxt

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4058,8 +4058,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "subxt"
-version = "0.25.0"
-source = "git+https://github.com/paritytech/subxt#e4e9562b45451f807099a0749dfc4f9a100247c6"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44ddcf2435955202d5f97934e80eb56bbafc85d31949a857ae77431b19f5eddf"
 dependencies = [
  "base58",
  "blake2",
@@ -4087,8 +4088,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.25.0"
-source = "git+https://github.com/paritytech/subxt#e4e9562b45451f807099a0749dfc4f9a100247c6"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0217ebd818e3d4ff1f56cdba4fcc08ede2b9c8eaf2945ad1b442685f674a465f"
 dependencies = [
  "darling",
  "frame-metadata",
@@ -4107,8 +4109,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.25.0"
-source = "git+https://github.com/paritytech/subxt#e4e9562b45451f807099a0749dfc4f9a100247c6"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd0663fedcacc1b3d1430c05e429c2ac40efeab41399efcaaf6ad4070737f3e9"
 dependencies = [
  "darling",
  "proc-macro-error",
@@ -4118,8 +4121,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.25.0"
-source = "git+https://github.com/paritytech/subxt#e4e9562b45451f807099a0749dfc4f9a100247c6"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419b06bdd1926c3b2c53d5ea4f2c875c29afaede2e5de11346f67199ed180685"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",

--- a/rust/parser/Cargo.toml
+++ b/rust/parser/Cargo.toml
@@ -25,7 +25,7 @@ thiserror = "1.0.38"
 pretty_assertions = { version = "1.3.0", optional = true }
 
 [dev-dependencies]
-subxt = { git = "https://github.com/paritytech/subxt", default-features = false }
+subxt = { version = "0.26", default-features = false }
 
 [features]
 default = ["test"]


### PR DESCRIPTION
## Purpose

Use `subxt` from crates.io, not from git.
