### PR TITLE
feat: ios: new empty state on key set details and updated spacing

### DIFF
--- a/ios/NativeSigner/Resources/en.lproj/Localizable.strings
+++ b/ios/NativeSigner/Resources/en.lproj/Localizable.strings
@@ -278,6 +278,9 @@
 "AddKeySet.Button.Recover" = "Recover Key Set";
 
 "KeyDetails.Label.Derived" = "Derived keys";
+"KeyDetails.Label.EmptyState.Header" = "Key Set Don't Have Any Derived Keys";
+"KeyDetails.Label.EmptyState.Action" = "Create Derived Key";
+
 "KeyDetails.Action.Create" = "Create Derived key";
 "KeyDetails.Overlay.Label.Title" = "%@ %@ selected";
 "KeyDetails.Overlay.Label.Key.Single" = "key";

--- a/ios/NativeSigner/Screens/KeyDetails/Views/KeyDetails+ViewModel.swift
+++ b/ios/NativeSigner/Screens/KeyDetails/Views/KeyDetails+ViewModel.swift
@@ -8,6 +8,11 @@
 import Foundation
 
 extension KeyDetailsView {
+    enum ViewState {
+        case emptyState
+        case list
+    }
+
     final class ViewModel: ObservableObject {
         let keyDetailsService: KeyDetailsService
         private let networksService: GetAllNetworksService
@@ -39,6 +44,7 @@ extension KeyDetailsView {
         // Error handling
         @Published var isPresentingError: Bool = false
         @Published var presentableError: ErrorBottomModalViewModel = .noNetworksAvailable()
+        @Published var viewState: ViewState = .list
 
         /// Name of seed to be removed with `Remove Seed` action
         var removeSeed: String = ""
@@ -234,6 +240,7 @@ private extension KeyDetailsView.ViewModel {
                     )
                 )
             }
+        viewState = derivedKeys.isEmpty ? .emptyState : .list
     }
 
     func refreshKeySummary() {

--- a/ios/NativeSigner/Screens/KeyDetails/Views/KeyDetailsView.swift
+++ b/ios/NativeSigner/Screens/KeyDetails/Views/KeyDetailsView.swift
@@ -230,7 +230,7 @@ struct KeyDetailsView: View {
             )
             .padding(Spacing.large)
         }
-        .containerBackground(CornerRadius.large, state: .error)
+        .containerBackground(CornerRadius.large, state: .actionableInfo)
         .padding(.horizontal, Spacing.medium)
     }
 }

--- a/ios/NativeSigner/Screens/KeyDetails/Views/KeyDetailsView.swift
+++ b/ios/NativeSigner/Screens/KeyDetails/Views/KeyDetailsView.swift
@@ -30,28 +30,37 @@ struct KeyDetailsView: View {
                         ]
                     )
                 )
-                ScrollView(showsIndicators: false) {
-                    // Main key cell
-                    rootKeyHeader()
-                    // Derived Keys header
-                    HStack {
-                        Localizable.KeyDetails.Label.derived.text
-                            .font(PrimaryFont.bodyM.font)
-                        Spacer().frame(maxWidth: .infinity)
-                        Asset.switches.swiftUIImage
-                            .foregroundColor(
-                                viewModel.isFilteringActive ? Asset.accentPink300.swiftUIColor : Asset
-                                    .textAndIconsTertiary.swiftUIColor
-                            )
-                            .frame(width: Heights.actionSheetButton)
-                            .onTapGesture {
-                                viewModel.onNetworkSelectionTap()
-                            }
+                switch viewModel.viewState {
+                case .list:
+                    ScrollView(showsIndicators: false) {
+                        // Main key cell
+                        rootKeyHeader()
+                        // Derived Keys header
+                        HStack {
+                            Localizable.KeyDetails.Label.derived.text
+                                .font(PrimaryFont.bodyM.font)
+                            Spacer().frame(maxWidth: .infinity)
+                            Asset.switches.swiftUIImage
+                                .foregroundColor(
+                                    viewModel.isFilteringActive ? Asset.accentPink300.swiftUIColor : Asset
+                                        .textAndIconsTertiary.swiftUIColor
+                                )
+                                .frame(width: Heights.actionSheetButton)
+                                .onTapGesture {
+                                    viewModel.onNetworkSelectionTap()
+                                }
+                        }
+                        .foregroundColor(Asset.textAndIconsTertiary.swiftUIColor)
+                        .padding(.horizontal, Spacing.large)
+                        .padding(.top, Spacing.medium)
+                        // List
+                        mainList
                     }
-                    .foregroundColor(Asset.textAndIconsTertiary.swiftUIColor)
-                    .padding(.horizontal, Spacing.large)
-                    // List
-                    mainList
+                case .emptyState:
+                    rootKeyHeader()
+                    Spacer()
+                    emptyState()
+                    Spacer()
                 }
             }
             .background(Asset.backgroundPrimary.swiftUIColor)
@@ -205,6 +214,25 @@ struct KeyDetailsView: View {
             EmptyView()
         }
     }
+
+    @ViewBuilder
+    func emptyState() -> some View {
+        VStack(spacing: 0) {
+            Localizable.KeyDetails.Label.EmptyState.header.text
+                .font(PrimaryFont.titleM.font)
+                .foregroundColor(Asset.textAndIconsPrimary.swiftUIColor)
+                .padding(.top, Spacing.large)
+                .padding(.horizontal, Spacing.componentSpacer)
+            PrimaryButton(
+                action: viewModel.onCreateDerivedKeyTap,
+                text: Localizable.KeyDetails.Label.EmptyState.action.key,
+                style: .secondary()
+            )
+            .padding(Spacing.large)
+        }
+        .containerBackground(CornerRadius.large, state: .error)
+        .padding(.horizontal, Spacing.medium)
+    }
 }
 
 private struct KeySummaryView: View {
@@ -216,6 +244,8 @@ private struct KeySummaryView: View {
             Text(viewModel.keyName)
                 .foregroundColor(Asset.textAndIconsPrimary.swiftUIColor)
                 .font(PrimaryFont.titleXL.font)
+                .padding(.top, Spacing.medium)
+                .padding(.bottom, Spacing.extraSmall)
             HStack {
                 Text(viewModel.base58.truncateMiddle())
                     .foregroundColor(Asset.textAndIconsTertiary.swiftUIColor)
@@ -225,7 +255,6 @@ private struct KeySummaryView: View {
                     .foregroundColor(Asset.textAndIconsSecondary.swiftUIColor)
             }
         }
-        .padding(.bottom, Spacing.medium)
         .padding(.horizontal, Spacing.large)
     }
 }


### PR DESCRIPTION
## Purpose
Empty state for Key Set Details after moving add button to navigation bar

## Screenshots

| Light | Dark |
|-|-|
|<img src="https://user-images.githubusercontent.com/1955364/217444000-fd5cc3c5-d8b8-4a42-8713-d3f65a32007a.gif" width="320px">|<img src="https://user-images.githubusercontent.com/1955364/217444008-bb076103-a79e-4516-928d-4d957e603308.gif" width="320px">|
