### PR TITLE
fix: android fix telling rust about airgap breached till rust navigation initizlied

### DIFF
--- a/android/src/main/java/io/parity/signer/bottomsheets/LogComment.kt
+++ b/android/src/main/java/io/parity/signer/bottomsheets/LogComment.kt
@@ -17,14 +17,14 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
 import io.parity.signer.components.HeaderBar
 import io.parity.signer.components.SingleTextInput
-import io.parity.signer.domain.MainFlowViewModel
+import io.parity.signer.domain.SignerMainViewModel
 import io.parity.signer.domain.navigate
 import io.parity.signer.ui.theme.Bg000
 import io.parity.signer.ui.theme.modal
 import io.parity.signer.uniffi.Action
 
 @Composable
-fun LogComment(mainFlowViewModel: MainFlowViewModel) {
+fun LogComment(signerMainViewModel: SignerMainViewModel) {
 	val comment = remember { mutableStateOf("") }
 	val focusManager = LocalFocusManager.current
 	val focusRequester = remember { FocusRequester() }
@@ -46,7 +46,7 @@ fun LogComment(mainFlowViewModel: MainFlowViewModel) {
 					comment.value = it
 				},
 				onDone = {
-					mainFlowViewModel.navigate(Action.GO_FORWARD, comment.value)
+					signerMainViewModel.navigate(Action.GO_FORWARD, comment.value)
 				},
 				focusManager = focusManager,
 				focusRequester = focusRequester

--- a/android/src/main/java/io/parity/signer/bottomsheets/ManageMetadata.kt
+++ b/android/src/main/java/io/parity/signer/bottomsheets/ManageMetadata.kt
@@ -18,7 +18,7 @@ import io.parity.signer.components.BigButton
 import io.parity.signer.components.HeaderBar
 import io.parity.signer.components.NetworkCard
 import io.parity.signer.components.NetworkCardModel
-import io.parity.signer.domain.MainFlowViewModel
+import io.parity.signer.domain.SignerMainViewModel
 import io.parity.signer.domain.navigate
 import io.parity.signer.ui.theme.Bg000
 import io.parity.signer.ui.theme.modal
@@ -28,13 +28,13 @@ import io.parity.signer.uniffi.MManageMetadata
 @Composable
 fun ManageMetadata(
     networks: MManageMetadata,
-    mainFlowViewModel: MainFlowViewModel
+    signerMainViewModel: SignerMainViewModel
 ) {
 	var confirm by remember { mutableStateOf(false) }
 
 	Surface(
 		color = Color.Transparent,
-		modifier = Modifier.clickable { mainFlowViewModel.navigate(Action.GO_BACK) }
+		modifier = Modifier.clickable { signerMainViewModel.navigate(Action.GO_BACK) }
 	) {
 		Column {
 			Spacer(Modifier.weight(1f))
@@ -64,7 +64,7 @@ fun ManageMetadata(
 						text = "Sign this metadata",
 						isShaded = true,
 						isCrypto = true,
-						action = { mainFlowViewModel.navigate(Action.SIGN_METADATA) })
+						action = { signerMainViewModel.navigate(Action.SIGN_METADATA) })
 					BigButton(
 						text = "Delete this metadata",
 						isShaded = true,
@@ -83,7 +83,7 @@ fun ManageMetadata(
 		header = "Remove metadata?",
 		text = "This metadata will be removed for all networks",
 		back = { confirm = false },
-		forward = { mainFlowViewModel.navigate(Action.REMOVE_METADATA) },
+		forward = { signerMainViewModel.navigate(Action.REMOVE_METADATA) },
 		backText = "Cancel",
 		forwardText = "Remove metadata"
 	)

--- a/android/src/main/java/io/parity/signer/bottomsheets/NetworkDetailsMenu.kt
+++ b/android/src/main/java/io/parity/signer/bottomsheets/NetworkDetailsMenu.kt
@@ -11,14 +11,14 @@ import androidx.compose.ui.unit.dp
 import io.parity.signer.alerts.AndroidCalledConfirm
 import io.parity.signer.components.BigButton
 import io.parity.signer.components.HeaderBar
-import io.parity.signer.domain.MainFlowViewModel
+import io.parity.signer.domain.SignerMainViewModel
 import io.parity.signer.domain.navigate
 import io.parity.signer.ui.theme.Bg000
 import io.parity.signer.ui.theme.modal
 import io.parity.signer.uniffi.Action
 
 @Composable
-fun NetworkDetailsMenu(mainFlowViewModel: MainFlowViewModel) {
+fun NetworkDetailsMenu(signerMainViewModel: SignerMainViewModel) {
 	var confirm by remember { mutableStateOf(false) }
 
 	Column {
@@ -35,7 +35,7 @@ fun NetworkDetailsMenu(mainFlowViewModel: MainFlowViewModel) {
 					text = "Sign network specs",
 					isShaded = true,
 					isCrypto = true,
-					action = { mainFlowViewModel.navigate(Action.SIGN_NETWORK_SPECS) })
+					action = { signerMainViewModel.navigate(Action.SIGN_NETWORK_SPECS) })
 				BigButton(
 					text = "Delete network",
 					isShaded = true,
@@ -52,7 +52,7 @@ fun NetworkDetailsMenu(mainFlowViewModel: MainFlowViewModel) {
 		header = "Remove network?",
 		text = "This network will be removed for whole device",
 		back = { confirm = false },
-		forward = { mainFlowViewModel.navigate(Action.REMOVE_NETWORK) },
+		forward = { signerMainViewModel.navigate(Action.REMOVE_NETWORK) },
 		backText = "Cancel",
 		forwardText = "Remove network"
 	)

--- a/android/src/main/java/io/parity/signer/bottomsheets/SelectSeed.kt
+++ b/android/src/main/java/io/parity/signer/bottomsheets/SelectSeed.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.unit.dp
 import io.parity.signer.components.SeedCard
 import io.parity.signer.components.toImageContent
 import io.parity.signer.dependencygraph.ServiceLocator
-import io.parity.signer.domain.MainFlowViewModel
+import io.parity.signer.domain.SignerMainViewModel
 import io.parity.signer.domain.storage.getSeed
 import io.parity.signer.domain.navigate
 import io.parity.signer.ui.theme.Bg100
@@ -23,7 +23,7 @@ import io.parity.signer.uniffi.Action
 import io.parity.signer.uniffi.MSeeds
 
 @Composable
-fun SelectSeed(seeds: MSeeds, mainFlowViewModel: MainFlowViewModel) {
+fun SelectSeed(seeds: MSeeds, signerMainViewModel: SignerMainViewModel) {
 	val cards = seeds.seedNameCards
 
 	Surface(
@@ -43,11 +43,11 @@ fun SelectSeed(seeds: MSeeds, mainFlowViewModel: MainFlowViewModel) {
 						Modifier
 							.clickable {
 								val authentication = ServiceLocator.authentication
-								authentication.authenticate(mainFlowViewModel.activity) {
+								authentication.authenticate(signerMainViewModel.activity) {
 									val seedName = cards[item].seedName
-									val seedPhrase = mainFlowViewModel.getSeed(seedName)
+									val seedPhrase = signerMainViewModel.getSeed(seedName)
 									if (seedPhrase.isNotBlank()) {
-										mainFlowViewModel.navigate(
+										signerMainViewModel.navigate(
 											Action.GO_FORWARD,
 											seedName,
 											seedPhrase

--- a/android/src/main/java/io/parity/signer/bottomsheets/TypesInfo.kt
+++ b/android/src/main/java/io/parity/signer/bottomsheets/TypesInfo.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import io.parity.signer.alerts.AndroidCalledConfirm
 import io.parity.signer.components.*
-import io.parity.signer.domain.MainFlowViewModel
+import io.parity.signer.domain.SignerMainViewModel
 import io.parity.signer.domain.navigate
 import io.parity.signer.ui.theme.Bg000
 import io.parity.signer.ui.theme.modal
@@ -18,7 +18,7 @@ import io.parity.signer.uniffi.Action
 import io.parity.signer.uniffi.MTypesInfo
 
 @Composable
-fun TypesInfo(typesInfo: MTypesInfo, mainFlowViewModel: MainFlowViewModel) {
+fun TypesInfo(typesInfo: MTypesInfo, signerMainViewModel: SignerMainViewModel) {
 	var confirm by remember { mutableStateOf(false) }
 
 	Column {
@@ -43,7 +43,7 @@ fun TypesInfo(typesInfo: MTypesInfo, mainFlowViewModel: MainFlowViewModel) {
 					text = "Sign types",
 					isShaded = true,
 					isCrypto = true,
-					action = { mainFlowViewModel.navigate(Action.SIGN_TYPES) })
+					action = { signerMainViewModel.navigate(Action.SIGN_TYPES) })
 				BigButton(
 					text = "Delete types",
 					isShaded = true,
@@ -60,7 +60,7 @@ fun TypesInfo(typesInfo: MTypesInfo, mainFlowViewModel: MainFlowViewModel) {
 		header = "Remove types?",
 		text = "Types information needed for support of pre-v14 metadata will be removed. Are you sure?",
 		back = { confirm = false },
-		forward = { mainFlowViewModel.navigate(Action.REMOVE_TYPES) },
+		forward = { signerMainViewModel.navigate(Action.REMOVE_TYPES) },
 		backText = "Cancel",
 		forwardText = "Remove types"
 	)

--- a/android/src/main/java/io/parity/signer/components/panels/BottomBar.kt
+++ b/android/src/main/java/io/parity/signer/components/panels/BottomBar.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
-import io.parity.signer.domain.MainFlowViewModel
+import io.parity.signer.domain.SignerMainViewModel
 import io.parity.signer.domain.navigate
 import io.parity.signer.ui.theme.Bg000
 import io.parity.signer.ui.theme.Text300
@@ -32,7 +32,7 @@ import io.parity.signer.uniffi.actionGetName
 @Composable
 @Deprecated("not used")
 fun BottomBar(
-	mainFlowViewModel: MainFlowViewModel,
+    signerMainViewModel: SignerMainViewModel,
 ) {
 	BottomAppBar(
 		backgroundColor = MaterialTheme.colors.Bg000,
@@ -44,22 +44,22 @@ fun BottomBar(
 			modifier = Modifier.fillMaxWidth(1f)
 		) {
 			BottomBarButton(
-				mainFlowViewModel = mainFlowViewModel,
+				signerMainViewModel = signerMainViewModel,
 				image = Icons.Default.Pattern,
 				action = Action.NAVBAR_KEYS
 			)
 			BottomBarButton(
-				mainFlowViewModel = mainFlowViewModel,
+				signerMainViewModel = signerMainViewModel,
 				image = Icons.Default.CropFree,
 				action = Action.NAVBAR_SCAN
 			)
 			BottomBarButton(
-				mainFlowViewModel = mainFlowViewModel,
+				signerMainViewModel = signerMainViewModel,
 				image = Icons.Default.CalendarViewDay,
 				action = Action.NAVBAR_LOG
 			)
 			BottomBarButton(
-				mainFlowViewModel = mainFlowViewModel,
+				signerMainViewModel = signerMainViewModel,
 				image = Icons.Default.Settings,
 				action = Action.NAVBAR_SETTINGS
 			)
@@ -74,12 +74,12 @@ fun BottomBar(
  */
 @Composable
 fun BottomBarButton(
-	mainFlowViewModel: MainFlowViewModel,
-	image: ImageVector,
-	action: Action,
+    signerMainViewModel: SignerMainViewModel,
+    image: ImageVector,
+    action: Action,
 ) {
 	val selected =
-		mainFlowViewModel.actionResult.collectAsState().value?.footerButton == actionGetName(action)
+		signerMainViewModel.actionResult.collectAsState().value?.footerButton == actionGetName(action)
 	val tint = if (selected) {
 		MaterialTheme.colors.Text600
 	} else {
@@ -94,7 +94,7 @@ fun BottomBarButton(
 		horizontalAlignment = Alignment.CenterHorizontally,
 		modifier = Modifier
 			.clickable(onClick = {
-				mainFlowViewModel.navigate(action)
+				signerMainViewModel.navigate(action)
 			})
 			.width(66.dp)
 	) {

--- a/android/src/main/java/io/parity/signer/components/panels/TopBar.kt
+++ b/android/src/main/java/io/parity/signer/components/panels/TopBar.kt
@@ -15,7 +15,7 @@ import androidx.compose.runtime.State
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import io.parity.signer.components.NavbarShield
-import io.parity.signer.domain.MainFlowViewModel
+import io.parity.signer.domain.SignerMainViewModel
 import io.parity.signer.domain.NetworkState
 import io.parity.signer.domain.navigate
 import io.parity.signer.ui.theme.Action400
@@ -28,9 +28,9 @@ import io.parity.signer.uniffi.ScreenNameType
 
 @Composable
 fun TopBar(
-	mainFlowViewModel: MainFlowViewModel,
-	actionResult: ActionResult,
-	networkState: State<NetworkState?>
+    signerMainViewModel: SignerMainViewModel,
+    actionResult: ActionResult,
+    networkState: State<NetworkState?>
 ) {
 
 	TopAppBar(
@@ -49,7 +49,7 @@ fun TopBar(
 						backgroundColor = MaterialTheme.colors.Bg100
 					),
 					onClick = {
-						mainFlowViewModel.navigate(Action.GO_BACK)
+						signerMainViewModel.navigate(Action.GO_BACK)
 					}
 				) {
 					if (actionResult.rightButton == RightButton.MULTI_SELECT) {
@@ -87,7 +87,7 @@ fun TopBar(
 				.weight(0.2f, fill = true)
 				.width(72.dp)
 		) {
-			IconButton(onClick = { mainFlowViewModel.navigate(Action.RIGHT_BUTTON_ACTION) }) {
+			IconButton(onClick = { signerMainViewModel.navigate(Action.RIGHT_BUTTON_ACTION) }) {
 				when (actionResult.rightButton) {
 					RightButton.NEW_SEED -> {
 						Icon(
@@ -122,7 +122,7 @@ fun TopBar(
 					}
 				}
 			}
-			IconButton(onClick = { mainFlowViewModel.navigate(Action.SHIELD) }) {
+			IconButton(onClick = { signerMainViewModel.navigate(Action.SHIELD) }) {
 				NavbarShield(networkState = networkState)
 			}
 		}

--- a/android/src/main/java/io/parity/signer/components/qrcode/EmptyQrCodeProvider.kt
+++ b/android/src/main/java/io/parity/signer/components/qrcode/EmptyQrCodeProvider.kt
@@ -10,7 +10,7 @@ import io.parity.signer.dependencygraph.ServiceLocator
  */
 class EmptyQrCodeProvider : AnimatedQrKeysProvider<List<List<UByte>>> {
 	private val uniffiInteractor: UniffiInteractor =
-		ServiceLocator.backendScope.uniffiInteractor
+		ServiceLocator.uniffiInteractor
 
 	override suspend fun getQrCodesList(input: List<List<UByte>>): AnimatedQrImages? {
 		return uniffiInteractor.encodeToQrImages(input).mapError()

--- a/android/src/main/java/io/parity/signer/dependencygraph/ServiceLocator.kt
+++ b/android/src/main/java/io/parity/signer/dependencygraph/ServiceLocator.kt
@@ -5,7 +5,6 @@ import androidx.fragment.app.FragmentActivity
 import io.parity.signer.backend.UniffiInteractor
 import io.parity.signer.domain.Authentication
 import io.parity.signer.domain.NetworkExposedStateKeeper
-import io.parity.signer.domain.getDbNameFromContext
 import io.parity.signer.domain.storage.DatabaseAssetsInteractor
 import io.parity.signer.domain.storage.SeedRepository
 import io.parity.signer.domain.storage.SeedStorage
@@ -16,7 +15,6 @@ object ServiceLocator {
 
 	fun initAppDependencies(appContext: Context) {
 		this.appContext = appContext
-		_backendScope = BackendScope(appContext.getDbNameFromContext())
 	}
 
 	fun initActivityDependencies(activity: FragmentActivity) {
@@ -27,23 +25,16 @@ object ServiceLocator {
 		_activityScope = null
 	}
 
-	private var _backendScope: BackendScope? = null
-	val backendScope: BackendScope
-		get() = _backendScope
-			?: throw RuntimeException("dependency is not initialized yet")
-
 	@Volatile private var _activityScope: ActivityScope? = null
 	val activityScope: ActivityScope? get() = _activityScope
 
+	val uniffiInteractor by lazy { UniffiInteractor() }
+
 	val seedStorage: SeedStorage = SeedStorage()
 	val databaseAssetsInteractor by lazy { DatabaseAssetsInteractor(appContext, seedStorage) }
-	val networkExposedStateKeeper by lazy { NetworkExposedStateKeeper(appContext) }
+	val networkExposedStateKeeper by lazy { NetworkExposedStateKeeper(appContext, uniffiInteractor) }
 	val authentication = Authentication()
 
-
-	class BackendScope(dbname: String) {
-		val uniffiInteractor by lazy { UniffiInteractor(dbname) }
-	}
 
 	class ActivityScope(val activity: FragmentActivity) {
 		val seedRepository: SeedRepository = SeedRepository(seedStorage,

--- a/android/src/main/java/io/parity/signer/domain/Navigation.kt
+++ b/android/src/main/java/io/parity/signer/domain/Navigation.kt
@@ -13,7 +13,7 @@ import io.parity.signer.uniffi.*
 
 
 @Deprecated("obsolete, for backwards compatibility, use SignerNavigator class")
-fun MainFlowViewModel.navigate(
+fun SignerMainViewModel.navigate(
 	button: Action,
 	details: String = "",
 	seedPhrase: String = ""
@@ -42,7 +42,7 @@ interface Navigator {
  * Class to navigate within rust state-machine area. It is one (big) part of compose-based navigation.
  * This class have nothing to do with composa-based navigation.
  */
-class SignerNavigator(private val singleton: MainFlowViewModel) : Navigator {
+class SignerNavigator(private val singleton: SignerMainViewModel) : Navigator {
 
 	override fun navigate(action: Action, details: String, seedPhrase: String) {
 		if (singleton.localNavAction.value != LocalNavAction.None) {

--- a/android/src/main/java/io/parity/signer/domain/SeedExtensions.kt
+++ b/android/src/main/java/io/parity/signer/domain/SeedExtensions.kt
@@ -4,7 +4,7 @@ import io.parity.signer.dependencygraph.ServiceLocator
 import io.parity.signer.domain.storage.getSeed
 
 
-suspend fun MainFlowViewModel.getSeedPhraseForBackup(seedName: String,
+suspend fun SignerMainViewModel.getSeedPhraseForBackup(seedName: String,
 ): String? {
 	return when (ServiceLocator.authentication.authenticate(activity)) {
 		AuthResult.AuthSuccess -> {

--- a/android/src/main/java/io/parity/signer/domain/SignerMainViewModel.kt
+++ b/android/src/main/java/io/parity/signer/domain/SignerMainViewModel.kt
@@ -16,7 +16,7 @@ import org.json.JSONObject
 
 
 @SuppressLint("StaticFieldLeak")
-class MainFlowViewModel(
+class SignerMainViewModel(
 	// todo migrate to use dependencies to DI rather than expecting them here
 	val context: Context,
 	val activity: FragmentActivity,
@@ -88,7 +88,8 @@ class MainFlowViewModel(
 	private fun totalRefreshDbExist() {
 		val allNames = seedStorage.getSeedNames()
 		initNavigation(context.getDbNameFromContext(), allNames.toList())
-		networkExposedStateKeeper.updateAlertState()
+		ServiceLocator.uniffiInteractor.wasRustInitialized.value = true
+		networkExposedStateKeeper.updateAlertStateFromHistory()
 		navigator.navigate(Action.START)
 	}
 
@@ -140,7 +141,7 @@ class MainFlowViewModel(
 @Suppress("UNCHECKED_CAST")
 class MainFlowViewModelFactory(private val appContext: Context, private val activity: FragmentActivity) : ViewModelProvider.Factory {
 	override fun <T : ViewModel> create(modelClass: Class<T>): T {
-		return MainFlowViewModel(appContext, activity) as T
+		return SignerMainViewModel(appContext, activity) as T
 	}
 }
 

--- a/android/src/main/java/io/parity/signer/domain/storage/SeedStorageOld.kt
+++ b/android/src/main/java/io/parity/signer/domain/storage/SeedStorageOld.kt
@@ -4,7 +4,7 @@ import android.util.Log
 import android.widget.Toast
 import androidx.lifecycle.viewModelScope
 import io.parity.signer.dependencygraph.ServiceLocator
-import io.parity.signer.domain.MainFlowViewModel
+import io.parity.signer.domain.SignerMainViewModel
 import io.parity.signer.uniffi.Action
 import io.parity.signer.uniffi.updateSeedNames
 import kotlinx.coroutines.*
@@ -15,7 +15,7 @@ import kotlinx.coroutines.*
  * authentication.authenticate(activity) {refreshSeedNames()}
  * which is somewhat asynchronous
  */
-internal fun MainFlowViewModel.tellRustSeedNames() {
+internal fun SignerMainViewModel.tellRustSeedNames() {
 	val allNames = seedStorage.getSeedNames()
 	updateSeedNames(allNames.toList())
 }
@@ -26,7 +26,7 @@ internal fun MainFlowViewModel.tellRustSeedNames() {
  * @param createRoots is fake and should always be true. It's added for educational reasons
  */
 @Deprecated("Use SeedRepository directly")
-fun MainFlowViewModel.addSeed(
+fun SignerMainViewModel.addSeed(
 	seedName: String,
 	seedPhrase: String,
 ) {
@@ -45,7 +45,7 @@ fun MainFlowViewModel.addSeed(
  * Fetch seed from strongbox; must be in unlocked scope
  */
 @Deprecated("Use SeedStorage or better SeedRepository")
-internal fun MainFlowViewModel.getSeed(
+internal fun SignerMainViewModel.getSeed(
 	seedName: String,
 	backup: Boolean = false
 ): String {
@@ -66,7 +66,7 @@ internal fun MainFlowViewModel.getSeed(
  * 3. Calls rust remove seed logic
  */
 @Deprecated("Use SeedStorage or better SeedRepository")
-fun MainFlowViewModel.removeSeed(seedName: String) {
+fun SignerMainViewModel.removeSeed(seedName: String) {
 	ServiceLocator.authentication.authenticate(activity) {
 		try {
 			seedStorage.removeSeed(seedName)

--- a/android/src/main/java/io/parity/signer/domain/storage/TransactionOld.kt
+++ b/android/src/main/java/io/parity/signer/domain/storage/TransactionOld.kt
@@ -1,11 +1,11 @@
 package io.parity.signer.domain.storage
 
 import io.parity.signer.dependencygraph.ServiceLocator
-import io.parity.signer.domain.MainFlowViewModel
+import io.parity.signer.domain.SignerMainViewModel
 import io.parity.signer.domain.navigate
 import io.parity.signer.uniffi.Action
 
-fun MainFlowViewModel.signSufficientCrypto(seedName: String, addressKey: String) {
+fun SignerMainViewModel.signSufficientCrypto(seedName: String, addressKey: String) {
 	ServiceLocator.authentication.authenticate(activity) {
 		val seedPhrase = getSeed(
 			seedName

--- a/android/src/main/java/io/parity/signer/screens/createderivation/DerivationCreateViewModel.kt
+++ b/android/src/main/java/io/parity/signer/screens/createderivation/DerivationCreateViewModel.kt
@@ -21,7 +21,7 @@ import kotlinx.coroutines.runBlocking
 
 class DerivationCreateViewModel : ViewModel() {
 
-	private val uniffiInteractor = ServiceLocator.backendScope.uniffiInteractor
+	private val uniffiInteractor = ServiceLocator.uniffiInteractor
 	private val seedRepository: SeedRepository by lazy { ServiceLocator.activityScope!!.seedRepository }
 	private val pathAnalyzer: DerivationPathAnalyzer = DerivationPathAnalyzer()
 

--- a/android/src/main/java/io/parity/signer/screens/keysetdetails/KeySetDetailsNavSubgraph.kt
+++ b/android/src/main/java/io/parity/signer/screens/keysetdetails/KeySetDetailsNavSubgraph.kt
@@ -16,10 +16,10 @@ import io.parity.signer.screens.keysetdetails.export.KeySetDetailsExportScreenFu
 
 @Composable
 fun KeySetDetailsNavSubgraph(
-	model: KeySetDetailsModel,
-	rootNavigator: Navigator,
-	networkState: State<NetworkState?>, //for shield icon
-	singleton: MainFlowViewModel,
+    model: KeySetDetailsModel,
+    rootNavigator: Navigator,
+    networkState: State<NetworkState?>, //for shield icon
+    singleton: SignerMainViewModel,
 ) {
 	val navController = rememberNavController()
 	NavHost(

--- a/android/src/main/java/io/parity/signer/screens/keysetdetails/export/KeySetDetailsExportService.kt
+++ b/android/src/main/java/io/parity/signer/screens/keysetdetails/export/KeySetDetailsExportService.kt
@@ -12,7 +12,7 @@ import io.parity.signer.domain.getData
 class KeySetDetailsExportService :
 	AnimatedQrKeysProvider<KeySetDetailsExportService.GetQrCodesListRequest> {
 	private val uniffiInteractor: UniffiInteractor =
-		ServiceLocator.backendScope.uniffiInteractor
+		ServiceLocator.uniffiInteractor
 
 	override suspend fun getQrCodesList(input: GetQrCodesListRequest): AnimatedQrImages? {
 		return uniffiInteractor.exportSeedWithKeys(

--- a/android/src/main/java/io/parity/signer/screens/keysets/export/KeySetsExportService.kt
+++ b/android/src/main/java/io/parity/signer/screens/keysets/export/KeySetsExportService.kt
@@ -11,7 +11,7 @@ import io.parity.signer.domain.getData
 
 class KeySetsExportService : AnimatedQrKeysProvider<List<KeySetModel>> {
 	private val uniffiInteractor: UniffiInteractor =
-		ServiceLocator.backendScope.uniffiInteractor
+		ServiceLocator.uniffiInteractor
 
 	override suspend fun getQrCodesList(input: List<KeySetModel>): AnimatedQrImages? {
 		return uniffiInteractor.exportSeedKeyInfos(input.map { it.seedName })

--- a/android/src/main/java/io/parity/signer/screens/scan/ScanViewModel.kt
+++ b/android/src/main/java/io/parity/signer/screens/scan/ScanViewModel.kt
@@ -27,7 +27,7 @@ private const val TAG = "ScanViewModelTag"
  */
 class ScanViewModel : ViewModel() {
 
-	private val uniffiInteractor = ServiceLocator.backendScope.uniffiInteractor
+	private val uniffiInteractor = ServiceLocator.uniffiInteractor
 	private val seedRepository: SeedRepository by lazy { ServiceLocator.activityScope!!.seedRepository }
 	private val importKeysService: ImportDerivedKeysRepository by lazy {
 		ImportDerivedKeysRepository(

--- a/android/src/main/java/io/parity/signer/screens/scan/bananasplit/BananaSplitViewModel.kt
+++ b/android/src/main/java/io/parity/signer/screens/scan/bananasplit/BananaSplitViewModel.kt
@@ -35,7 +35,7 @@ class BananaSplitViewModel() : ViewModel() {
 	val wrongPasswordCurrent = _wrongPasswordCurrent.asStateFlow()
 
 
-	private val uniffiInteractor = ServiceLocator.backendScope.uniffiInteractor
+	private val uniffiInteractor = ServiceLocator.uniffiInteractor
 	private val seedRepository: SeedRepository by lazy { ServiceLocator.activityScope!!.seedRepository }
 	private lateinit var qrCodeData: List<String>
 	private var invalidPasswordAttempts = 0

--- a/android/src/main/java/io/parity/signer/screens/scan/camera/ScanScreen.kt
+++ b/android/src/main/java/io/parity/signer/screens/scan/camera/ScanScreen.kt
@@ -20,8 +20,8 @@ import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.rememberPermissionState
 import com.google.accompanist.permissions.shouldShowRationale
 import io.parity.signer.R
-import io.parity.signer.domain.KeepScreenOn
 import io.parity.signer.domain.Callback
+import io.parity.signer.domain.KeepScreenOn
 import io.parity.signer.screens.scan.camera.*
 import io.parity.signer.ui.theme.SignerNewTheme
 import io.parity.signer.ui.theme.SignerTypeface

--- a/android/src/main/java/io/parity/signer/screens/scan/importderivations/Extensions.kt
+++ b/android/src/main/java/io/parity/signer/screens/scan/importderivations/Extensions.kt
@@ -1,6 +1,5 @@
 package io.parity.signer.screens.scan.importderivations
 
-import android.util.Log
 import io.parity.signer.screens.scan.transaction.sortedValueCards
 import io.parity.signer.uniffi.*
 
@@ -9,7 +8,6 @@ import io.parity.signer.uniffi.*
 // hence we need this support function to find out what is the proper UI error to show
 // if there are no importable keys left
 fun List<MTransaction>.dominantImportError(): DerivedKeyError? {
-	Log.e("LOG", "checking dominant error, has keys is ${hasImportableKeys()}")
 	if (hasImportableKeys()) return null
 
 	val allErrors: List<DerivedKeyError> = flatMap { it.allImportDerivedKeys() }
@@ -18,13 +16,11 @@ fun List<MTransaction>.dominantImportError(): DerivedKeyError? {
 		.filterIsInstance<DerivedKeyStatus.Invalid>()
 		.flatMap { it.errors }
 
-	Log.e("LOG", "checking dominant error, all errors is ${allErrors}")
 	val mostCommonError = allErrors
 		.groupBy { it }
 		.maxByOrNull { entry -> entry.value.size }
 		?.key
 
-	Log.e("LOG", "most common error is ${mostCommonError}")
 	return mostCommonError
 }
 

--- a/android/src/main/java/io/parity/signer/screens/scan/importderivations/Extensions.kt
+++ b/android/src/main/java/io/parity/signer/screens/scan/importderivations/Extensions.kt
@@ -1,5 +1,6 @@
 package io.parity.signer.screens.scan.importderivations
 
+import android.util.Log
 import io.parity.signer.screens.scan.transaction.sortedValueCards
 import io.parity.signer.uniffi.*
 
@@ -8,6 +9,7 @@ import io.parity.signer.uniffi.*
 // hence we need this support function to find out what is the proper UI error to show
 // if there are no importable keys left
 fun List<MTransaction>.dominantImportError(): DerivedKeyError? {
+	Log.e("LOG", "checking dominant error, has keys is ${hasImportableKeys()}")
 	if (hasImportableKeys()) return null
 
 	val allErrors: List<DerivedKeyError> = flatMap { it.allImportDerivedKeys() }
@@ -16,11 +18,13 @@ fun List<MTransaction>.dominantImportError(): DerivedKeyError? {
 		.filterIsInstance<DerivedKeyStatus.Invalid>()
 		.flatMap { it.errors }
 
+	Log.e("LOG", "checking dominant error, all errors is ${allErrors}")
 	val mostCommonError = allErrors
 		.groupBy { it }
 		.maxByOrNull { entry -> entry.value.size }
 		?.key
 
+	Log.e("LOG", "most common error is ${mostCommonError}")
 	return mostCommonError
 }
 

--- a/android/src/main/java/io/parity/signer/ui/MainScreensAppFlow.kt
+++ b/android/src/main/java/io/parity/signer/ui/MainScreensAppFlow.kt
@@ -6,7 +6,6 @@ import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
-import androidx.compose.runtime.*
 import androidx.compose.ui.platform.LocalContext
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -15,7 +14,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import io.parity.signer.components.panels.BottomBar
 import io.parity.signer.components.panels.TopBar
-import io.parity.signer.domain.MainFlowViewModel
+import io.parity.signer.domain.SignerMainViewModel
 import io.parity.signer.domain.MainFlowViewModelFactory
 import io.parity.signer.domain.NavigationMigrations
 import io.parity.signer.domain.findActivity
@@ -26,34 +25,34 @@ import io.parity.signer.ui.rustnavigationselectors.*
 
 fun NavGraphBuilder.mainSignerAppFlow(globalNavController: NavHostController) {
 	composable(route = MainGraphRoutes.mainScreenRoute) {
-		val mainFlowViewModel: MainFlowViewModel = viewModel(
+		val signerMainViewModel: SignerMainViewModel = viewModel(
 			factory = MainFlowViewModelFactory(
 				appContext = LocalContext.current.applicationContext,
 				activity = LocalContext.current.findActivity() as FragmentActivity
 			)
 		)
 
-		val authenticated = mainFlowViewModel.authenticated.collectAsState()
+		val authenticated = signerMainViewModel.authenticated.collectAsState()
 
 		BackHandler {
-			mainFlowViewModel.navigator.backAction()
+			signerMainViewModel.navigator.backAction()
 		}
 
 		if (authenticated.value) {
-			SignerMainSubgraph(mainFlowViewModel)
+			SignerMainSubgraph(signerMainViewModel)
 		} else {
-			UnlockAppAuthScreen { mainFlowViewModel.totalRefresh() }
+			UnlockAppAuthScreen { signerMainViewModel.totalRefresh() }
 		}
 	}
 }
 
 
 @Composable
-fun SignerMainSubgraph(mainFlowViewModel: MainFlowViewModel) {
+fun SignerMainSubgraph(signerMainViewModel: SignerMainViewModel) {
 
-	val actionResultState = mainFlowViewModel.actionResult.collectAsState()
-	val shieldAlert = mainFlowViewModel.networkState.collectAsState()
-	val localNavAction = mainFlowViewModel.localNavAction.collectAsState()
+	val actionResultState = signerMainViewModel.actionResult.collectAsState()
+	val shieldAlert = signerMainViewModel.networkState.collectAsState()
+	val localNavAction = signerMainViewModel.localNavAction.collectAsState()
 
 	val actionResult = actionResultState.value
 
@@ -75,7 +74,7 @@ fun SignerMainSubgraph(mainFlowViewModel: MainFlowViewModel) {
 						)
 					) {
 						TopBar(
-							mainFlowViewModel = mainFlowViewModel,
+							signerMainViewModel = signerMainViewModel,
 							actionResult = actionResult,
 							networkState = shieldAlert,
 						)
@@ -88,7 +87,7 @@ fun SignerMainSubgraph(mainFlowViewModel: MainFlowViewModel) {
 						)
 						&& actionResult.footer
 					) {
-						BottomBar(mainFlowViewModel = mainFlowViewModel)
+						BottomBar(signerMainViewModel = signerMainViewModel)
 					}
 				},
 			) { innerPadding ->
@@ -96,15 +95,15 @@ fun SignerMainSubgraph(mainFlowViewModel: MainFlowViewModel) {
 					ScreenSelector(
 						screenData = actionResult.screenData,
 						networkState = shieldAlert,
-						navigate = mainFlowViewModel.navigator::navigate,
-						mainFlowViewModel = mainFlowViewModel
+						navigate = signerMainViewModel.navigator::navigate,
+						signerMainViewModel = signerMainViewModel
 					)
 					ModalSelector(
 						modalData = actionResult.modalData,
 						localNavAction = localNavAction.value,
 						networkState = shieldAlert,
-						navigate = mainFlowViewModel.navigator::navigate,
-						mainFlowViewModel = mainFlowViewModel,
+						navigate = signerMainViewModel.navigator::navigate,
+						signerMainViewModel = signerMainViewModel,
 					)
 				}
 			}
@@ -118,20 +117,20 @@ fun SignerMainSubgraph(mainFlowViewModel: MainFlowViewModel) {
 					screenData = actionResult.screenData,
 					localNavAction = localNavAction.value,
 					networkState = shieldAlert,
-					mainFlowViewModel = mainFlowViewModel
+					signerMainViewModel = signerMainViewModel
 				)
 				BottomSheetSelector(
 					modalData = actionResult.modalData,
 					localNavAction = localNavAction.value,
 					networkState = shieldAlert,
-					mainFlowViewModel = mainFlowViewModel,
-					navigator = mainFlowViewModel.navigator,
+					signerMainViewModel = signerMainViewModel,
+					navigator = signerMainViewModel.navigator,
 				)
 				AlertSelector(
 					alert = actionResult.alertData,
 					networkState = shieldAlert,
-					navigate = mainFlowViewModel.navigator::navigate,
-					acknowledgeWarning = mainFlowViewModel::acknowledgeWarning
+					navigate = signerMainViewModel.navigator::navigate,
+					acknowledgeWarning = signerMainViewModel::acknowledgeWarning
 				)
 			}
 		}

--- a/android/src/main/java/io/parity/signer/ui/rustnavigationselectors/ScreenSelectorsNew.kt
+++ b/android/src/main/java/io/parity/signer/ui/rustnavigationselectors/ScreenSelectorsNew.kt
@@ -41,14 +41,14 @@ import io.parity.signer.uniffi.keysBySeedName
 
 @Composable
 fun CombinedScreensSelector(
-	screenData: ScreenData,
-	localNavAction: LocalNavAction?,
-	networkState: State<NetworkState?>,
-	mainFlowViewModel: MainFlowViewModel
+    screenData: ScreenData,
+    localNavAction: LocalNavAction?,
+    networkState: State<NetworkState?>,
+    signerMainViewModel: SignerMainViewModel
 ) {
-	val rootNavigator = mainFlowViewModel.navigator
+	val rootNavigator = signerMainViewModel.navigator
 	val seedNames =
-		mainFlowViewModel.seedStorage.lastKnownSeedNames.collectAsState()
+		signerMainViewModel.seedStorage.lastKnownSeedNames.collectAsState()
 
 	when (screenData) {
 		is ScreenData.SeedSelector -> {
@@ -64,7 +64,7 @@ fun CombinedScreensSelector(
 				model = keys.toKeySetDetailsModel(),
 				rootNavigator = rootNavigator,
 				networkState = networkState,
-				singleton = mainFlowViewModel,
+				singleton = signerMainViewModel,
 			)
 		}
 		is ScreenData.KeyDetails ->
@@ -91,9 +91,9 @@ fun CombinedScreensSelector(
 			Box(modifier = Modifier.statusBarsPadding()) {
 				SettingsScreen(
 					rootNavigator = rootNavigator,
-					isStrongBoxProtected = mainFlowViewModel.seedStorage.isStrongBoxProtected,
-					appVersion = mainFlowViewModel.getAppVersion(),
-					wipeToFactory = mainFlowViewModel::wipeToFactory,
+					isStrongBoxProtected = signerMainViewModel.seedStorage.isStrongBoxProtected,
+					appVersion = signerMainViewModel.getAppVersion(),
+					wipeToFactory = signerMainViewModel::wipeToFactory,
 					networkState = networkState
 				)
 			}
@@ -136,11 +136,11 @@ fun CombinedScreensSelector(
 
 @Composable
 fun BottomSheetSelector(
-	modalData: ModalData?,
-	localNavAction: LocalNavAction?,
-	networkState: State<NetworkState?>,
-	mainFlowViewModel: MainFlowViewModel,
-	navigator: Navigator,
+    modalData: ModalData?,
+    localNavAction: LocalNavAction?,
+    networkState: State<NetworkState?>,
+    signerMainViewModel: SignerMainViewModel,
+    navigator: Navigator,
 ) {
 	SignerNewTheme {
 
@@ -165,7 +165,7 @@ fun BottomSheetSelector(
 					}) {
 						KeyDetailsMenuAction(
 							navigator = navigator,
-							keyDetails = mainFlowViewModel.lastOpenedKeyDetails
+							keyDetails = signerMainViewModel.lastOpenedKeyDetails
 						)
 					}
 				is ModalData.NewSeedMenu ->
@@ -175,14 +175,14 @@ fun BottomSheetSelector(
 					}) {
 						NewSeedMenu(
 							networkState = networkState,
-							navigator = mainFlowViewModel.navigator,
+							navigator = signerMainViewModel.navigator,
 						)
 					}
 				is ModalData.NewSeedBackup -> {
 					NewKeySetBackupScreenFull(
 						model = modalData.f.toNewSeedBackupModel(),
 						onBack = { navigator.backAction() },
-						onCreateKeySet = mainFlowViewModel::addSeed
+						onCreateKeySet = signerMainViewModel::addSeed
 					)
 				}
 				is ModalData.LogRight ->
@@ -190,7 +190,7 @@ fun BottomSheetSelector(
 						navigator.backAction()
 					}) {
 						LogsMenu(
-							navigator = mainFlowViewModel.navigator,
+							navigator = signerMainViewModel.navigator,
 						)
 					}
 				is ModalData.EnterPassword ->
@@ -210,7 +210,7 @@ fun BottomSheetSelector(
 					}
 				is ModalData.SignatureReady -> {}//part of camera flow now
 				//old design
-				is ModalData.LogComment -> LogComment(mainFlowViewModel = mainFlowViewModel)
+				is ModalData.LogComment -> LogComment(signerMainViewModel = signerMainViewModel)
 				else -> {}
 			}
 		}

--- a/android/src/main/java/io/parity/signer/ui/rustnavigationselectors/SignerSelectorsLegacy.kt
+++ b/android/src/main/java/io/parity/signer/ui/rustnavigationselectors/SignerSelectorsLegacy.kt
@@ -26,12 +26,12 @@ fun ScreenSelector(
     screenData: ScreenData,
     networkState: State<NetworkState?>,
     navigate: (Action, String, String) -> Unit,
-    mainFlowViewModel: MainFlowViewModel
+    signerMainViewModel: SignerMainViewModel
 ) {
 	val button2: (Action, String) -> Unit =
 		{ action, details -> navigate(action, details, "") }
 	val seedNames =
-		mainFlowViewModel.seedStorage.lastKnownSeedNames.collectAsState()
+		signerMainViewModel.seedStorage.lastKnownSeedNames.collectAsState()
 
 	when (screenData) {
 		is ScreenData.DeriveKey -> {} // migrated
@@ -58,13 +58,13 @@ fun ScreenSelector(
 		is ScreenData.NewSeed -> {} // new selector
 		is ScreenData.RecoverSeedName -> RecoverSeedName(
 			screenData.f,
-			mainFlowViewModel::navigate,
+			signerMainViewModel::navigate,
 			seedNames.value
 		)
 		is ScreenData.RecoverSeedPhrase -> RecoverSeedPhrase(
 			recoverSeedPhrase = screenData.f,
-			button = mainFlowViewModel::navigate,
-			addSeed = mainFlowViewModel::addSeed
+			button = signerMainViewModel::navigate,
+			addSeed = signerMainViewModel::addSeed
 		)
 		ScreenData.Scan -> {} //in new selector
 		is ScreenData.Transaction -> {} //in new selector
@@ -76,11 +76,11 @@ fun ScreenSelector(
 		is ScreenData.Settings -> {} //new selector
 		is ScreenData.SignSufficientCrypto -> SignSufficientCrypto(
 			screenData.f,
-			mainFlowViewModel::signSufficientCrypto
+			signerMainViewModel::signSufficientCrypto
 		)
 		is ScreenData.VVerifier -> VerifierScreen(
 			screenData.f,
-			mainFlowViewModel::wipeToJailbreak
+			signerMainViewModel::wipeToJailbreak
 		)
 	}
 }
@@ -91,7 +91,7 @@ fun ModalSelector(
     localNavAction: LocalNavAction?,
     networkState: State<NetworkState?>,
     navigate: (Action, String, String) -> Unit,
-    mainFlowViewModel: MainFlowViewModel
+    signerMainViewModel: SignerMainViewModel
 ) {
 	val button2: (Action, String) -> Unit =
 		{ action, details -> navigate(action, details, "") }
@@ -121,10 +121,10 @@ fun ModalSelector(
 			is ModalData.EnterPassword -> {} //in new selector
 			is ModalData.LogRight -> {} //migrated to bottom sheet
 			is ModalData.NetworkDetailsMenu -> NetworkDetailsMenu(
-				mainFlowViewModel = mainFlowViewModel
+				signerMainViewModel = signerMainViewModel
 			)
 			is ModalData.ManageMetadata -> {
-				ManageMetadata(modalData.f, mainFlowViewModel = mainFlowViewModel)
+				ManageMetadata(modalData.f, signerMainViewModel = signerMainViewModel)
 			}
 			is ModalData.SufficientCryptoReady -> SufficientCryptoReady(
 				modalData.f,
@@ -132,13 +132,13 @@ fun ModalSelector(
 			is ModalData.KeyDetailsAction -> {} //migrated to bottom sheet
 			is ModalData.TypesInfo -> TypesInfo(
 				modalData.f,
-				mainFlowViewModel = mainFlowViewModel
+				signerMainViewModel = signerMainViewModel
 			)
 			is ModalData.NewSeedBackup -> {}//moved to new selector
 			is ModalData.LogComment -> {} //moved to new sheet
 			is ModalData.SelectSeed -> {
 				submitErrorState("This is part of refactored screen and not shown separately")
-				SelectSeed(modalData.f, mainFlowViewModel = mainFlowViewModel)
+				SelectSeed(modalData.f, signerMainViewModel = signerMainViewModel)
 			}
 			null -> {}
 		}


### PR DESCRIPTION
 On startup avoid telling rust about exposed airgap before rust navigation is initizlied, suspent till that happens.
 
 This happens when app starting with airplane off.
 
And main viewmodel renamed as previous name probably misleading.