### PR TITLE
fix: ios: fix multiple touch events on dismiss actions

### DIFF
--- a/ios/NativeSigner/Modals/Alerts/HorizontalActionsBottomModal.swift
+++ b/ios/NativeSigner/Modals/Alerts/HorizontalActionsBottomModal.swift
@@ -115,7 +115,7 @@ struct HorizontalActionsBottomModal: View {
         Animations.chainAnimation(
             animateBackground.toggle(),
             delayedAnimationClosure: {
-                isShowingBottomAlert.toggle()
+                isShowingBottomAlert = false
                 completion()
             }()
         )

--- a/ios/NativeSigner/Modals/Alerts/VerticalActionsBottomModal.swift
+++ b/ios/NativeSigner/Modals/Alerts/VerticalActionsBottomModal.swift
@@ -80,7 +80,7 @@ struct VerticalActionsBottomModal: View {
         Animations.chainAnimation(
             animateBackground.toggle(),
             delayedAnimationClosure: {
-                isShowingBottomAlert.toggle()
+                isShowingBottomAlert = false
                 completion()
             }()
         )

--- a/ios/NativeSigner/Modals/Backup/BackupModal.swift
+++ b/ios/NativeSigner/Modals/Backup/BackupModal.swift
@@ -111,7 +111,7 @@ struct BackupModal: View {
     private func animateDismissal() {
         Animations.chainAnimation(
             animateBackground.toggle(),
-            delayedAnimationClosure: isShowingBackupModal.toggle()
+            delayedAnimationClosure: { isShowingBackupModal = false }()
         )
     }
 }

--- a/ios/NativeSigner/Modals/Errors/ErrorBottomModal.swift
+++ b/ios/NativeSigner/Modals/Errors/ErrorBottomModal.swift
@@ -108,7 +108,7 @@ struct ErrorBottomModal: View {
         Animations.chainAnimation(
             animateBackground.toggle(),
             delayedAnimationClosure: {
-                isShowingBottomAlert.toggle()
+                isShowingBottomAlert = false
                 completion()
             }()
         )

--- a/ios/NativeSigner/Modals/ExportKeys/ExportMultipleKeysModal.swift
+++ b/ios/NativeSigner/Modals/ExportKeys/ExportMultipleKeysModal.swift
@@ -183,7 +183,7 @@ private extension ExportMultipleKeysModal {
     func animateDismissal() {
         Animations.chainAnimation(
             viewModel.animateBackground.toggle(),
-            delayedAnimationClosure: viewModel.isPresented.toggle()
+            delayedAnimationClosure: { self.viewModel.isPresented = false }()
         )
     }
 }

--- a/ios/NativeSigner/Modals/ExportPrivateKey/ExportPrivateKeyModal.swift
+++ b/ios/NativeSigner/Modals/ExportPrivateKey/ExportPrivateKeyModal.swift
@@ -71,7 +71,7 @@ struct ExportPrivateKeyModal: View {
     private func animateDismissal() {
         Animations.chainAnimation(
             animateBackground.toggle(),
-            delayedAnimationClosure: isPresentingExportKeysModal.toggle()
+            delayedAnimationClosure: { isPresentingExportKeysModal = false }()
         )
     }
 }

--- a/ios/NativeSigner/Modals/ExportPrivateKey/ExportPrivateKeyWarningModal.swift
+++ b/ios/NativeSigner/Modals/ExportPrivateKey/ExportPrivateKeyWarningModal.swift
@@ -56,7 +56,7 @@ struct ExportPrivateKeyWarningModal: View {
     private func animateDismissal() {
         Animations.chainAnimation(
             animateBackground.toggle(),
-            delayedAnimationClosure: isPresentingExportKeysWarningModal.toggle()
+            delayedAnimationClosure: { isPresentingExportKeysWarningModal = false }()
         )
     }
 }

--- a/ios/NativeSigner/Modals/KeySet/KeyDetailsActionsModal.swift
+++ b/ios/NativeSigner/Modals/KeySet/KeyDetailsActionsModal.swift
@@ -64,7 +64,7 @@ struct KeyDetailsActionsModal: View {
         Animations.chainAnimation(
             animateBackground.toggle(),
             delayedAnimationClosure: {
-                isShowingActionSheet.toggle()
+                isShowingActionSheet = false
                 completion()
             }()
         )

--- a/ios/NativeSigner/Modals/KeySet/PublicKeyActionsModal.swift
+++ b/ios/NativeSigner/Modals/KeySet/PublicKeyActionsModal.swift
@@ -66,7 +66,7 @@ struct PublicKeyActionsModal: View {
         Animations.chainAnimation(
             animateBackground.toggle(),
             delayedAnimationClosure: {
-                isShowingActionSheet.toggle()
+                isShowingActionSheet = false
                 completion()
             }()
         )

--- a/ios/NativeSigner/Modals/NetworkSelection/NetworkSelectionModal.swift
+++ b/ios/NativeSigner/Modals/NetworkSelection/NetworkSelectionModal.swift
@@ -146,7 +146,7 @@ extension NetworkSelectionModal {
 //        }
 
         func hide() {
-            isPresented.toggle()
+            isPresented = false
         }
 
         func animateDismissal() {

--- a/ios/NativeSigner/Screens/DerivedKey/Subviews/ChooseNetworkForKeyView.swift
+++ b/ios/NativeSigner/Screens/DerivedKey/Subviews/ChooseNetworkForKeyView.swift
@@ -155,7 +155,7 @@ extension ChooseNetworkForKeyView {
         }
 
         private func hide() {
-            isPresented.toggle()
+            isPresented = false
         }
     }
 }

--- a/ios/NativeSigner/Screens/DerivedKey/Subviews/CreateDerivedKeyConfirmationView.swift
+++ b/ios/NativeSigner/Screens/DerivedKey/Subviews/CreateDerivedKeyConfirmationView.swift
@@ -127,7 +127,7 @@ extension CreateDerivedKeyConfirmationView {
         }
 
         private func hide() {
-            isPresented.toggle()
+            isPresented = false
         }
     }
 }

--- a/ios/NativeSigner/Screens/DerivedKey/Subviews/DerivationMethodsInfoView.swift
+++ b/ios/NativeSigner/Screens/DerivedKey/Subviews/DerivationMethodsInfoView.swift
@@ -84,7 +84,7 @@ extension DerivationMethodsInfoView {
         }
 
         private func hide() {
-            isPresented.toggle()
+            isPresented = false
         }
     }
 }

--- a/ios/NativeSigner/Screens/KeyDetails/Views/RootKeyDetailsModal.swift
+++ b/ios/NativeSigner/Screens/KeyDetails/Views/RootKeyDetailsModal.swift
@@ -55,7 +55,7 @@ struct RootKeyDetailsModal: View {
     private func animateDismissal() {
         Animations.chainAnimation(
             animateBackground.toggle(),
-            delayedAnimationClosure: isPresented.toggle()
+            delayedAnimationClosure: { isPresented = false }()
         )
     }
 }

--- a/ios/NativeSigner/Screens/KeySetsList/AddKeySetModal.swift
+++ b/ios/NativeSigner/Screens/KeySetsList/AddKeySetModal.swift
@@ -65,7 +65,7 @@ struct AddKeySetModal: View {
         Animations.chainAnimation(
             animateBackground.toggle(),
             delayedAnimationClosure: {
-                isShowingNewSeedMenu.toggle()
+                isShowingNewSeedMenu = false
                 completion()
             }()
         )

--- a/ios/NativeSigner/Screens/KeySetsList/KeyListMoreMenuModal.swift
+++ b/ios/NativeSigner/Screens/KeySetsList/KeyListMoreMenuModal.swift
@@ -48,7 +48,7 @@ struct KeyListMoreMenuModal: View {
         Animations.chainAnimation(
             animateBackground.toggle(),
             delayedAnimationClosure: {
-                isPresented.toggle()
+                self.isPresented = false
                 completion()
             }()
         )

--- a/ios/NativeSigner/Screens/Logs/Views/LogNoteModal.swift
+++ b/ios/NativeSigner/Screens/Logs/Views/LogNoteModal.swift
@@ -102,12 +102,12 @@ extension LogNoteModal {
         }
 
         func onCancelTap() {
-            isPresented.toggle()
+            isPresented = false
         }
 
         func onDoneTap() {
             navigation.performFake(navigation: .init(action: .goForward, details: note))
-            isPresented.toggle()
+            isPresented = false
         }
 
         private func subscribeToUpdates() {

--- a/ios/NativeSigner/Screens/Logs/Views/LogsMoreActionsModal.swift
+++ b/ios/NativeSigner/Screens/Logs/Views/LogsMoreActionsModal.swift
@@ -50,7 +50,7 @@ struct LogsMoreActionsModal: View {
         Animations.chainAnimation(
             animateBackground.toggle(),
             delayedAnimationClosure: {
-                isShowingActionSheet.toggle()
+                isShowingActionSheet = false
                 completion()
             }()
         )

--- a/ios/NativeSigner/Screens/Scan/EnterBananaSplitPasswordModal.swift
+++ b/ios/NativeSigner/Screens/Scan/EnterBananaSplitPasswordModal.swift
@@ -141,7 +141,7 @@ extension EnterBananaSplitPasswordModal {
         }
 
         func onCancelTap() {
-            isPresented.toggle()
+            isPresented = false
         }
 
         func onDoneTap() {
@@ -179,7 +179,7 @@ extension EnterBananaSplitPasswordModal {
                     navigation.performFake(navigation: .init(action: .goBack))
                     navigation.overrideQRScannerDismissalNavigation = .init(action: .selectSeed, details: seedName)
                     isKeyRecovered = true
-                    isPresented.toggle()
+                    isPresented = false
                 }
             } catch QrSequenceDecodeError.BananaSplitWrongPassword {
                 invalidPasswordAttempts += 1
@@ -200,7 +200,7 @@ extension EnterBananaSplitPasswordModal {
         private func dismissWithError(_ model: ErrorBottomModalViewModel) {
             presentableError = model
             isErrorPresented = true
-            isPresented.toggle()
+            isPresented = false
         }
 
         private func subscribeToUpdates() {

--- a/ios/NativeSigner/Screens/Scan/EnterPasswordModal.swift
+++ b/ios/NativeSigner/Screens/Scan/EnterPasswordModal.swift
@@ -152,11 +152,11 @@ extension EnterPasswordModal {
             navigation.performFake(navigation: .init(action: .goBack))
             // Pretending to navigate back to `Scan` so navigation states for new QR code scan will work
             navigation.performFake(navigation: .init(action: .navbarScan))
-            isPresented.toggle()
+            isPresented = false
         }
 
         func onErrorDismiss() {
-            isPresented.toggle()
+            isPresented = false
         }
 
         func onDoneTap() {

--- a/ios/NativeSigner/Screens/Scan/TransactionDetailsView.swift
+++ b/ios/NativeSigner/Screens/Scan/TransactionDetailsView.swift
@@ -61,7 +61,7 @@ extension TransactionDetailsView {
         }
 
         func onBackButtonTap() {
-            isPresented.toggle()
+            isPresented = false
         }
     }
 }

--- a/ios/NativeSigner/Screens/Scan/TransactionPreview.swift
+++ b/ios/NativeSigner/Screens/Scan/TransactionPreview.swift
@@ -283,7 +283,7 @@ extension TransactionPreview {
                         style: .warning
                     )
                     self.snackbarPresentation.isSnackbarPresented = true
-                    self.isPresented.toggle()
+                    self.isPresented = false
                 }
             }
         }
@@ -302,22 +302,22 @@ extension TransactionPreview {
 
         func onBackButtonTap() {
             navigation.performFake(navigation: .init(action: .goBack))
-            isPresented.toggle()
+            isPresented = false
         }
 
         func onDoneTap() {
             navigation.performFake(navigation: .init(action: .goBack))
-            isPresented.toggle()
+            isPresented = false
         }
 
         func onCancelTap() {
             navigation.performFake(navigation: .init(action: .goBack))
-            isPresented.toggle()
+            isPresented = false
         }
 
         func onApproveTap() {
             navigation.perform(navigation: .init(action: .goForward))
-            isPresented.toggle()
+            isPresented = false
             switch dataModel.first?.content.previewType {
             case let .addNetwork(network):
                 snackbarPresentation.viewModel = .init(
@@ -361,7 +361,7 @@ extension TransactionPreview {
                 }
 
                 self.snackbarPresentation.isSnackbarPresented = true
-                self.isPresented.toggle()
+                self.isPresented = false
             }
         }
 

--- a/ios/NativeSigner/Screens/Settings/Subviews/Backup/SettingsBackupModal.swift
+++ b/ios/NativeSigner/Screens/Settings/Subviews/Backup/SettingsBackupModal.swift
@@ -94,7 +94,7 @@ struct SettingsBackupModal: View {
     private func animateDismissal() {
         Animations.chainAnimation(
             animateBackground.toggle(),
-            delayedAnimationClosure: isShowingBackupModal.toggle()
+            delayedAnimationClosure: { self.isShowingBackupModal = false }()
         )
     }
 }

--- a/ios/NativeSigner/Screens/Settings/Subviews/Networks/NetworkSettingsDetailsActionModal.swift
+++ b/ios/NativeSigner/Screens/Settings/Subviews/Networks/NetworkSettingsDetailsActionModal.swift
@@ -50,7 +50,7 @@ struct NetworkSettingsDetailsActionModal: View {
         Animations.chainAnimation(
             animateBackground.toggle(),
             delayedAnimationClosure: {
-                isShowingActionSheet.toggle()
+                isShowingActionSheet = false
                 completion()
             }()
         )


### PR DESCRIPTION
## Purpose
Currently for modal components, there is a possibility to trigger `dismiss -> presentation` event with multiple touches on SwiftUI components as we don't block it and use `.toggle()` modifier on `Bool` properties that are being updated within animation block - this PR fixes that to not allow for looping those events.
