### PR TITLE
feat: ios: connectivity alert when accessing backup from settings list

### DIFF
--- a/ios/PolkadotVault/Screens/Settings/SettingsView.swift
+++ b/ios/PolkadotVault/Screens/Settings/SettingsView.swift
@@ -69,7 +69,10 @@ struct SettingsView: View {
             PrivacyPolicyView(viewModel: .init(isPresented: $viewModel.isPresentingPrivacyPolicy))
         }
         .fullScreenCover(isPresented: $viewModel.isPresentingBackup) {
-            BackupSelectKeyView(viewModel: .init(isPresented: $viewModel.isPresentingBackup))
+            BackupSelectKeyView(viewModel: .init(
+                isPresented: $viewModel.isPresentingBackup,
+                resetWarningAction: .init(alert: $data.alert)
+            ))
         }
     }
 }


### PR DESCRIPTION
## Purpose
This PR aligns connectivity checks between main Backup modal flow and one in settings

## Screenshots

| Connectivity on | Connectivity was on |
|-|-|
|<img src="https://user-images.githubusercontent.com/1955364/220591874-15291a8a-cda7-4d6e-a87c-2edf2bc035ca.gif" width="320px">|<img src="https://user-images.githubusercontent.com/1955364/220591863-c307004c-4ae2-4c56-9256-ffc08916f30a.gif" width="320px">|
