### PR TITLE
fix: ios: png support

### DIFF
--- a/ios/PolkadotVault/Backend/ExportPrivateKeyService.swift
+++ b/ios/PolkadotVault/Backend/ExportPrivateKeyService.swift
@@ -34,7 +34,7 @@ final class ExportPrivateKeyService {
         return ExportPrivateKeyViewModel(
             qrCode: qrCode,
             addressFooter: .init(
-                identicon: keyDetails.address.identicon.svgPayload,
+                identicon: keyDetails.address.identicon,
                 rootKeyName: keyDetails.address.seedName,
                 path: keyDetails.address.path,
                 hasPassword: keyDetails.address.hasPwd,

--- a/ios/PolkadotVault/Cards/HistoryCardExtended.swift
+++ b/ios/PolkadotVault/Cards/HistoryCardExtended.swift
@@ -95,7 +95,7 @@ struct HistoryCardExtended: View {
                 OldTransactionBlock(cards: event.decoded?.asSortedCards() ?? [])
                 Localizable.signedBy.text
                 HStack {
-                    Identicon(identicon: event.signedBy?.address.identicon.svgPayload ?? [])
+                    Identicon(identicon: event.signedBy?.address.identicon ?? .svg(image: []))
                     VStack {
                         Text(value.signedBy.show())
                         Text((event.signedBy?.address.seedName ?? "") + (event.signedBy?.address.path ?? ""))
@@ -111,7 +111,7 @@ struct HistoryCardExtended: View {
                 OldTransactionBlock(cards: event.decoded?.asSortedCards() ?? [])
                 Localizable.signedBy.text
                 HStack {
-                    Identicon(identicon: event.signedBy?.address.identicon.svgPayload ?? [])
+                    Identicon(identicon: event.signedBy?.address.identicon ?? .svg(image: []))
                     VStack {
                         Text(value.signedBy.show())
                         Text((event.signedBy?.address.seedName ?? "") + (event.signedBy?.address.path ?? ""))

--- a/ios/PolkadotVault/Components/Image/Identicon.swift
+++ b/ios/PolkadotVault/Components/Image/Identicon.swift
@@ -11,31 +11,38 @@ import SwiftUI
 /// UI container to display identicon
 /// Can take `[UInt8]`, `Data` or `SignerImage` as input
 struct Identicon: View {
-    let identicon: Data
+    let identicon: SignerImage
     var rowHeight: CGFloat?
 
     init(identicon: SignerImage, rowHeight: CGFloat? = Heights.identiconInCell) {
-        self.identicon = Data(identicon.svgPayload)
-        self.rowHeight = rowHeight
-    }
-
-    init(identicon: Data, rowHeight: CGFloat? = Heights.identiconInCell) {
         self.identicon = identicon
         self.rowHeight = rowHeight
     }
 
     var body: some View {
-        if let rowHeight = rowHeight {
-            SVGView(data: identicon)
-                .frame(width: rowHeight, height: rowHeight)
-                .clipShape(Circle())
-        } else {
-            SVGView(data: identicon)
-                .clipShape(Circle())
+        switch identicon {
+        case let .svg(image: svgImage):
+            if let rowHeight = rowHeight {
+                SVGView(data: Data(svgImage))
+                    .frame(width: rowHeight, height: rowHeight)
+                    .clipShape(Circle())
+            } else {
+                SVGView(data: Data(svgImage))
+                    .clipShape(Circle())
+            }
+        case let .png(image: pngImage):
+            if let rowHeight = rowHeight {
+                Image(uiImage: UIImage(data: Data(pngImage)) ?? UIImage())
+                    .resizable(resizingMode: .stretch)
+                    .frame(width: rowHeight, height: rowHeight)
+                    .clipShape(Circle())
+            } else {
+                Image(uiImage: UIImage(data: Data(pngImage)) ?? UIImage())
+                    .resizable(resizingMode: .stretch)
+                    .clipShape(Circle())
+            }
         }
     }
-
-
 }
 
 #if DEBUG
@@ -47,11 +54,15 @@ struct Identicon: View {
                     identicon: .svg(image: PreviewData.exampleIdenticon)
                 )
                 Identicon(
-                    identicon: try! Data(
-                        contentsOf: Bundle.main.url(
-                            forResource: "identicon_example",
-                            withExtension: "svg"
-                        )!
+                    identicon: .svg(
+                        image: Array(
+                            try! Data(
+                                contentsOf: Bundle.main.url(
+                                    forResource: "identicon_example",
+                                    withExtension: "svg"
+                                )!
+                            )
+                        )
                     ),
                     rowHeight: 200
                 )
@@ -60,11 +71,15 @@ struct Identicon: View {
             .previewLayout(.sizeThatFits)
             VStack(alignment: .center, spacing: 10) {
                 Identicon(
-                    identicon: try! Data(
-                        contentsOf: Bundle.main.url(
-                            forResource: "identicon_example",
-                            withExtension: "svg"
-                        )!
+                    identicon: .svg(
+                        image: Array(
+                            try! Data(
+                                contentsOf: Bundle.main.url(
+                                    forResource: "identicon_example",
+                                    withExtension: "svg"
+                                )!
+                            )
+                        )
                     ),
                     rowHeight: nil
                 )

--- a/ios/PolkadotVault/Components/Image/Identicon.swift
+++ b/ios/PolkadotVault/Components/Image/Identicon.swift
@@ -14,11 +14,6 @@ struct Identicon: View {
     let identicon: Data
     var rowHeight: CGFloat?
 
-    init(identicon: [UInt8], rowHeight: CGFloat? = Heights.identiconInCell) {
-        self.identicon = Data(identicon)
-        self.rowHeight = rowHeight
-    }
-
     init(identicon: SignerImage, rowHeight: CGFloat? = Heights.identiconInCell) {
         self.identicon = Data(identicon.svgPayload)
         self.rowHeight = rowHeight
@@ -39,6 +34,8 @@ struct Identicon: View {
                 .clipShape(Circle())
         }
     }
+
+
 }
 
 #if DEBUG
@@ -46,7 +43,9 @@ struct Identicon: View {
     struct Identicon_Previews: PreviewProvider {
         static var previews: some View {
             VStack(alignment: .center, spacing: 10) {
-                Identicon(identicon: PreviewData.exampleIdenticon)
+                Identicon(
+                    identicon: .svg(image: PreviewData.exampleIdenticon)
+                )
                 Identicon(
                     identicon: try! Data(
                         contentsOf: Bundle.main.url(

--- a/ios/PolkadotVault/Components/Image/NetworkIdenticon.swift
+++ b/ios/PolkadotVault/Components/Image/NetworkIdenticon.swift
@@ -11,26 +11,12 @@ import SwiftUI
 /// UI container to display identicon
 /// Can take `[UInt8]`, `Data` or `SignerImage` as input
 struct NetworkIdenticon: View {
-    let identicon: Data
+    let identicon: SignerImage
     let network: String?
     let background: Color
     let size: CGFloat
 
-    init(identicon: [UInt8], network: String? = nil, background: Color, size: CGFloat = Heights.identiconInCell) {
-        self.identicon = Data(identicon)
-        self.network = network
-        self.background = background
-        self.size = size
-    }
-
     init(identicon: SignerImage, network: String? = nil, background: Color, size: CGFloat = Heights.identiconInCell) {
-        self.identicon = Data(identicon.svgPayload)
-        self.network = network
-        self.background = background
-        self.size = size
-    }
-
-    init(identicon: Data, network: String? = nil, background: Color, size: CGFloat = Heights.identiconInCell) {
         self.identicon = identicon
         self.network = network
         self.background = background
@@ -39,9 +25,7 @@ struct NetworkIdenticon: View {
 
     var body: some View {
         ZStack(alignment: .bottomTrailing) {
-            SVGView(data: identicon)
-                .frame(width: size, height: size)
-                .clipShape(Circle())
+            Identicon(identicon: identicon, rowHeight: size)
             if let network = network, !network.isEmpty {
                 NetworkLogoIcon(
                     networkName: network,
@@ -63,17 +47,21 @@ struct NetworkIdenticon: View {
         static var previews: some View {
             VStack(alignment: .center, spacing: 10) {
                 NetworkIdenticon(
-                    identicon: PreviewData.exampleIdenticon,
+                    identicon: .svg(image: PreviewData.exampleIdenticon),
                     network: "polkadot",
                     background: Asset.backgroundPrimary.swiftUIColor
                 )
                 .frame(width: Heights.identiconInCell, height: Heights.identiconInCell)
                 NetworkIdenticon(
-                    identicon: try! Data(
-                        contentsOf: Bundle.main.url(
-                            forResource: "identicon_example",
-                            withExtension: "svg"
-                        )!
+                    identicon: .svg(
+                        image: Array(
+                            try! Data(
+                                contentsOf: Bundle.main.url(
+                                    forResource: "identicon_example",
+                                    withExtension: "svg"
+                                )!
+                            )
+                        )
                     ),
                     network: "kusama",
                     background: Asset.backgroundPrimary.swiftUIColor
@@ -83,11 +71,15 @@ struct NetworkIdenticon: View {
             .background(Asset.backgroundPrimary.swiftUIColor)
             VStack(alignment: .center, spacing: 10) {
                 NetworkIdenticon(
-                    identicon: try! Data(
-                        contentsOf: Bundle.main.url(
-                            forResource: "identicon_example",
-                            withExtension: "svg"
-                        )!
+                    identicon: .svg(
+                        image: Array(
+                            try! Data(
+                                contentsOf: Bundle.main.url(
+                                    forResource: "identicon_example",
+                                    withExtension: "svg"
+                                )!
+                            )
+                        )
                     ),
                     network: "polkadot",
                     background: Asset.backgroundPrimary.swiftUIColor,

--- a/ios/PolkadotVault/Components/QRCode/QRCodeAddressFooterView.swift
+++ b/ios/PolkadotVault/Components/QRCode/QRCodeAddressFooterView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct QRCodeAddressFooterViewModel: Equatable {
-    let identicon: [UInt8]
+    let identicon: SignerImage
     let rootKeyName: String
     let path: String
     let hasPassword: Bool

--- a/ios/PolkadotVault/Components/Rows/DerivedKeyOverviewRow.swift
+++ b/ios/PolkadotVault/Components/Rows/DerivedKeyOverviewRow.swift
@@ -9,14 +9,14 @@ import SwiftUI
 
 struct DerivedKeyOverviewViewModel: Equatable, Identifiable {
     let id = UUID()
-    let identicon: [UInt8]
+    let identicon: SignerImage
     let path: String
     let hasPassword: Bool
     let network: String
     let networkLogo: String
 
     init(
-        identicon: [UInt8],
+        identicon: SignerImage,
         path: String,
         hasPassword: Bool,
         network: String,
@@ -33,7 +33,7 @@ struct DerivedKeyOverviewViewModel: Equatable, Identifiable {
 extension DerivedKeyOverviewViewModel {
     init(_ key: MKeyAndNetworkCard) {
         path = key.key.address.path
-        identicon = key.key.address.identicon.svgPayload
+        identicon = key.key.address.identicon
         hasPassword = key.key.address.hasPwd
         network = key.network.networkTitle
         networkLogo = key.network.networkLogo
@@ -88,7 +88,7 @@ struct DerivedKeyOverviewRow: View {
             VStack(alignment: .leading) {
                 DerivedKeyOverviewRow(
                     DerivedKeyOverviewViewModel(
-                        identicon: PreviewData.exampleIdenticon,
+                        identicon: .svg(image: PreviewData.exampleIdenticon),
                         path: "",
                         hasPassword: false,
                         network: "Kusama",
@@ -97,7 +97,7 @@ struct DerivedKeyOverviewRow: View {
                 )
                 DerivedKeyOverviewRow(
                     DerivedKeyOverviewViewModel(
-                        identicon: PreviewData.exampleIdenticon,
+                        identicon: .svg(image: PreviewData.exampleIdenticon),
                         path: "//polkadot",
                         hasPassword: false,
                         network: "Polkadot",
@@ -106,7 +106,7 @@ struct DerivedKeyOverviewRow: View {
                 )
                 DerivedKeyOverviewRow(
                     DerivedKeyOverviewViewModel(
-                        identicon: PreviewData.exampleIdenticon,
+                        identicon: .svg(image: PreviewData.exampleIdenticon),
                         path: "//astar",
                         hasPassword: false,
                         network: "Astar",
@@ -115,7 +115,7 @@ struct DerivedKeyOverviewRow: View {
                 )
                 DerivedKeyOverviewRow(
                     DerivedKeyOverviewViewModel(
-                        identicon: PreviewData.exampleIdenticon,
+                        identicon: .svg(image: PreviewData.exampleIdenticon),
                         path: "//kusama",
                         hasPassword: true,
                         network: "Kusama",
@@ -124,7 +124,7 @@ struct DerivedKeyOverviewRow: View {
                 )
                 DerivedKeyOverviewRow(
                     DerivedKeyOverviewViewModel(
-                        identicon: PreviewData.exampleIdenticon,
+                        identicon: .svg(image: PreviewData.exampleIdenticon),
                         path: "//kusama//verylongpathsolongthatmightbemultilineandhaspasswordtoo",
                         hasPassword: true,
                         network: "Kusama",

--- a/ios/PolkadotVault/Extensions/Models/SignerImage+Helpers.swift
+++ b/ios/PolkadotVault/Extensions/Models/SignerImage+Helpers.swift
@@ -18,4 +18,15 @@ extension SignerImage {
             return []
         }
     }
+
+    /// Convienience accessor for `png` payload for `SignerImage`
+    /// Returns `[]` for `.svg` value
+    var pngPayload: [UInt8] {
+        switch self {
+        case .svg:
+            return []
+        case let .png(payload):
+            return payload
+        }
+    }
 }

--- a/ios/PolkadotVault/Previews/PreviewData+Components.swift
+++ b/ios/PolkadotVault/Previews/PreviewData+Components.swift
@@ -15,7 +15,7 @@ extension PreviewData {
     )
 
     static let qrCodeAddressFooterViewModel = QRCodeAddressFooterViewModel(
-        identicon: PreviewData.exampleIdenticon,
+        identicon: .svg(image: PreviewData.exampleIdenticon),
         rootKeyName: "Dotsama parachains",
         path: "//polkadot//path",
         hasPassword: true,
@@ -25,7 +25,7 @@ extension PreviewData {
     )
 
     static let qrCodeAddressFooterViewModelNoPath = QRCodeAddressFooterViewModel(
-        identicon: PreviewData.exampleIdenticon,
+        identicon: .svg(image: PreviewData.exampleIdenticon),
         rootKeyName: "Dotsama parachains",
         path: "",
         hasPassword: false,
@@ -35,7 +35,7 @@ extension PreviewData {
     )
 
     static let qrCodeAddressFooterViewModelVeryLongPath = QRCodeAddressFooterViewModel(
-        identicon: PreviewData.exampleIdenticon,
+        identicon: .svg(image: PreviewData.exampleIdenticon),
         rootKeyName: "Dotsama Crowdloans and Parity is a not just a very long name but the longest name",
         path: "//kusama//verylongpathsolongitrequirestwolinesoftextormaybeevenmoremaybethree",
         hasPassword: false,
@@ -85,7 +85,7 @@ extension PreviewData {
     )
 
     static let exampleDerivedKeyOverview = DerivedKeyOverviewViewModel(
-        identicon: PreviewData.exampleIdenticon,
+        identicon: .svg(image: PreviewData.exampleIdenticon),
         path: "//polkadot",
         hasPassword: false,
         network: "Polkadot",
@@ -94,35 +94,35 @@ extension PreviewData {
 
     static let exampleDerivedKeyOverviews: [DerivedKeyOverviewViewModel] = [
         DerivedKeyOverviewViewModel(
-            identicon: PreviewData.exampleIdenticon,
+            identicon: .svg(image: PreviewData.exampleIdenticon),
             path: "",
             hasPassword: false,
             network: "Kusama",
             networkLogo: "kusama"
         ),
         DerivedKeyOverviewViewModel(
-            identicon: PreviewData.exampleIdenticon,
+            identicon: .svg(image: PreviewData.exampleIdenticon),
             path: "//polkadot",
             hasPassword: false,
             network: "Polkadot",
             networkLogo: "polkadot"
         ),
         DerivedKeyOverviewViewModel(
-            identicon: PreviewData.exampleIdenticon,
+            identicon: .svg(image: PreviewData.exampleIdenticon),
             path: "//astar",
             hasPassword: false,
             network: "Astar",
             networkLogo: "astar"
         ),
         DerivedKeyOverviewViewModel(
-            identicon: PreviewData.exampleIdenticon,
+            identicon: .svg(image: PreviewData.exampleIdenticon),
             path: "//kusama",
             hasPassword: true,
             network: "Kusama",
             networkLogo: "kusama"
         ),
         DerivedKeyOverviewViewModel(
-            identicon: PreviewData.exampleIdenticon,
+            identicon: .svg(image: PreviewData.exampleIdenticon),
             path: "//kusama//verylongpathsolongthatmightbemultilineandhaspasswordtoo",
             hasPassword: true,
             network: "Kusama",
@@ -162,6 +162,6 @@ extension PreviewData {
         name: "Parity Keys",
         network: "polkadot",
         base58: "1219xC79CXV31543DDXoQMjuA",
-        identicon: PreviewData.exampleIdenticon
+        identicon: .svg(image: PreviewData.exampleIdenticon)
     )
 }

--- a/ios/PolkadotVault/Screens/KeyDetails/Models/DerivedKeyRowModel.swift
+++ b/ios/PolkadotVault/Screens/KeyDetails/Models/DerivedKeyRowModel.swift
@@ -21,7 +21,7 @@ struct DerivedKeyActionModel: Equatable {
 
 struct DerivedKeyRowViewModel: Equatable {
     let addressKey: String
-    let identicon: [UInt8]
+    let identicon: SignerImage
     let network: String
     let path: String
     let hasPassword: Bool
@@ -32,7 +32,7 @@ struct DerivedKeyRowViewModel: Equatable {
     init(_ key: MKeyAndNetworkCard) {
         addressKey = key.key.addressKey
         path = key.key.address.path
-        identicon = key.key.address.identicon.svgPayload
+        identicon = key.key.address.identicon
         network = key.network.networkLogo
         hasPassword = key.key.address.hasPwd
         base58 = key.key.base58
@@ -43,7 +43,7 @@ struct DerivedKeyRowViewModel: Equatable {
 extension DerivedKeyRowViewModel {
     init(
         addressKey: String = "",
-        identicon: [UInt8],
+        identicon: SignerImage,
         network: String,
         path: String,
         hasPassword: Bool,

--- a/ios/PolkadotVault/Screens/KeyDetails/Views/DerivedKeyRow.swift
+++ b/ios/PolkadotVault/Screens/KeyDetails/Views/DerivedKeyRow.swift
@@ -82,7 +82,7 @@ struct DerivedKeyRow: View {
             VStack {
                 DerivedKeyRow(
                     viewModel: DerivedKeyRowViewModel(
-                        identicon: PreviewData.exampleIdenticon,
+                        identicon: .svg(image: PreviewData.exampleIdenticon),
                         network: "polkadot",
                         path: "//polkadot",
                         hasPassword: false,
@@ -94,7 +94,7 @@ struct DerivedKeyRow: View {
                 )
                 DerivedKeyRow(
                     viewModel: DerivedKeyRowViewModel(
-                        identicon: PreviewData.exampleIdenticon,
+                        identicon: .svg(image: PreviewData.exampleIdenticon),
                         network: "kusama",
                         path: "",
                         hasPassword: false,
@@ -105,7 +105,7 @@ struct DerivedKeyRow: View {
                 )
                 DerivedKeyRow(
                     viewModel: DerivedKeyRowViewModel(
-                        identicon: PreviewData.exampleIdenticon,
+                        identicon: .svg(image: PreviewData.exampleIdenticon),
                         network: "astar",
                         path: "//astar",
                         hasPassword: false,
@@ -116,7 +116,7 @@ struct DerivedKeyRow: View {
                 )
                 DerivedKeyRow(
                     viewModel: DerivedKeyRowViewModel(
-                        identicon: PreviewData.exampleIdenticon,
+                        identicon: .svg(image: PreviewData.exampleIdenticon),
                         network: "kusama",
                         path: "//kusama",
                         hasPassword: true,
@@ -127,7 +127,7 @@ struct DerivedKeyRow: View {
                 )
                 DerivedKeyRow(
                     viewModel: DerivedKeyRowViewModel(
-                        identicon: PreviewData.exampleIdenticon,
+                        identicon: .svg(image: PreviewData.exampleIdenticon),
                         network: "kusama",
                         path: "//kusama//verylongpathsolongitrequirestwolinesoftextormaybeevenmoremaybethree",
                         hasPassword: true,

--- a/ios/PolkadotVault/Screens/KeySetsList/KeySetListViewModelBuilder.swift
+++ b/ios/PolkadotVault/Screens/KeySetsList/KeySetListViewModelBuilder.swift
@@ -18,14 +18,14 @@ struct KeySetViewModel: Equatable, Identifiable {
     let seed: SeedNameCard
     let keyName: String
     let derivedKeys: String?
-    let identicon: [UInt8]
+    let identicon: SignerImage
     let networks: [String]
 
     init(
         seed: SeedNameCard,
         keyName: String,
         derivedKeys: String?,
-        identicon: [UInt8],
+        identicon: SignerImage,
         networks: [String]
     ) {
         self.seed = seed
@@ -45,7 +45,7 @@ final class KeySetListViewModelBuilder {
                     seed: $0,
                     keyName: $0.seedName,
                     derivedKeys: derivedKeys(for: $0),
-                    identicon: $0.identicon.svgPayload,
+                    identicon: $0.identicon,
                     networks: $0.usedInNetworks
                 )
             }

--- a/ios/PolkadotVault/Screens/KeySetsList/KeySetRow.swift
+++ b/ios/PolkadotVault/Screens/KeySetsList/KeySetRow.swift
@@ -109,7 +109,7 @@ struct KeySetRow: View {
                         seed: PreviewData.seedNameCard,
                         keyName: "Main Polkadot",
                         derivedKeys: "5 Derived Key",
-                        identicon: PreviewData.exampleIdenticon,
+                        identicon: .svg(image: PreviewData.exampleIdenticon),
                         networks: ["polkadot", "kusama", "astar", "westend", "phala"]
                     ),
                     selectedItems: Binding<[KeySetViewModel]>.constant([]),
@@ -120,7 +120,7 @@ struct KeySetRow: View {
                         seed: PreviewData.seedNameCard,
                         keyName: "Kusama",
                         derivedKeys: nil,
-                        identicon: PreviewData.exampleIdenticon,
+                        identicon: .svg(image: PreviewData.exampleIdenticon),
                         networks: []
                     ),
                     selectedItems: Binding<[KeySetViewModel]>.constant([]),
@@ -131,7 +131,7 @@ struct KeySetRow: View {
                         seed: PreviewData.seedNameCard,
                         keyName: "Dotsama crowdloans with very long title",
                         derivedKeys: "435 Derived Keys",
-                        identicon: PreviewData.exampleIdenticon,
+                        identicon: .svg(image: PreviewData.exampleIdenticon),
                         networks: [
                             "polkadot",
                             "kusama",
@@ -158,14 +158,14 @@ struct KeySetRow: View {
                         seed: PreviewData.seedNameCard,
                         keyName: "Dotsama crowdloans with very long title",
                         derivedKeys: "3 Derived Keys",
-                        identicon: PreviewData.exampleIdenticon,
+                        identicon: .svg(image: PreviewData.exampleIdenticon),
                         networks: ["polkadot", "kusama", "astar", "westend", "phala"]
                     ),
                     selectedItems: Binding<[KeySetViewModel]>.constant([KeySetViewModel(
                         seed: PreviewData.seedNameCard,
                         keyName: "Dotsama crowdloans",
                         derivedKeys: "3 Derived Keys",
-                        identicon: PreviewData.exampleIdenticon,
+                        identicon: .svg(image: PreviewData.exampleIdenticon),
                         networks: ["polkadot", "kusama", "astar", "westend", "phala"]
                     )]),
                     isExportKeysSelected: Binding<Bool>.constant(true)

--- a/ios/PolkadotVault/Screens/PublicKey/KeyDetailsPublicKeyViewModel.swift
+++ b/ios/PolkadotVault/Screens/PublicKey/KeyDetailsPublicKeyViewModel.swift
@@ -16,7 +16,7 @@ struct KeyDetailsPublicKeyViewModel: Equatable {
     init(_ keyDetails: MKeyDetails) {
         qrCode = keyDetails.qr
         footer = .init(
-            identicon: keyDetails.address.identicon.svgPayload,
+            identicon: keyDetails.address.identicon,
             rootKeyName: keyDetails.address.seedName,
             path: keyDetails.address.path,
             hasPassword: keyDetails.address.hasPwd,

--- a/ios/PolkadotVault/Screens/Scan/Models/TransactionSummaryModels.swift
+++ b/ios/PolkadotVault/Screens/Scan/Models/TransactionSummaryModels.swift
@@ -42,7 +42,7 @@ extension TransactionPreviewRenderable {
                 name: author.address.seedName,
                 network: transaction.networkInfo?.networkLogo,
                 base58: author.base58,
-                identicon: author.address.identicon.svgPayload,
+                identicon: author.address.identicon,
                 hasPassword: author.address.hasPwd
             )
         } else {
@@ -101,7 +101,7 @@ struct TransactionSignatureRenderable: Equatable {
     let name: String
     let network: String?
     let base58: String
-    let identicon: [UInt8]
+    let identicon: SignerImage
     let hasPassword: Bool
 
     init(
@@ -109,7 +109,7 @@ struct TransactionSignatureRenderable: Equatable {
         name: String = "",
         network: String? = nil,
         base58: String = "",
-        identicon: [UInt8] = [],
+        identicon: SignerImage = .svg(image: []),
         hasPassword: Bool = false
     ) {
         self.path = path


### PR DESCRIPTION
## Purpose
This PR brings back support for png payloads for identicons

## Screenshots

| Moonbeam example |  |
|-|-|
|<img src="https://user-images.githubusercontent.com/1955364/220600462-68def9d2-7473-4af4-b07b-a18072922f24.png" width="320px">||
