### PR TITLE
feat: ios: support enter password modal flow for signing network specs / metadata

### DIFF
--- a/ios/PolkadotVault.xcodeproj/project.pbxproj
+++ b/ios/PolkadotVault.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		6D2D244F28CE5C1B00862726 /* NavbarActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D2D244E28CE5C1B00862726 /* NavbarActionButton.swift */; };
 		6D2D245228CE5F2D00862726 /* KeyDetailsPublicKeyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D2D245128CE5F2D00862726 /* KeyDetailsPublicKeyView.swift */; };
 		6D2D245728CF5C5200862726 /* PublicKeyActionsModal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D2D245628CF5C5200862726 /* PublicKeyActionsModal.swift */; };
+		6D30228329D183BE0074CDDF /* SignSpecEnterPasswordModal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D30228229D183BE0074CDDF /* SignSpecEnterPasswordModal.swift */; };
 		6D3423352994F0D200F3BA27 /* ErrorBottomModalViewModel+TransactionErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D3423342994F0D200F3BA27 /* ErrorBottomModalViewModel+TransactionErrors.swift */; };
 		6D34233A299615FD00F3BA27 /* MVerifier+Type.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D342339299615FD00F3BA27 /* MVerifier+Type.swift */; };
 		6D3A538729968D920004DDDD /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6D3A538629968D920004DDDD /* LaunchScreen.storyboard */; };
@@ -403,6 +404,7 @@
 		6D2D244E28CE5C1B00862726 /* NavbarActionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavbarActionButton.swift; sourceTree = "<group>"; };
 		6D2D245128CE5F2D00862726 /* KeyDetailsPublicKeyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyDetailsPublicKeyView.swift; sourceTree = "<group>"; };
 		6D2D245628CF5C5200862726 /* PublicKeyActionsModal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicKeyActionsModal.swift; sourceTree = "<group>"; };
+		6D30228229D183BE0074CDDF /* SignSpecEnterPasswordModal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignSpecEnterPasswordModal.swift; sourceTree = "<group>"; };
 		6D3423342994F0D200F3BA27 /* ErrorBottomModalViewModel+TransactionErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ErrorBottomModalViewModel+TransactionErrors.swift"; sourceTree = "<group>"; };
 		6D342339299615FD00F3BA27 /* MVerifier+Type.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MVerifier+Type.swift"; sourceTree = "<group>"; };
 		6D3A538629968D920004DDDD /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -1027,6 +1029,7 @@
 			children = (
 				6D4F779829CAECA500374C83 /* SignSpecsListView.swift */,
 				6D4F779A29CAF55200374C83 /* SignSpecDetailsView.swift */,
+				6D30228229D183BE0074CDDF /* SignSpecEnterPasswordModal.swift */,
 			);
 			path = SignSpecs;
 			sourceTree = "<group>";
@@ -2081,6 +2084,7 @@
 				6D5801D728991F11006C41D8 /* RuntimePropertiesProvider.swift in Sources */,
 				6DA08B9029B68AF90027CFCB /* NavigationInitialisationService.swift in Sources */,
 				6DA501D9290C1C3E0096DA4E /* MKeyAndNetworkCard+PathAndNetwork.swift in Sources */,
+				6D30228329D183BE0074CDDF /* SignSpecEnterPasswordModal.swift in Sources */,
 				6DDEF11428AD12FA004CA2FD /* Tab.swift in Sources */,
 				6DA2ACAC2939E87600AAEADC /* Event+Value.swift in Sources */,
 				6DDF439C29879D3900881AFF /* SecondaryFont.swift in Sources */,

--- a/ios/PolkadotVault/Core/Navigation/NavigationCoordinator.swift
+++ b/ios/PolkadotVault/Core/Navigation/NavigationCoordinator.swift
@@ -93,8 +93,9 @@ extension NavigationCoordinator {
         backendActionPerformer.performTransaction(with: payload)
     }
 
