### PR TITLE
feat: ios: error handling for seed phrase recovery

### DIFF
--- a/ios/PolkadotVault/Core/Keychain/SeedsMediator.swift
+++ b/ios/PolkadotVault/Core/Keychain/SeedsMediator.swift
@@ -36,7 +36,7 @@ protocol SeedsMediating: AnyObject {
     ///   - seedName: seed name
     ///   - seedPhrase: seed phrase to be saved
     @discardableResult
-    func restoreSeed(seedName: String, seedPhrase: String, navigate: Bool) -> Bool
+    func restoreSeed(seedName: String, seedPhrase: String, navigate: Bool, shouldCheckForCollision: Bool) -> Bool
     /// Checks for existance of `seedName` in Keychain
     /// Each seed name needs to be unique, this helps to not overwrite old seeds
     /// - Parameter seedName: seedName to be checked
@@ -122,9 +122,14 @@ final class SeedsMediator: SeedsMediating {
     }
 
     @discardableResult
-    func restoreSeed(seedName: String, seedPhrase: String, navigate: Bool = true) -> Bool {
+    func restoreSeed(
+        seedName: String,
+        seedPhrase: String,
+        navigate: Bool = true,
+        shouldCheckForCollision: Bool
+    ) -> Bool {
         guard !seedName.isEmpty, let finalSeedPhrase = seedPhrase.data(using: .utf8) else { return false }
-        if navigate, checkSeedPhraseCollision(seedPhrase: seedPhrase) {
+        if shouldCheckForCollision, checkSeedPhraseCollision(seedPhrase: seedPhrase) {
             return false
         }
         let saveSeedResult = keychainAccessAdapter.saveSeed(

--- a/ios/PolkadotVault/Modals/Errors/ErrorBottomModalViewModel.swift
+++ b/ios/PolkadotVault/Modals/Errors/ErrorBottomModalViewModel.swift
@@ -188,4 +188,14 @@ struct ErrorBottomModalViewModel {
             secondaryAction: .init(label: Localizable.ErrorModal.Action.ok.key, action: action)
         )
     }
+
+    static func recoverySeedPhraseIncorrectPhrase(
+        _ action: @escaping @autoclosure () -> Void = {}()
+    ) -> ErrorBottomModalViewModel {
+        ErrorBottomModalViewModel(
+            title: Localizable.RecoverSeedPhrase.Error.IncorrectPhrase.title.string,
+            content: Localizable.RecoverSeedPhrase.Error.IncorrectPhrase.message.string,
+            secondaryAction: .init(label: Localizable.ErrorModal.Action.ok.key, action: action)
+        )
+    }
 }

--- a/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
+++ b/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
@@ -77,6 +77,8 @@
 "RecoverSeedPhrase.Action.Done" = "Done";
 "RecoverSeedPhrase.Label.Title" = "Recover Key Set";
 "RecoverSeedPhrase.Label.Header" = "Secret Recovery Phrase";
+"RecoverSeedPhrase.Error.IncorrectPhrase.Title" = "Please enter the correct Secret Recovery phrase";
+"RecoverSeedPhrase.Error.IncorrectPhrase.Message" = "Please edit your secret recovery phrase and try again.";
 
 // Sign Sufficient Crypto
 "Select key for signing" = "Select key for signing";

--- a/ios/PolkadotVault/Screens/CreateKey/NewKeySet/CreateKeySetSeedPhraseView.swift
+++ b/ios/PolkadotVault/Screens/CreateKey/NewKeySet/CreateKeySetSeedPhraseView.swift
@@ -122,7 +122,8 @@ extension CreateKeySetSeedPhraseView {
             seedsMediator.restoreSeed(
                 seedName: dataModel.seed,
                 seedPhrase: dataModel.seedPhrase,
-                navigate: true
+                navigate: true,
+                shouldCheckForCollision: true
             )
         }
 


### PR DESCRIPTION
## Purpose
We need some proper error handling for updated seed phrase recovery

## Scope
- error handling for seed phrase already exists
- error handling for invalid 24 word combination that is not a valid seed phrase 

## Screenshots

| Seed Phrase already exists | Seed Phrase is invalid |
|-|-|
|<img src="https://user-images.githubusercontent.com/1955364/223465934-23ea959a-4d3a-4107-b7e2-8247259b5242.gif" width="320px">|<img src="https://user-images.githubusercontent.com/1955364/223465953-4301f48e-6d26-4ef0-b385-bf253ff38c51.gif" width="320px">|

