### PR TITLE
fix: ios: Fixed layout for ipod touch on onboarding screen

### DIFF
--- a/ios/NativeSigner/Screens/Onboarding/Overview/OnboardingOverviewView.swift
+++ b/ios/NativeSigner/Screens/Onboarding/Overview/OnboardingOverviewView.swift
@@ -124,6 +124,8 @@ struct FeatureOverviewView: View {
             Spacer()
             HStack {
                 image
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
             }
         }
         .padding(.horizontal, Spacing.large)


### PR DESCRIPTION
## Purpose
This PR fixes scalability of image on onboarding screen

## Screenshots

| iPod touch |  |
|-|-|
|<img src="https://user-images.githubusercontent.com/1955364/216256236-9b452991-39f3-4d22-bfde-32444e7c552b.png" width="320px">|<img src="https://user-images.githubusercontent.com/1955364/216256244-c4b35606-d20d-43b3-aca6-c12e653d2bc8.png" width="320px">|
|<img src="https://user-images.githubusercontent.com/1955364/216256255-969de57c-c382-4614-bb5e-f0388f022675.png" width="320px">|<img src="https://user-images.githubusercontent.com/1955364/216256178-5a1946dd-f678-49c7-a06c-7fe7ef700828.png" width="320px">|