-    func perform(navigation: Navigation, skipDebounce: Bool = false) {
-        guard isActionAvailable else { return }
+    @discardableResult
+    func perform(navigation: Navigation, skipDebounce: Bool = false) -> ActionResult {
+        guard isActionAvailable else { return actionResult }
         defer { handleDebounce(skipDebounce) }
 
         isActionAvailable = false
@@ -114,6 +115,7 @@ extension NavigationCoordinator {
             genericError.errorMessage = error.description
             genericError.isPresented = true
         }
+        return actionResult
     }
 }
 

--- a/ios/PolkadotVault/Screens/Containers/AuthenticatedScreenContainer.swift
+++ b/ios/PolkadotVault/Screens/Containers/AuthenticatedScreenContainer.swift
@@ -82,7 +82,7 @@ struct AuthenticatedScreenContainer: View {
         ) {
             ErrorBottomModal(
                 viewModel: .alertError(message: navigation.genericError.errorMessage),
-                dismissAction: navigation.perform(navigation: .init(action: .goBack)),
+                dismissAction: viewModel.onDismissErrorTap(),
                 isShowingBottomAlert: $navigation.genericError.isPresented
             )
             .clearModalBackground()
@@ -105,6 +105,10 @@ extension AuthenticatedScreenContainer {
             self.modalFactory = modalFactory
             self.mainScreenFactory = mainScreenFactory
             navigation.perform(navigation: .init(action: .start))
+        }
+
+        func onDismissErrorTap() {
+            navigation.perform(navigation: .init(action: .goBack))
         }
     }
 }

