### PR TITLE
chore: ios: update workflows to use newest Xcode and iOS SDK 16.1

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -25,7 +25,7 @@ jobs:
           submodules:         'recursive'
 
       - name:                 Setup - Xcode
-        run:                  sudo xcode-select -switch '/Applications/Xcode_14.0.app/Contents/Developer' && /usr/bin/xcodebuild -version
+        run:                  sudo xcode-select -switch '/Applications/Xcode_14.2.app/Contents/Developer' && /usr/bin/xcodebuild -version
 
       - name:                 Install dependencies
         run:                  |

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -25,7 +25,7 @@ jobs:
           bundler-cache:      true
 
       - name:                 Setup - Xcode
-        run:                  sudo xcode-select -switch '/Applications/Xcode_14.0.app/Contents/Developer' && /usr/bin/xcodebuild -version
+        run:                  sudo xcode-select -switch '/Applications/Xcode_14.2.app/Contents/Developer' && /usr/bin/xcodebuild -version
 
       - name:                 Install dependencies
         run:                  |


### PR DESCRIPTION
## Purpose
We need to bump up minimum Xcode version as without it we can no longer post new TF builds