### PR TITLE
chore: ios: capitalise network name everywhere but during import

### DIFF
--- a/ios/PolkadotVault/Components/Text/NetworkCapsuleView.swift
+++ b/ios/PolkadotVault/Components/Text/NetworkCapsuleView.swift
@@ -11,7 +11,7 @@ struct NetworkCapsuleView: View {
     let network: String
 
     var body: some View {
-        Text(network)
+        Text(network.capitalized)
             .foregroundColor(Asset.textAndIconsTertiary.swiftUIColor)
             .font(PrimaryFont.captionM.font)
             .padding([.top, .bottom], Spacing.extraExtraSmall)

--- a/ios/PolkadotVault/Modals/NetworkSelection/NetworkSelectionModal.swift
+++ b/ios/PolkadotVault/Modals/NetworkSelection/NetworkSelectionModal.swift
@@ -66,7 +66,7 @@ struct NetworkSelectionModal: View {
         HStack(alignment: .center, spacing: 0) {
             NetworkLogoIcon(networkName: network.logo)
                 .padding(.trailing, Spacing.small)
-            Text(network.title)
+            Text(network.title.capitalized)
                 .foregroundColor(Asset.textAndIconsPrimary.swiftUIColor)
                 .font(PrimaryFont.labelM.font)
             Spacer()

--- a/ios/PolkadotVault/Screens/DerivedKey/CreateDerivedKeyView.swift
+++ b/ios/PolkadotVault/Screens/DerivedKey/CreateDerivedKeyView.swift
@@ -130,7 +130,7 @@ struct CreateDerivedKeyView: View {
                 HStack(spacing: 0) {
                     NetworkLogoIcon(networkName: network.logo, size: Heights.networkLogoInCapsule)
                         .padding(.trailing, Spacing.extraSmall)
-                    Text(network.title)
+                    Text(network.title.capitalized)
                         .foregroundColor(Asset.textAndIconsSecondary.swiftUIColor)
                         .font(PrimaryFont.bodyM.font)
                         .padding(.trailing, Spacing.extraSmall)

--- a/ios/PolkadotVault/Screens/DerivedKey/Subviews/ChooseNetworkForKeyView.swift
+++ b/ios/PolkadotVault/Screens/DerivedKey/Subviews/ChooseNetworkForKeyView.swift
@@ -58,7 +58,7 @@ struct ChooseNetworkForKeyView: View {
         HStack(alignment: .center, spacing: 0) {
             NetworkLogoIcon(networkName: network.logo)
                 .padding(.trailing, Spacing.small)
-            Text(network.title)
+            Text(network.title.capitalized)
                 .foregroundColor(Asset.textAndIconsPrimary.swiftUIColor)
                 .font(PrimaryFont.titleS.font)
             Spacer()

--- a/ios/PolkadotVault/Screens/Settings/Subviews/Networks/NetworkSelectionSettings.swift
+++ b/ios/PolkadotVault/Screens/Settings/Subviews/Networks/NetworkSelectionSettings.swift
@@ -60,7 +60,7 @@ struct NetworkSelectionSettings: View {
         HStack(alignment: .center, spacing: 0) {
             NetworkLogoIcon(networkName: network.logo)
                 .padding(.trailing, Spacing.small)
-            Text(network.title)
+            Text(network.title.capitalized)
                 .foregroundColor(Asset.textAndIconsPrimary.swiftUIColor)
                 .font(PrimaryFont.labelL.font)
             Spacer()

--- a/ios/PolkadotVault/Screens/Settings/Subviews/Networks/NetworkSettingsDetails.swift
+++ b/ios/PolkadotVault/Screens/Settings/Subviews/Networks/NetworkSettingsDetails.swift
@@ -28,7 +28,7 @@ struct NetworkSettingsDetails: View {
                     VStack(alignment: .center, spacing: 0) {
                         NetworkLogoIcon(networkName: viewModel.networkDetails.logo, size: Heights.networkLogoInHeader)
                             .padding(.bottom, Spacing.small)
-                        Text(viewModel.networkDetails.name)
+                        Text(viewModel.networkDetails.name.capitalized)
                             .font(PrimaryFont.titleM.font)
                             .foregroundColor(Asset.textAndIconsPrimary.swiftUIColor)
                             .padding(.bottom, Spacing.large)


### PR DESCRIPTION
## Purpose
Capitalise network name everywhere, but during network import via qr code to not create confusion about qr code payload

## Screenshots

| Network name previews | 
|-|
|<img src="https://user-images.githubusercontent.com/1955364/223667182-85bff874-c10b-4cff-be12-387498ae4f0e.gif" width="320px">|
