### PR TITLE
fix: ios: fix initial calls to Rust hierarchy

### DIFF
--- a/ios/NativeSigner/Core/Keychain/SeedsMediator.swift
+++ b/ios/NativeSigner/Core/Keychain/SeedsMediator.swift
@@ -29,6 +29,8 @@ protocol SeedsMediating: AnyObject {
     ///
     /// This is also used as generic auth request operation that will lock the app on failure
     func refreshSeeds()
+    /// Get all seed names from secure storage without sending update to Rust
+    func initialRefreshSeeds()
     /// Saves a seed within Keychain and adjust app state
     /// - Parameters:
     ///   - seedName: seed name
@@ -96,6 +98,14 @@ final class SeedsMediator: SeedsMediating {
     }
 
     func refreshSeeds() {
+        refreshSeeds(firstRun: false)
+    }
+
+    func initialRefreshSeeds() {
+        refreshSeeds(firstRun: true)
+    }
+
+    private func refreshSeeds(firstRun: Bool) {
         let result = keychainAccessAdapter.fetchSeedNames()
         switch result {
         case let .success(payload):
@@ -103,7 +113,9 @@ final class SeedsMediator: SeedsMediating {
             if let authenticated = payload.authenticated {
                 signerDataModel.authenticated = authenticated
             }
-            attemptToUpdate(seedNames: seedNames)
+            if !firstRun {
+                attemptToUpdate(seedNames: seedNames)
+            }
         case .failure:
             signerDataModel.authenticated = false
         }

--- a/ios/NativeSigner/Models/RustNative.swift
+++ b/ios/NativeSigner/Models/RustNative.swift
@@ -87,7 +87,7 @@ private extension SignerDataModel {
 
     func finaliseInitialisation() {
         if onboardingDone {
-            seedsMediator.refreshSeeds()
+            seedsMediator.initialRefreshSeeds()
             do {
                 try initNavigation(dbname: databaseMediator.databaseName, seedNames: seedsMediator.seedNames)
             } catch {


### PR DESCRIPTION
## Purpose
On iOS after recent changes we were calling `update_seed_names` before `init_navigation` thus resulting in failure and setting authentication status to `false` and triggering another passcode screen, this PR fixes that.
