### PR TITLE
fix: Android copy typo 

### DIFF
--- a/android/src/main/java/io/parity/signer/screens/scan/transaction/TransactionsScreenFull.kt
+++ b/android/src/main/java/io/parity/signer/screens/scan/transaction/TransactionsScreenFull.kt
@@ -129,7 +129,7 @@ private fun getTransactionsTitle(
 		is TransactionPreviewType.AddNetwork -> stringResource(R.string.transactions_title_network)
 		is TransactionPreviewType.Metadata -> stringResource(R.string.transactions_title_metadata)
 		TransactionPreviewType.Transfer, TransactionPreviewType.Unknown -> pluralStringResource(
-			id = R.plurals.transactions_title_other, transactionsCount,
+			id = R.plurals.transactions_title_other, transactionsCount, transactionsCount
 		)
 	}
 }


### PR DESCRIPTION
Added missing parameter for copy to show amount of transaction in the title