### PR TITLE
fix: ios: unable to delete network 

### DIFF
--- a/ios/PolkadotVault.xcodeproj/project.pbxproj
+++ b/ios/PolkadotVault.xcodeproj/project.pbxproj
@@ -2414,7 +2414,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/PolkadotVault",
 				);
-				MARKETING_VERSION = 6.0.1;
+				MARKETING_VERSION = 6.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = io.parity.NativeSigner;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2449,7 +2449,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/PolkadotVault",
 				);
-				MARKETING_VERSION = 6.0.1;
+				MARKETING_VERSION = 6.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = io.parity.NativeSigner;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/ios/PolkadotVault/Screens/Settings/Subviews/Networks/NetworkSettingsDetails.swift
+++ b/ios/PolkadotVault/Screens/Settings/Subviews/Networks/NetworkSettingsDetails.swift
@@ -355,12 +355,15 @@ extension NetworkSettingsDetails {
         }
 
         func onMoreActionSheetDismissal() {
-            if shouldSignSpecs {
-                navigation.perform(navigation: .init(action: .signNetworkSpecs))
-            }
-            if shouldPresentRemoveNetworkConfirmation {
-                shouldPresentRemoveNetworkConfirmation = false
-                isPresentingRemoveNetworkConfirmation = true
+            // Due to iOS 15 handling of following .fullscreen presentation after dismissal, we need to enforce sync on main queue
+            DispatchQueue.main.async {
+                if self.shouldSignSpecs {
+                    self.navigation.perform(navigation: .init(action: .signNetworkSpecs))
+                }
+                if self.shouldPresentRemoveNetworkConfirmation {
+                    self.shouldPresentRemoveNetworkConfirmation = false
+                    self.isPresentingRemoveNetworkConfirmation = true
+                }
             }
         }
 


### PR DESCRIPTION
## Purpose
Fix for #1693. On iOS 15 we are unable to properly delete network from Network Details in Settings 