--- a/ios/PolkadotVault/Screens/Factories/ModalFactory.swift
+++ b/ios/PolkadotVault/Screens/Factories/ModalFactory.swift
@@ -11,8 +11,6 @@ final class ModalFactory {
     @ViewBuilder
     func modal(for modalData: ModalData?) -> some View {
         switch modalData {
-        case let .sufficientCryptoReady(value):
-            SignSpecDetails(viewModel: .init(content: value))
         case let .newSeedBackup(value):
             CreateKeySetSeedPhraseView(viewModel: .init(dataModel: value))
         case let .selectSeed(value):
@@ -34,6 +32,7 @@ final class ModalFactory {
             .networkSelector,
             .manageMetadata,
             .networkDetailsMenu,
+            .sufficientCryptoReady,
             nil:
             EmptyView()
         }

--- a/ios/PolkadotVault/Screens/Settings/Subviews/SignSpecs/SignSpecDetailsView.swift
+++ b/ios/PolkadotVault/Screens/Settings/Subviews/SignSpecs/SignSpecDetailsView.swift
@@ -136,10 +136,14 @@ extension SignSpecDetails {
         var content: MSufficientCryptoReady
         private weak var navigation: NavigationCoordinator!
 
+        @Binding var isPresented: Bool
+
         init(
-            content: MSufficientCryptoReady
+            content: MSufficientCryptoReady,
+            isPresented: Binding<Bool>
         ) {
             self.content = content
+            _isPresented = isPresented
         }
 
         func use(navigation: NavigationCoordinator) {
@@ -147,6 +151,7 @@ extension SignSpecDetails {
         }
 
         func onBackTap() {
+            isPresented = false
             navigation.perform(navigation: .init(action: .goBack))
         }
     }

--- a/ios/PolkadotVault/Screens/Settings/Subviews/SignSpecs/SignSpecEnterPasswordModal.swift
+++ b/ios/PolkadotVault/Screens/Settings/Subviews/SignSpecs/SignSpecEnterPasswordModal.swift
@@ -1,0 +1,224 @@
+//
+//  SignSpecEnterPasswordModal.swift
+//  PolkadotVault
+//
+//  Created by Krzysztof Rodak on 27/03/2023.
+//
+
+import SwiftUI
+
+struct SignSpecEnterPasswordModal: View {
+    @EnvironmentObject private var navigation: NavigationCoordinator
+    @StateObject var viewModel: ViewModel
+    @FocusState var focusedField: SecurePrimaryTextField.Field?
+    @State var animateBackground: Bool = false
+    @Environment(\.safeAreaInsets) private var safeAreaInsets
+
+    var body: some View {
+        FullScreenRoundedModal(
+            backgroundTapAction: {
+                viewModel.onCancelTap()
+            },
+            animateBackground: $animateBackground,
+            ignoredEdges: .top
+        ) {
+            VStack(spacing: Spacing.medium) {
+                HStack {
+                    Button(
+                        action: viewModel.onCancelTap
+                    ) {
+                        Asset.xmarkButtonMedium.swiftUIImage
+                            .foregroundColor(Asset.textAndIconsSecondary.swiftUIColor)
+                            .frame(
+                                width: Heights.navigationButton,
+                                height: Heights.navigationButton,
+                                alignment: .center
+                            )
+                    }
+                    .padding(.leading, Spacing.extraExtraSmall)
+                    Spacer()
+                    CapsuleButton(
+                        action: viewModel.onDoneTap,
+                        title: Localizable.Transaction.EnterPassword.Action.done.string,
+                        isDisabled: $viewModel.isActionDisabled
+                    )
+                }
+                .padding(.top, -Spacing.extraSmall)
+                .padding(.horizontal, Spacing.extraSmall)
+                VStack(alignment: .leading, spacing: 0) {
+                    Localizable.Transaction.EnterPassword.Label.title.text
+                        .font(PrimaryFont.titleL.font)
+                        .foregroundColor(Asset.textAndIconsPrimary.swiftUIColor)
+                        .padding(.bottom, Spacing.extraSmall)
+                    keyComponent()
+                        .padding(.top, Spacing.medium)
+                    SecurePrimaryTextField(
+                        placeholder: Localizable.Transaction.EnterPassword.Label.placeholder.string,
+                        text: $viewModel.password,
+                        isValid: $viewModel.isValid,
+                        focusedField: _focusedField,
+                        onCommit: { viewModel.onDoneTap() }
+                    )
+                    .padding(.top, Spacing.medium)
+                    Group {
+                        if !viewModel.isValid {
+                            Localizable.Transaction.EnterPassword.Label.invalidPassword.text
+                                .foregroundColor(Asset.accentRed300.swiftUIColor)
+                        }
+                        Localizable.Transaction.EnterPassword.Label.explanation.text
+                            .foregroundColor(Asset.textAndIconsTertiary.swiftUIColor)
+                    }
+                    .font(PrimaryFont.captionM.font)
+                    .padding(.top, Spacing.extraSmall)
+                    .padding(.bottom, Spacing.small)
+                }
+                .padding(.horizontal, Spacing.large)
+            }
+            .background(Asset.backgroundTertiary.swiftUIColor)
+            .onAppear {
+                viewModel.use(navigation: navigation)
+                focusedField = .secure
+            }
+        }
+    }
+
+    @ViewBuilder
+    func keyComponent() -> some View {
+        HStack {
+            VStack(alignment: .leading, spacing: Spacing.extraExtraSmall) {
+                renderablePath
+                    .foregroundColor(Asset.textAndIconsTertiary.swiftUIColor)
+                    .font(PrimaryFont.captionM.font)
+                Text(viewModel.dataModel.authorInfo.address.seedName)
+                    .foregroundColor(Asset.textAndIconsPrimary.swiftUIColor)
+                    .font(PrimaryFont.bodyM.font)
+                HStack {
+                    Text(
+                        viewModel.dataModel.authorInfo.base58
+                            .truncateMiddle()
+                    )
+                    .foregroundColor(Asset.textAndIconsTertiary.swiftUIColor)
+                    .font(PrimaryFont.bodyM.font)
+                }
+            }
+            Spacer()
+            NetworkIdenticon(
+                identicon: viewModel.dataModel.authorInfo.address.identicon,
+                network: viewModel.dataModel.networkInfo?.networkLogo,
+                background: Asset.accentRed300Overlay.swiftUIColor,
+                size: Heights.identiconInCell
+            )
+        }
+        .padding(Spacing.small)
+        .containerBackground(state: .error)
+    }
+
+    /// Manual string interpolation for `lock` `SFSymbol`
+    private var renderablePath: Text {
+        Text(
+            // swiftlint:disable:next line_length
+            "\(viewModel.dataModel.authorInfo.address.path)\(Localizable.Shared.Label.passwordedPathDelimeter.string)\(Image(.lock))"
+        )
+    }
+}
+
+extension SignSpecEnterPasswordModal {
+    final class ViewModel: ObservableObject {
+        private weak var navigation: NavigationCoordinator!
+        @Binding var isPresented: Bool
+        @Binding var shouldPresentError: Bool
+        @Binding var dataModel: MEnterPassword
+        @Binding var detailsContent: MSufficientCryptoReady?
+
+        @Published var password: String = ""
+        @Published var isActionDisabled: Bool = true
+        @Published var isValid: Bool = true
+        private var cancelBag = CancelBag()
+
+        init(
+            isPresented: Binding<Bool>,
+            shouldPresentError: Binding<Bool>,
+            dataModel: Binding<MEnterPassword>,
+            detailsContent: Binding<MSufficientCryptoReady?>
+        ) {
+            _isPresented = isPresented
+            _shouldPresentError = shouldPresentError
+            _dataModel = dataModel
+            _detailsContent = detailsContent
+            subscribeToUpdates()
+        }
+
+        func use(navigation: NavigationCoordinator) {
+            self.navigation = navigation
+        }
+
+        func onCancelTap() {
+            isPresented = false
+        }
+
+        func onErrorDismiss() {
+            isPresented = false
+        }
+
+        func onDoneTap() {
+            let actionResult = navigation.performFake(navigation: .init(action: .goForward, details: password))
+            switch actionResult.modalData {
+            case let .enterPassword(value):
+                dataModel = value
+                isValid = false
+            case let .sufficientCryptoReady(value):
+                detailsContent = value
+                isPresented = false
+                shouldPresentError = false
+            default:
+                proceedtoErrorState()
+            }
+        }
+
+        private func proceedtoErrorState() {
+            isPresented = false
+            shouldPresentError = true
+        }
+
+        private func subscribeToUpdates() {
+            $password.sink { newValue in
+                self.isActionDisabled = newValue.isEmpty
+            }
+            .store(in: cancelBag)
+        }
+    }
+}
+
+struct SignSpecEnterPasswordModal_Previews: PreviewProvider {
+    static var previews: some View {
+        SignSpecEnterPasswordModal(
+            viewModel: .init(
+                isPresented: Binding<Bool>.constant(true),
+                shouldPresentError: Binding<Bool>.constant(false),
+                dataModel: Binding<MEnterPassword>.constant(
+                    .init(
+                        authorInfo: .init(
+                            base58: PreviewData.base58,
+                            addressKey: "01e143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e",
+                            address: .init(
+                                path: "//polkadot",
+                                hasPwd: true,
+                                identicon: .svg(image: PreviewData.exampleIdenticon),
+                                seedName: "Parity Keys",
+                                secretExposed: true
+                            )
+                        ),
+                        networkInfo: MscNetworkInfo(
+                            networkTitle: "Polkadot",
+                            networkLogo: "polkadot",
+                            networkSpecsKey: "sr25519"
+                        ),
+                        counter: 2
+                    )
+                ),
+                detailsContent: .constant(nil)
+            )
+        )
+        .environmentObject(NavigationCoordinator())
+    }
+}


### PR DESCRIPTION
## Purpose
This PR introduces support for signing network specs and metadata with passworded keys

## Screenshots

| Example |  |
|-|-|
|<img src="https://user-images.githubusercontent.com/1955364/227984765-ea1e521d-2380-49cb-b4a0-333bc39babde.gif" width="320px">|<img src="" width="320px">|
|<img src="https://user-images.githubusercontent.com/1955364/227985236-41ada201-17d3-47b3-8f6a-3a46af091e97.gif" width="320px">|<img src="" width="320px">|
|<img src="https://user-images.githubusercontent.com/1955364/227985283-93987309-62f2-4fe3-a3b1-d1452d711c54.gif" width="320px">|<img src="" width="320px">|
