### PR TITLE
feat: ios: don't block iOS system auto-lock feature

### DIFF
--- a/ios/PolkadotVault/Screens/Scan/CameraView.swift
+++ b/ios/PolkadotVault/Screens/Scan/CameraView.swift
@@ -35,7 +35,6 @@ struct CameraView: View {
                 }
                 .onChange(of: model.captured) { newValue in
                     progressViewModel.current = newValue
-                    UIApplication.shared.isIdleTimerDisabled = newValue > 0
                 }
                 .onChange(of: model.requestPassword) { newValue in
                     guard newValue else { return }
@@ -122,7 +121,6 @@ struct CameraView: View {
             viewModel.use(navigation: navigation)
         }
         .onDisappear {
-            UIApplication.shared.isIdleTimerDisabled = false
             model.shutdown()
         }
         .background(Asset.backgroundPrimary.swiftUIColor)


### PR DESCRIPTION
## Purpose
Currently we've decided to not block iOS auto-lock setting when user is scanning qr code transaction as we don't explicitly inform user about it and this could lead to battery drain. 
Related to #1703 

## Scope
- don't pause system auto-lock when on QR code scanner screen