### PR TITLE
fix: do not gobble up errors in bulks

### DIFF
--- a/ios/PolkadotVault/Components/QRCode/QRCodeAddressFooterView.swift
+++ b/ios/PolkadotVault/Components/QRCode/QRCodeAddressFooterView.swift
@@ -49,9 +49,9 @@ struct QRCodeAddressFooterView: View {
                     size: Heights.identiconInCell
                 )
             }
-            HStack(alignment: .top, spacing: Spacing.small) {
+            HStack(alignment: .center, spacing: Spacing.small) {
                 VStack(alignment: .leading, spacing: Spacing.extraExtraSmall) {
-                    HStack(spacing: Spacing.extraExtraSmall) {
+                    HStack(alignment: .center, spacing: Spacing.extraExtraSmall) {
                         Text(showFullAddress ? viewModel.base58 : viewModel.base58.truncateMiddle())
                             .foregroundColor(Asset.textAndIconsTertiary.swiftUIColor)
                             .font(PrimaryFont.bodyM.font)

--- a/ios/PolkadotVaultTests/Screens/KeySetList/KeySetListViewModelBuilderTests.swift
+++ b/ios/PolkadotVaultTests/Screens/KeySetList/KeySetListViewModelBuilderTests.swift
@@ -20,10 +20,10 @@ final class KeySetListViewModelBuilderTests: XCTestCase {
         // Given
         let name = "name"
         let derivedKeys: String? = nil
-        let identicon: [UInt8] = [123]
+        let identicon = SignerImage.svg(image: [123])
         let seedNameCard = SeedNameCard(
             seedName: name,
-            identicon: .svg(image: identicon),
+            identicon: identicon,
             usedInNetworks: ["polkadot", "kusama", "westend"],
             derivedKeysCount: 0
         )
@@ -42,10 +42,10 @@ final class KeySetListViewModelBuilderTests: XCTestCase {
         // Given
         let name = "name"
         let derivedKeys = "1 Key"
-        let identicon: [UInt8] = [123]
+        let identicon = SignerImage.svg(image: [123])
         let seedNameCard = SeedNameCard(
             seedName: name,
-            identicon: .svg(image: identicon),
+            identicon: identicon,
             usedInNetworks: ["polkadot", "kusama", "westend"],
             derivedKeysCount: 1
         )
@@ -64,10 +64,10 @@ final class KeySetListViewModelBuilderTests: XCTestCase {
         // Given
         let name = "name"
         let derivedKeys = "3 Keys"
-        let identicon: [UInt8] = [123]
+        let identicon = SignerImage.svg(image: [123])
         let seedNameCard = SeedNameCard(
             seedName: name,
-            identicon: .svg(image: identicon),
+            identicon: identicon,
             usedInNetworks: ["polkadot", "kusama", "westend"],
             derivedKeysCount: 3
         )

--- a/rust/transaction_parsing/src/lib.rs
+++ b/rust/transaction_parsing/src/lib.rs
@@ -79,13 +79,15 @@ fn parse_transaction_bulk(database: &sled::Db, payload: &str) -> Result<Transact
                 let encoded = hex::encode(t);
                 let encoded = "53".to_string() + &encoded;
                 let action = parse_transaction(database, &encoded, true)?;
-                if let TransactionAction::Sign {
-                    actions: a,
-                    checksum: c,
-                } = action
-                {
-                    checksum = c;
-                    actions.push(a[0].clone());
+                match action {
+                    TransactionAction::Sign {
+                        actions: a,
+                        checksum: c,
+                    } => {
+                        checksum = c;
+                        actions.push(a[0].clone());
+                    }
+                    _ => return Ok(action),
                 }
             }
 


### PR DESCRIPTION
## Purpose

If one TX in the bulk is faulty or is not a Tranasction Signing action,
return just it.
