### PR TITLE
fix: Android testing fixes 2

### DIFF
--- a/android/src/main/java/io/parity/signer/bottomsheets/sufficientcrypto/SufficientCryptoReady.kt
+++ b/android/src/main/java/io/parity/signer/bottomsheets/sufficientcrypto/SufficientCryptoReady.kt
@@ -1,14 +1,19 @@
 package io.parity.signer.bottomsheets
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
+import io.parity.signer.bottomsheets.sufficientcrypto.SufficientCryptoReadyViewModel
 import io.parity.signer.components.*
 import io.parity.signer.domain.intoImageBitmap
 import io.parity.signer.ui.theme.Bg000
@@ -31,7 +36,9 @@ fun SufficientCryptoReady(
 		) {
 			HeaderBar("Your signature", "Scan this into your application")
 			Image(
-				bitmap = sufficientCrypto.sufficient.intoImageBitmap(),
+				bitmap = SufficientCryptoReadyViewModel.getQrCodeBitmapFromQrCodeData(
+					sufficientCrypto.sufficient
+				)?.intoImageBitmap() ?: ImageBitmap(1, 1),
 				contentDescription = "Signed update",
 				contentScale = ContentScale.FillWidth,
 				modifier = Modifier.fillMaxWidth()

--- a/android/src/main/java/io/parity/signer/bottomsheets/sufficientcrypto/SufficientCryptoReadyViewModel.kt
+++ b/android/src/main/java/io/parity/signer/bottomsheets/sufficientcrypto/SufficientCryptoReadyViewModel.kt
@@ -1,0 +1,17 @@
+package io.parity.signer.bottomsheets.sufficientcrypto
+
+import io.parity.signer.backend.mapError
+import io.parity.signer.dependencygraph.ServiceLocator
+import kotlinx.coroutines.runBlocking
+
+
+object SufficientCryptoReadyViewModel {
+	fun getQrCodeBitmapFromQrCodeData(data: List<UByte>): List<UByte>? {
+		val interactor = ServiceLocator.uniffiInteractor
+		return runBlocking {
+			interactor.encodeToQrImages(listOf(data))
+				.mapError()
+				?.firstOrNull()
+		}
+	}
+}

--- a/android/src/main/java/io/parity/signer/components/items/KeyDerivedItem.kt
+++ b/android/src/main/java/io/parity/signer/components/items/KeyDerivedItem.kt
@@ -23,9 +23,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.parity.signer.R
 import io.parity.signer.components.IdentIcon
-import io.parity.signer.domain.BASE58_STYLE_ABBREVIATE
-import io.parity.signer.domain.KeyModel
-import io.parity.signer.domain.abbreviateString
+import io.parity.signer.components.base.SignerDivider
+import io.parity.signer.components.sharedcomponents.NetworkLabel
+import io.parity.signer.domain.*
 import io.parity.signer.ui.theme.SignerNewTheme
 import io.parity.signer.ui.theme.SignerTypeface
 import io.parity.signer.ui.theme.textDisabled
@@ -88,32 +88,47 @@ fun KeyDerivedItem(
 }
 
 @Composable
-fun SlimKeyItem(model: KeyModel) {
+fun SlimKeyItem(model: KeyAndNetworkModel) {
 	Row(
 		modifier = Modifier.fillMaxWidth(1f),
 		verticalAlignment = Alignment.CenterVertically,
 	) {
 		IdentIcon(
-			identicon = model.identicon, size = 36.dp, modifier = Modifier.padding(
+			identicon = model.key.identicon,
+			size = 36.dp,
+			modifier = Modifier.padding(
 				top = 16.dp,
 				bottom = 16.dp,
 				start = 24.dp,
 				end = 12.dp
 			)
 		)
-		Text(
-			text = model.path,
-			color = MaterialTheme.colors.primary,
-			style = SignerTypeface.LabelM,
-		)
-		if (model.hasPwd) {
-			Icon(
-				painterResource(id = R.drawable.ic_lock_16),
-				contentDescription = stringResource(R.string.key_lock_item),
-				tint = MaterialTheme.colors.textTertiary,
-				modifier = Modifier.padding(start = 8.dp)
+		if (model.key.path.isNotEmpty()) {
+			Text(
+				text = model.key.path,
+				color = MaterialTheme.colors.primary,
+				style = SignerTypeface.LabelM,
+			)
+			if (model.key.hasPwd) {
+				Icon(
+					painterResource(id = R.drawable.ic_lock_16),
+					contentDescription = stringResource(R.string.key_lock_item),
+					tint = MaterialTheme.colors.textTertiary,
+					modifier = Modifier.padding(start = 8.dp)
+				)
+			}
+		} else {
+			Text(
+				text = stringResource(R.string.derivation_key_empty_path_placeholder),
+				color = MaterialTheme.colors.textTertiary,
+				style = SignerTypeface.LabelM,
 			)
 		}
+		Spacer(modifier = Modifier.weight(1f))
+		NetworkLabel(
+			networkName = model.network.networkTitle,
+			modifier = Modifier.padding(end = 24.dp, start = 8.dp)
+		)
 	}
 }
 
@@ -145,9 +160,15 @@ private fun PreviewKeyDerivedItem() {
 )
 @Composable
 private fun PreviewSlimKeyItem() {
+	val model = KeyAndNetworkModel(
+		key = KeyModel.createStub(),
+		network = NetworkInfoModel.createStub()
+	)
 	SignerNewTheme {
-		SlimKeyItem(
-			KeyModel.createStub()
-		)
+		Column {
+			SlimKeyItem(model)
+			SignerDivider()
+			SlimKeyItem(model.copy(key = model.key.copy(path = "")))
+		}
 	}
 }

--- a/android/src/main/java/io/parity/signer/components/sharedcomponents/KeyCard.kt
+++ b/android/src/main/java/io/parity/signer/components/sharedcomponents/KeyCard.kt
@@ -114,12 +114,12 @@ fun KeyCard(model: KeyCardModel) {
 }
 
 @Composable
-private fun NetworkLabel(networkName: String) {
+fun NetworkLabel(networkName: String, modifier: Modifier = Modifier) {
 	Text(
 		networkName,
 		color = MaterialTheme.colors.textTertiary,
 		style = SignerTypeface.CaptionM,
-		modifier = Modifier
+		modifier = modifier
 			.background(
 				MaterialTheme.colors.fill12,
 				RoundedCornerShape(dimensionResource(id = R.dimen.innerFramesCornerRadius))
@@ -193,15 +193,6 @@ data class KeyCardModel(
 		/**
 		 * @param networkTitle probably from keyDetails.networkInfo.networkTitle
 		 */
-		fun fromAddress(
-			address_card: MAddressCard,
-			networkTitle: String
-		): KeyCardModel =
-			KeyCardModel(
-				network = networkTitle,
-				cardBase = KeyCardModelBase.fromAddress(address_card)
-			)
-
 		fun fromAddress(
 			address: Address,
 			base58: String,

--- a/android/src/main/java/io/parity/signer/domain/SeedExtensions.kt
+++ b/android/src/main/java/io/parity/signer/domain/SeedExtensions.kt
@@ -4,9 +4,11 @@ import io.parity.signer.dependencygraph.ServiceLocator
 import io.parity.signer.domain.storage.getSeed
 
 
-suspend fun SharedViewModel.getSeedPhraseForBackup(seedName: String,
+suspend fun SharedViewModel.getSeedPhraseForBackup(
+	seedName: String,
 ): String? {
-	return when (ServiceLocator.authentication.authenticate(activity)) {
+	val authenticator = ServiceLocator.authentication
+	return when (authenticator.authenticate(activity)) {
 		AuthResult.AuthSuccess -> {
 			val seedPhrase = getSeed(seedName, backup = true)
 			seedPhrase

--- a/android/src/main/java/io/parity/signer/domain/SharedViewModel.kt
+++ b/android/src/main/java/io/parity/signer/domain/SharedViewModel.kt
@@ -16,8 +16,10 @@ import org.json.JSONObject
 
 @SuppressLint("StaticFieldLeak")
 class SharedViewModel() : ViewModel() {
-	val context: Context = ServiceLocator.appContext.applicationContext
-	val activity: FragmentActivity = ServiceLocator.activityScope!!.activity
+	val context: Context
+		get() = ServiceLocator.appContext.applicationContext
+	val activity: FragmentActivity
+		get() = ServiceLocator.activityScope!!.activity
 
 	init {
 		// Imitate ios behavior
@@ -26,6 +28,7 @@ class SharedViewModel() : ViewModel() {
 			totalRefresh()
 		}
 	}
+
 	val navigator by lazy { SignerNavigator(this) }
 
 	// Current key details, after rust API will migrate to REST-like should not store this value here.
@@ -41,7 +44,8 @@ class SharedViewModel() : ViewModel() {
 		ServiceLocator.networkExposedStateKeeper
 
 	// Navigator
-	internal val _actionResult = MutableStateFlow<ActionResult?>(null
+	internal val _actionResult = MutableStateFlow<ActionResult?>(
+		null
 	)
 
 	internal val _localNavAction = MutableStateFlow<LocalNavAction>(

--- a/android/src/main/java/io/parity/signer/screens/keysetdetails/backup/SeedbBackupItems.kt
+++ b/android/src/main/java/io/parity/signer/screens/keysetdetails/backup/SeedbBackupItems.kt
@@ -1,14 +1,14 @@
 package io.parity.signer.screens.keysetdetails.backup
 
-import io.parity.signer.domain.KeyModel
+import io.parity.signer.domain.KeyAndNetworkModel
 import io.parity.signer.domain.KeySetDetailsModel
 
 data class SeedBackupModel(
 	val seedName: String,
 	val seedBase58: String,
-	val derivations: List<KeyModel>
+	val derivations: List<KeyAndNetworkModel>
 )
 fun KeySetDetailsModel.toSeedBackupModel(): SeedBackupModel? {
 	val root = root ?: return null
-	return SeedBackupModel(root.seedName, root.base58, keysAndNetwork.map { it.key })
+	return SeedBackupModel(root.seedName, root.base58, keysAndNetwork)
 }

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -308,6 +308,7 @@
 	<string name="settings_confirmation_wipe_all_message_highlited_warning">Warning:</string>
 	<string name="settings_confirmation_wipe_all_title">Wipe All Data?</string>
 	<string name="settings_confirmation_wipe_all_message_yes_label">I Understand, Remove all Data</string>
+	<string name="derivation_key_empty_path_placeholder">Derivation Path is Empty</string>
 
 </resources>
 


### PR DESCRIPTION

## Scope
-    fix: #1680 - explicitly wrote getters so kotlin won't create backed fields and use outdated activity or context from shared viewmodel
-   fix: added network logo and empty path placeholder #1680
-   fix: android fix for old screen qr code was not shown fixed #1679
 

## Screenshots
| Left title, i.e. "Before" | Right title, i.e. "After" |
|-|-|
| ![black](https://user-images.githubusercontent.com/11879032/222806748-c263430d-e2a3-489e-bf32-c6b5d6d99dde.png) | ![white](https://user-images.githubusercontent.com/11879032/222806636-cb18018e-6cf8-4c88-a700-45e847b29484.png) |


