### PR TITLE
feat: ios: update recover seed screens

### DIFF
--- a/ios/PolkadotVault/Core/Navigation/NavigationCoordinator.swift
+++ b/ios/PolkadotVault/Core/Navigation/NavigationCoordinator.swift
@@ -141,7 +141,9 @@ private extension NavigationCoordinator {
              .manageNetworks,
              .nNetworkDetails,
              .deriveKey,
-             .newSeed:
+             .newSeed,
+             .recoverSeedName,
+             .recoverSeedPhrase:
             updatedShouldSkipInjectedViews = true
         default:
             updatedShouldSkipInjectedViews = false

--- a/ios/PolkadotVault/Models/Utils.swift
+++ b/ios/PolkadotVault/Models/Utils.swift
@@ -7,12 +7,6 @@
 
 import Foundation
 
-extension MRecoverSeedPhrase {
-    func draftPhrase() -> String {
-        draft.joined(separator: " ")
-    }
-}
-
 extension Verifier {
     func show() -> String {
         switch v {

--- a/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
+++ b/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
@@ -76,6 +76,7 @@
 "SEED PHRASE" = "Secret Recovery Phrase";
 "RecoverSeedPhrase.Action.Recover" = "Recover Key Set";
 "RecoverSeedPhrase.Label.Title" = "Recover Key Set";
+"RecoverSeedPhrase.Label.Footer" = "Tap \"←\" when textfield is empty to delete last selected seed word";
 
 // Sign Sufficient Crypto
 "Select key for signing" = "Select key for signing";

--- a/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
+++ b/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
@@ -67,12 +67,15 @@
 "TCAuthor.SignedWith" = "Signed with %@";
 
 // Recover seed name
-"DISPLAY NAME" = "DISPLAY NAME";
-"Display name visible only to you" = "Display name visible only to you";
-"Next" = "Next";
+"RecoverSeedName.Label.Title" = "Recover Key Set";
+"RecoverSeedName.Label.Content" = "Enter a name that will help you identify this key set";
+"RecoverSeedName.Label.Footer" = "Key set name visible only to you";
+"RecoverSeedName.Action.Next" = "Next";
 "Seed" = "Seed";
-"seed_name" = "Seed name";
-"SEED PHRASE" = "SEED PHRASE";
+"seed_name" = "Enter Key Set Name";
+"SEED PHRASE" = "Secret Recovery Phrase";
+"RecoverSeedPhrase.Action.Recover" = "Recover Key Set";
+"RecoverSeedPhrase.Label.Title" = "Recover Key Set";
 
 // Sign Sufficient Crypto
 "Select key for signing" = "Select key for signing";

--- a/ios/PolkadotVault/Screens/CreateKey/RecoverSeedName.swift
+++ b/ios/PolkadotVault/Screens/CreateKey/RecoverSeedName.swift
@@ -14,44 +14,62 @@ struct RecoverSeedName: View {
     @EnvironmentObject var navigation: NavigationCoordinator
 
     var body: some View {
-        VStack(alignment: .leading) {
-            Localizable.displayName.text.font(PrimaryFont.labelS.font)
-            ZStack {
-                RoundedRectangle(cornerRadius: 8)
-                    .stroke(Asset.fill12.swiftUIColor)
-                    .frame(height: 39)
-                TextField(Localizable.seed.string, text: $seedName, prompt: Localizable.seedName.text)
-                    .focused($nameFocused)
+        VStack(alignment: .leading, spacing: 0) {
+            NavigationBarView(
+                viewModel: .init(
+                    title: nil,
+                    leftButtons: [.init(
+                        type: .xmark,
+                        action: { navigation.perform(navigation: .init(action: .goBack)) }
+                    )],
+                    rightButtons: [.init(
+                        type: .activeAction(
+                            Localizable.RecoverSeedName.Action.next.key,
+                            .constant(
+                                (seedName.isEmpty) || ServiceLocator.seedsMediator
+                                    .checkSeedCollision(seedName: seedName)
+                            )
+                        ),
+                        action: {
+                            self.nameFocused = false
+                            self.navigation.perform(navigation: .init(action: .goForward, details: seedName))
+                        }
+                    )]
+                )
+            )
+            VStack(alignment: .leading, spacing: 0) {
+                Localizable.RecoverSeedName.Label.title.text
+                    .foregroundColor(Asset.textAndIconsPrimary.swiftUIColor)
+                    .font(PrimaryFont.titleL.font)
+                    .padding(.top, Spacing.extraSmall)
+                Localizable.RecoverSeedName.Label.content.text
                     .foregroundColor(Asset.textAndIconsPrimary.swiftUIColor)
                     .font(PrimaryFont.bodyL.font)
-                    .disableAutocorrection(true)
-                    .keyboardType(.asciiCapable)
+                    .padding(.vertical, Spacing.extraSmall)
+                TextField("", text: $seedName)
                     .submitLabel(.done)
+                    .primaryTextFieldStyle(
+                        Localizable.seedName.string,
+                        text: $seedName
+                    )
+                    .focused($nameFocused)
                     .onSubmit {
                         if !seedName.isEmpty, !ServiceLocator.seedsMediator.checkSeedCollision(seedName: seedName) {
                             navigation.perform(navigation: .init(action: .goForward, details: seedName))
                         }
                     }
-                    .onAppear(perform: {
+                    .onAppear {
                         seedName = content.seedName
                         nameFocused = content.keyboard
-                    })
-                    .padding(.horizontal, 8)
+                    }
+                    .padding(.vertical, Spacing.medium)
+                Localizable.RecoverSeedName.Label.footer.text
+                    .foregroundColor(Asset.textAndIconsTertiary.swiftUIColor)
+                    .font(PrimaryFont.captionM.font)
+                Spacer()
             }
-            Localizable.displayNameVisibleOnlyToYou.text.font(.callout)
-            Spacer()
-            PrimaryButton(
-                action: {
-                    navigation.perform(navigation: .init(action: .goForward, details: seedName))
-                },
-                text: Localizable.next.key,
-                style: .primary(isDisabled: .constant(
-                    (seedName.isEmpty) || ServiceLocator.seedsMediator
-                        .checkSeedCollision(seedName: seedName)
-                ))
-            )
-            Spacer()
-        }.padding()
+            .padding(.horizontal, Spacing.large)
+        }
     }
 }
 

--- a/ios/PolkadotVault/Screens/CreateKey/RecoverSeedPhrase.swift
+++ b/ios/PolkadotVault/Screens/CreateKey/RecoverSeedPhrase.swift
@@ -97,6 +97,9 @@ struct RecoverSeedPhrase: View {
                                 }
                             }
                         }
+                        Localizable.RecoverSeedPhrase.Label.footer.text
+                            .foregroundColor(Asset.textAndIconsTertiary.swiftUIColor)
+                            .font(PrimaryFont.captionM.font)
                         Spacer()
                         HStack {
                             PrimaryButton(

--- a/ios/PolkadotVault/Screens/CreateKey/RecoverSeedPhrase.swift
+++ b/ios/PolkadotVault/Screens/CreateKey/RecoverSeedPhrase.swift
@@ -15,13 +15,35 @@ struct RecoverSeedPhrase: View {
     let content: MRecoverSeedPhrase
 
     var body: some View {
-        ZStack {
+        VStack(alignment: .leading, spacing: 0) {
+            NavigationBarView(
+                viewModel: .init(
+                    title: nil,
+                    leftButtons: [
+                        .init(
+                            type: .arrow,
+                            action: { navigation.perform(navigation: .init(action: .goBack)) }
+                        )
+                    ],
+                    rightButtons: [.init(type: .empty, action: {})]
+                )
+            )
             ScrollView {
-                VStack {
+                VStack(alignment: .leading, spacing: 0) {
+                    Localizable.RecoverSeedPhrase.Label.title.text
+                        .foregroundColor(Asset.textAndIconsPrimary.swiftUIColor)
+                        .font(PrimaryFont.titleL.font)
+                        .padding(.top, Spacing.extraSmall)
                     Text(content.seedName)
-                    VStack(alignment: .leading) {
-                        Localizable.seedPhrase.text.font(PrimaryFont.labelS.font)
-                        VStack {
+                        .foregroundColor(Asset.textAndIconsPrimary.swiftUIColor)
+                        .font(PrimaryFont.bodyL.font)
+                        .padding(.vertical, Spacing.extraSmall)
+                    Localizable.seedPhrase.text
+                        .font(PrimaryFont.labelS.font)
+                        .foregroundColor(Asset.textAndIconsPrimary.swiftUIColor)
+                        .padding(.vertical, Spacing.extraSmall)
+                    VStack(alignment: .leading, spacing: Spacing.small) {
+                        VStack(alignment: .leading, spacing: 0) {
                             Text(
                                 content.draftPhrase()
                             )
@@ -29,40 +51,36 @@ struct RecoverSeedPhrase: View {
                             .fixedSize(horizontal: false, vertical: true)
                             .font(.robotoMonoBold)
                             .foregroundColor(Asset.accentPink300.swiftUIColor)
-                            .padding(12)
-                            Divider().foregroundColor(Asset.fill12.swiftUIColor)
+                            .padding(Spacing.small)
                             HStack {
-                                Text(">").foregroundColor(Asset.textAndIconsTertiary.swiftUIColor)
-                                    .font(.robotoMonoBold)
-                                TextField(Localizable.seed.string, text: $userInput, prompt: Localizable.seedName.text)
-                                    .focused($focus)
-                                    .foregroundColor(Asset.textAndIconsPrimary.swiftUIColor)
-                                    .font(PrimaryFont.bodyL.font)
-                                    .disableAutocorrection(true)
-                                    .textInputAutocapitalization(.never)
-                                    .keyboardType(.asciiCapable)
-                                    .submitLabel(.done)
-                                    .onChange(of: userInput, perform: { word in
-                                        navigation.perform(navigation: .init(action: .textEntry, details: word))
-                                        shadowUserInput = word
-                                    })
-                                    .onSubmit {}
-                                    .onChange(of: shadowUserInput, perform: { _ in
-                                        userInput = " " + content.userInput
-                                    })
-                                    .onChange(of: content, perform: { input in
-                                        userInput = " " + input.userInput
-                                    })
-                                    .onAppear(perform: {
-                                        userInput = " " + content.userInput
-                                        focus = content.keyboard
-                                    })
-                                    .padding(.horizontal, 12)
-                                    .padding(.top, 0)
-                                    .padding(.bottom, 10)
+                                Spacer()
                             }
                         }
-                        .background(RoundedRectangle(cornerRadius: 8).stroke(Asset.fill12.swiftUIColor))
+                        .strokeContainerBackground(state: .actionableInfo)
+                        HStack {
+                            TextField(
+                                Localizable.seedName.string,
+                                text: $userInput
+                            )
+                            .focused($focus)
+                            .submitLabel(.done)
+                            .primaryTextFieldStyle(Localizable.seedName.string, text: $userInput)
+                            .onChange(of: userInput, perform: { word in
+                                navigation.perform(navigation: .init(action: .textEntry, details: word))
+                                shadowUserInput = word
+                            })
+                            .onSubmit {}
+                            .onChange(of: shadowUserInput, perform: { _ in
+                                userInput = " " + content.userInput
+                            })
+                            .onChange(of: content, perform: { input in
+                                userInput = " " + input.userInput
+                            })
+                            .onAppear(perform: {
+                                userInput = " " + content.userInput
+                                focus = content.keyboard
+                            })
+                        }
                         ScrollView(.horizontal, showsIndicators: false) {
                             LazyHStack {
                                 ForEach(content.guessSet, id: \.self) { guess in
@@ -89,15 +107,22 @@ struct RecoverSeedPhrase: View {
                                         navigate: true
                                     )
                                 },
-                                text: Localizable.next.key,
+                                text: Localizable.RecoverSeedPhrase.Action.recover.key,
                                 style: .primary(isDisabled: .constant(content.readySeed == nil))
                             )
                             .padding(Spacing.medium)
                         }
-                    }.padding(.horizontal)
+                    }
                 }
+                .padding(.horizontal, Spacing.large)
             }
         }
+    }
+}
+
+private extension MRecoverSeedPhrase {
+    func draftPhrase() -> String {
+        draft.joined(separator: " ")
     }
 }
 


### PR DESCRIPTION
## Purpose
Visual update to copy and design for Recover Seed Phrase

## Screenshots

| Examples |  |
|-|-|
|<img src="https://user-images.githubusercontent.com/1955364/220306391-1b5eeb55-6ff0-41c0-aece-65e3314e70b0.png" width="320px">|<img src="https://user-images.githubusercontent.com/1955364/220306262-62cd76b7-f622-4e32-954e-bef39e87f451.png" width="320px">|

| Interaction |  |
|-|-|
|<img src="https://user-images.githubusercontent.com/1955364/220306292-5b57e008-4b02-4726-ac82-f6049f90f8c6.gif" width="320px">| <img src="" width="320px">|
