### PR TITLE
fix: android text input workaround 

### DIFF
--- a/android/src/main/java/io/parity/signer/bottomsheets/password/EnterPassword.kt
+++ b/android/src/main/java/io/parity/signer/bottomsheets/password/EnterPassword.kt
@@ -91,7 +91,9 @@ fun EnterPassword(
 				visualTransformation = if (passwordVisible) VisualTransformation.None else PasswordVisualTransformation(),
 				keyboardOptions = KeyboardOptions(
 					keyboardType = KeyboardType.Password,
-					imeAction = if (canProceed) ImeAction.Done else ImeAction.None
+//				fixme #1749 recreation of options leading to first letter dissapearing on some samsung devices
+//				imeAction = if (canProceed) ImeAction.Done else ImeAction.None
+					imeAction = ImeAction.Done
 				),
 				keyboardActions = KeyboardActions(
 					onDone = {

--- a/android/src/main/java/io/parity/signer/screens/createderivation/derivationsubscreens/DerivationPathScreen.kt
+++ b/android/src/main/java/io/parity/signer/screens/createderivation/derivationsubscreens/DerivationPathScreen.kt
@@ -99,7 +99,9 @@ fun DerivationPathScreen(
 			value = path.value, //hide password, add hint
 			onValueChange = { newStr -> path.value = newStr },
 			keyboardOptions = KeyboardOptions(
-				imeAction = if (canProceed) ImeAction.Done else ImeAction.None
+//				fixme #1749 recreation of options leading to first letter dissapearing on some samsung devices
+//				imeAction = if (canProceed) ImeAction.Done else ImeAction.None
+				imeAction = ImeAction.Done
 			),
 			visualTransformation = DerivationPathVisualTransformation(
 				context = LocalContext.current,

--- a/android/src/main/java/io/parity/signer/screens/keysets/create/NewKeySetNameScreen.kt
+++ b/android/src/main/java/io/parity/signer/screens/keysets/create/NewKeySetNameScreen.kt
@@ -78,7 +78,9 @@ fun NewKeySetNameScreen(
 			value = keySetName,
 			onValueChange = { newStr -> keySetName = newStr },
 			keyboardOptions = KeyboardOptions(
-				imeAction = if (canProceed) ImeAction.Done else ImeAction.None
+//				fixme #1749 recreation of options leading to first letter dissapearing on some samsung devices
+//				imeAction = if (canProceed) ImeAction.Done else ImeAction.None
+				imeAction = ImeAction.Done
 			),
 			keyboardActions = KeyboardActions(
 				onDone = {

--- a/android/src/main/java/io/parity/signer/screens/scan/bananasplit/BananaSplitPasswordScreen.kt
+++ b/android/src/main/java/io/parity/signer/screens/scan/bananasplit/BananaSplitPasswordScreen.kt
@@ -160,10 +160,14 @@ private fun BananaSplitPasswordInternal(
 				value = name.value,
 				onValueChange = { newStr -> onChangeSeedName(newStr) },
 				keyboardOptions = KeyboardOptions(
-					imeAction = if (name.value.isNotEmpty() && !nameCollision.value) ImeAction.Go else ImeAction.None
+					//				fixme #1749 recreation of options leading to first letter dissapearing on some samsung devices
+//					imeAction = if (name.value.isNotEmpty() && !nameCollision.value) ImeAction.Go else ImeAction.None
+					imeAction = ImeAction.Go
 				),
 				keyboardActions = KeyboardActions(onGo = {
-					passwordFocusRequester.requestFocus()
+					if (name.value.isNotEmpty() && !nameCollision.value) {
+						passwordFocusRequester.requestFocus()
+					}
 				}),
 				placeholder = { Text(text = stringResource(R.string.banana_split_password_name_label)) },
 				isError = nameCollision.value,
@@ -202,7 +206,9 @@ private fun BananaSplitPasswordInternal(
 				visualTransformation = if (passwordVisible) VisualTransformation.None else PasswordVisualTransformation(),
 				keyboardOptions = KeyboardOptions(
 					keyboardType = KeyboardType.Password,
-					imeAction = if (canProceed) ImeAction.Done else ImeAction.None
+//				fixme #1749 recreation of options leading to first letter dissapearing on some samsung devices
+//				imeAction = if (canProceed) ImeAction.Done else ImeAction.None
+					imeAction = ImeAction.Done
 				),
 				keyboardActions = KeyboardActions(
 					onDone = {


### PR DESCRIPTION
That first letter won't disappear on some devices

Workaround for #1749. Now keyboard icon will always be CTA, With this the issue will have low priority and we can release with it.