### PR TITLE
fix: Android transaction with no logo for network

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,8 +12,8 @@ android {
 		applicationId "io.parity.signer"
 		minSdk 23
 		targetSdk 33
-		versionCode 60100
-		versionName "6.1.0"
+		versionCode 60102
+		versionName "6.1.2"
 		ndk {
 			abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
 		}

--- a/android/src/main/java/io/parity/signer/components/AutosizeText.kt
+++ b/android/src/main/java/io/parity/signer/components/AutosizeText.kt
@@ -91,19 +91,21 @@ fun AutoSizeText(
 
 		check(targetWidth.isFinite || maxFontSize.isSpecified) { "maxFontSize must be specified if the target with isn't finite!" }
 
-		with(LocalDensity.current) {
-			// this loop will attempt to quickly find the correct size font by scaling it by the error
-			// it only runs if the max font size isn't specified or the font must be smaller
-			// minIntrinsicWidth is "The width for text if all soft wrap opportunities were taken."
-			if (maxFontSize.isUnspecified || targetWidth < intrinsics.minIntrinsicWidth.toDp())
-				while ((targetWidth - intrinsics.minIntrinsicWidth.toDp()).toPx().absoluteValue.toDp() > acceptableError / 2f) {
-					shrunkFontSize *= targetWidth.toPx() / intrinsics.minIntrinsicWidth
+		if (text.isNotEmpty()) {
+			with(LocalDensity.current) {
+				// this loop will attempt to quickly find the correct size font by scaling it by the error
+				// it only runs if the max font size isn't specified or the font must be smaller
+				// minIntrinsicWidth is "The width for text if all soft wrap opportunities were taken."
+				if (maxFontSize.isUnspecified || targetWidth < intrinsics.minIntrinsicWidth.toDp())
+					while ((targetWidth - intrinsics.minIntrinsicWidth.toDp()).toPx().absoluteValue.toDp() > acceptableError / 2f) {
+						shrunkFontSize *= targetWidth.toPx() / intrinsics.minIntrinsicWidth
+						intrinsics = calculateIntrinsics()
+					}
+				// checks if the text fits in the bounds and scales it by 90% until it does
+				while (intrinsics.didExceedMaxLines || maxHeight < intrinsics.height.toDp() || maxWidth < intrinsics.minIntrinsicWidth.toDp()) {
+					shrunkFontSize *= 0.9f
 					intrinsics = calculateIntrinsics()
 				}
-			// checks if the text fits in the bounds and scales it by 90% until it does
-			while (intrinsics.didExceedMaxLines || maxHeight < intrinsics.height.toDp() || maxWidth < intrinsics.minIntrinsicWidth.toDp()) {
-				shrunkFontSize *= 0.9f
-				intrinsics = calculateIntrinsics()
 			}
 		}
 

--- a/android/src/main/java/io/parity/signer/components/Networklabel.kt
+++ b/android/src/main/java/io/parity/signer/components/Networklabel.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import io.parity.signer.components.base.SignerDivider
 import io.parity.signer.components.networkicon.NetworkIcon
 import io.parity.signer.ui.theme.SignerNewTheme
 import io.parity.signer.ui.theme.SignerTypeface
@@ -61,8 +62,10 @@ fun NetworkLabelWithIcon(networkName: String,
 @Composable
 private fun PreviewNetworkLabelWithIcon() {
 	SignerNewTheme {
-		Column() {
+		Column {
 			NetworkLabelWithIcon("kusama", "kusama", 24.dp, SignerTypeface.BodyM)
+			SignerDivider()
+			NetworkLabelWithIcon("kusama", "", 24.dp, SignerTypeface.BodyM)
 		}
 	}
 }

--- a/android/src/main/java/io/parity/signer/components/networkicon/NetworkIcon.kt
+++ b/android/src/main/java/io/parity/signer/components/networkicon/NetworkIcon.kt
@@ -61,13 +61,11 @@ private fun UnknownNetworkIcon(
 			.background(networkColors.background, CircleShape),
 		contentAlignment = Alignment.Center
 	) {
-		if (chars.isNotEmpty()) {
-			AutoSizeText(
-				text = chars,
-				fontWeight = FontWeight.Bold,
-				color = networkColors.text,
-			)
-		}
+		AutoSizeText(
+			text = chars,
+			fontWeight = FontWeight.Bold,
+			color = networkColors.text,
+		)
 	}
 }
 
@@ -220,7 +218,6 @@ private fun getResourceIdForNetwork(networkName: String) =
 		"zeitgeist" -> R.drawable.network_zeitgeist
 		else -> -1
 	}
-
 
 
 @Preview(

--- a/android/src/main/java/io/parity/signer/components/networkicon/NetworkIcon.kt
+++ b/android/src/main/java/io/parity/signer/components/networkicon/NetworkIcon.kt
@@ -61,11 +61,13 @@ private fun UnknownNetworkIcon(
 			.background(networkColors.background, CircleShape),
 		contentAlignment = Alignment.Center
 	) {
-		AutoSizeText(
-			text = chars,
-			fontWeight = FontWeight.Bold,
-			color = networkColors.text,
-		)
+		if (chars.isNotEmpty()) {
+			AutoSizeText(
+				text = chars,
+				fontWeight = FontWeight.Bold,
+				color = networkColors.text,
+			)
+		}
 	}
 }
 
@@ -220,6 +222,26 @@ private fun getResourceIdForNetwork(networkName: String) =
 	}
 
 
+
+@Preview(
+	name = "light", group = "themes", uiMode = Configuration.UI_MODE_NIGHT_NO,
+	showBackground = true, backgroundColor = 0xFFFFFFFF,
+)
+@Preview(
+	name = "dark", group = "themes", uiMode = Configuration.UI_MODE_NIGHT_YES,
+	showBackground = true, backgroundColor = 0xFF000000,
+)
+@Composable
+private fun PreviewEmptyIcon() {
+	SignerNewTheme {
+		Column(
+			horizontalAlignment = Alignment.CenterHorizontally,
+		) {
+			NetworkIcon("")
+		}
+	}
+}
+
 @Preview(
 	name = "light", group = "themes", uiMode = Configuration.UI_MODE_NIGHT_NO,
 	showBackground = true, backgroundColor = 0xFFFFFFFF,
@@ -268,3 +290,6 @@ private fun PreviewNetworkIconUnknownIcons() {
 		}
 	}
 }
+
+
+

--- a/android/src/main/java/io/parity/signer/domain/UnifiiStubs.kt
+++ b/android/src/main/java/io/parity/signer/domain/UnifiiStubs.kt
@@ -7,7 +7,7 @@ import io.parity.signer.uniffi.*
 
 object UnifiiStubs {
 	/**
-	 * sample of import netowork from Talisman
+	 * sample of add netowork specs from Talisman
 	 */
 	fun makeTransactionStubList(): List<MTransaction> {
 		return listOf<MTransaction>(
@@ -78,6 +78,91 @@ object UnifiiStubs {
 							0.toUInt(), 0.toUInt(), Card.VerifierCard(
 								f = MVerifierDetails(
 									publicKey = "b04b58ffedd058a81a625819d437d7a35485c63cfac9fc9f0907c16b3e3e9d6c",
+									identicon = SignerImage.Png((PreviewData.exampleIdenticonPng as ImageContent.Png).image),
+									encryption = Encryption.SR25519.toString(),
+								)
+							)
+						)
+					),
+					warning = null,
+					typesInfo = null,
+				),
+				ttype = TransactionType.STUB,
+				authorInfo = null,
+				networkInfo = null,
+			)
+		)
+	}
+
+	fun makeTransactionAddNetworksNovasamaStub(): List<MTransaction> {
+		return listOf<MTransaction>(
+			MTransaction(
+				content = TransactionCardSet(
+					author = null,
+					error = null,
+					extensions = null,
+					importingDerivations = null,
+					message = null,
+					meta = null,
+					method = null,
+					newSpecs = listOf(
+						TransactionCard(
+							1.toUInt(), indent = 0.toUInt(),
+							card = Card.NewSpecsCard(
+								f = NetworkSpecs(
+									base58prefix = 5u.toUShort(),
+									color = "#660D35",
+									encryption = Encryption.SR25519,
+									decimals = 18.toUByte(),
+									genesisHash = listOf(
+										158,
+										183,
+										108,
+										81,
+										132,
+										196,
+										171,
+										134,
+										121,
+										210,
+										213,
+										216,
+										25,
+										253,
+										249,
+										11,
+										156,
+										0,
+										20,
+										3,
+										233,
+										225,
+										125,
+										162,
+										225,
+										75,
+										109,
+										138,
+										236,
+										64,
+										41,
+										198
+									).map { it.toUByte() },
+									logo = "astar",
+									name = "astar",
+									pathId = "#262626",
+									secondaryColor = "#262626",
+									title = "astar-sr25519",
+									unit = "ASTR",
+								)
+							),
+						),
+					),
+					verifier = listOf(
+						TransactionCard(
+							0.toUInt(), 0.toUInt(), Card.VerifierCard(
+								f = MVerifierDetails(
+									publicKey = "16d5a6266345874d8f5b7f88a6619711b2829b52b2865826b1ecefb62beef34f",
 									identicon = SignerImage.Png((PreviewData.exampleIdenticonPng as ImageContent.Png).image),
 									encryption = Encryption.SR25519.toString(),
 								)

--- a/android/src/main/java/io/parity/signer/domain/UnifiiStubs.kt
+++ b/android/src/main/java/io/parity/signer/domain/UnifiiStubs.kt
@@ -1,0 +1,95 @@
+package io.parity.signer.domain
+
+import io.parity.signer.ui.helpers.PreviewData
+import io.parity.signer.uniffi.*
+
+
+object UnifiiStubs {
+	/**
+	 * sample of import netowork from Talisman
+	 */
+	fun makeTransactionStubList(): List<MTransaction> {
+		return listOf<MTransaction>(
+			MTransaction(
+				content = TransactionCardSet(
+					author = null,
+					error = null,
+					extensions = null,
+					importingDerivations = null,
+					message = null,
+					meta = null,
+					method = null,
+					newSpecs = listOf(
+						TransactionCard(
+							1.toUInt(), indent = 0.toUInt(),
+							card = Card.NewSpecsCard(
+								f = NetworkSpecs(
+									base58prefix = 5u.toUShort(),
+									color = "#03b0fb",
+									encryption = Encryption.SR25519,
+									decimals = 18.toUByte(),
+									genesisHash = listOf(
+										158,
+										183,
+										108,
+										81,
+										132,
+										196,
+										171,
+										134,
+										121,
+										210,
+										213,
+										216,
+										25,
+										253,
+										249,
+										11,
+										156,
+										0,
+										20,
+										3,
+										233,
+										225,
+										125,
+										162,
+										225,
+										75,
+										109,
+										138,
+										236,
+										64,
+										41,
+										198
+									).map { it.toUByte() },
+									logo = "",
+									name = "astar",
+									pathId = "//astar",
+									secondaryColor = "#000000",
+									title = "Astar",
+									unit = "ASTR",
+								)
+							),
+						),
+					),
+					verifier = listOf(
+						TransactionCard(
+							0.toUInt(), 0.toUInt(), Card.VerifierCard(
+								f = MVerifierDetails(
+									publicKey = "b04b58ffedd058a81a625819d437d7a35485c63cfac9fc9f0907c16b3e3e9d6c",
+									identicon = SignerImage.Png((PreviewData.exampleIdenticonPng as SignerImage.Png).image),
+									encryption = Encryption.SR25519.toString(),
+								)
+							)
+						)
+					),
+					warning = null,
+					typesInfo = null,
+				),
+				ttype = TransactionType.STUB,
+				authorInfo = null,
+				networkInfo = null,
+			)
+		)
+	}
+}

--- a/android/src/main/java/io/parity/signer/domain/UnifiiStubs.kt
+++ b/android/src/main/java/io/parity/signer/domain/UnifiiStubs.kt
@@ -1,5 +1,6 @@
 package io.parity.signer.domain
 
+import io.parity.signer.components.ImageContent
 import io.parity.signer.ui.helpers.PreviewData
 import io.parity.signer.uniffi.*
 
@@ -77,7 +78,7 @@ object UnifiiStubs {
 							0.toUInt(), 0.toUInt(), Card.VerifierCard(
 								f = MVerifierDetails(
 									publicKey = "b04b58ffedd058a81a625819d437d7a35485c63cfac9fc9f0907c16b3e3e9d6c",
-									identicon = SignerImage.Png((PreviewData.exampleIdenticonPng as SignerImage.Png).image),
+									identicon = SignerImage.Png((PreviewData.exampleIdenticonPng as ImageContent.Png).image),
 									encryption = Encryption.SR25519.toString(),
 								)
 							)

--- a/android/src/main/java/io/parity/signer/screens/scan/ScanNavSubgraph.kt
+++ b/android/src/main/java/io/parity/signer/screens/scan/ScanNavSubgraph.kt
@@ -12,7 +12,6 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import io.parity.signer.R
 import io.parity.signer.bottomsheets.password.EnterPassword
 import io.parity.signer.components.panels.CameraParentSingleton
-import io.parity.signer.components.panels.toAction
 import io.parity.signer.domain.FakeNavigator
 import io.parity.signer.domain.Navigator
 import io.parity.signer.screens.scan.bananasplit.BananaSplitPasswordScreen

--- a/android/src/main/java/io/parity/signer/screens/scan/transaction/TransactionsScreenFull.kt
+++ b/android/src/main/java/io/parity/signer/screens/scan/transaction/TransactionsScreenFull.kt
@@ -328,7 +328,7 @@ private fun MTransaction.shouldShowAsSummaryTransaction(): Boolean {
 @Composable
 private fun PreviewTransactionsScreenFull() {
 	SignerNewTheme {
-		val transaction = UnifiiStubs.makeTransactionAddNetworksNovasamaStub()
+		val transaction = UnifiiStubs.makeTransactionStubList()
 		TransactionsScreenFull(transaction, null, Modifier, {}, {}, {})
 	}
 }

--- a/android/src/main/java/io/parity/signer/screens/scan/transaction/TransactionsScreenFull.kt
+++ b/android/src/main/java/io/parity/signer/screens/scan/transaction/TransactionsScreenFull.kt
@@ -328,7 +328,7 @@ private fun MTransaction.shouldShowAsSummaryTransaction(): Boolean {
 @Composable
 private fun PreviewTransactionsScreenFull() {
 	SignerNewTheme {
-		val transaction = UnifiiStubs.makeTransactionStubList()
+		val transaction = UnifiiStubs.makeTransactionAddNetworksNovasamaStub()
 		TransactionsScreenFull(transaction, null, Modifier, {}, {}, {})
 	}
 }

--- a/android/src/main/java/io/parity/signer/screens/scan/transaction/TransactionsScreenFull.kt
+++ b/android/src/main/java/io/parity/signer/screens/scan/transaction/TransactionsScreenFull.kt
@@ -1,5 +1,6 @@
 package io.parity.signer.screens.scan.transaction
 
+import android.content.res.Configuration
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -15,6 +16,7 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.parity.signer.R
 import io.parity.signer.components.base.PrimaryButtonWide
@@ -23,17 +25,17 @@ import io.parity.signer.components.base.SecondaryButtonWide
 import io.parity.signer.components.qrcode.AnimatedQrKeysInfo
 import io.parity.signer.components.qrcode.EmptyQrCodeProvider
 import io.parity.signer.domain.Callback
+import io.parity.signer.domain.UnifiiStubs
 import io.parity.signer.domain.getData
 import io.parity.signer.domain.submitErrorState
 import io.parity.signer.screens.scan.errors.TransactionErrorEmbedded
 import io.parity.signer.screens.scan.transaction.components.TransactionElementSelector
 import io.parity.signer.screens.scan.transaction.components.TransactionSummaryView
 import io.parity.signer.screens.scan.transaction.components.toSigningTransactionModels
+import io.parity.signer.ui.theme.SignerNewTheme
 import io.parity.signer.ui.theme.SignerTypeface
 import io.parity.signer.ui.theme.backgroundPrimary
-import io.parity.signer.uniffi.MSignatureReady
-import io.parity.signer.uniffi.MTransaction
-import io.parity.signer.uniffi.TransactionType
+import io.parity.signer.uniffi.*
 
 
 /**
@@ -129,7 +131,9 @@ private fun getTransactionsTitle(
 		is TransactionPreviewType.AddNetwork -> stringResource(R.string.transactions_title_network)
 		is TransactionPreviewType.Metadata -> stringResource(R.string.transactions_title_metadata)
 		TransactionPreviewType.Transfer, TransactionPreviewType.Unknown -> pluralStringResource(
-			id = R.plurals.transactions_title_other, transactionsCount, transactionsCount
+			id = R.plurals.transactions_title_other,
+			transactionsCount,
+			transactionsCount
 		)
 	}
 }
@@ -180,8 +184,8 @@ private fun QrSignatureData(signature: MSignatureReady) {
 		input = signature.signatures.map { it.getData() },
 		provider = EmptyQrCodeProvider(),
 		modifier = Modifier
-            .fillMaxWidth(1f)
-            .padding(horizontal = 24.dp)
+			.fillMaxWidth(1f)
+			.padding(horizontal = 24.dp)
 	)
 }
 
@@ -215,15 +219,15 @@ private fun ActionButtons(
 			PrimaryButtonWide(
 				label = stringResource(R.string.transaction_action_approve),
 				modifier = Modifier
-                    .padding(horizontal = 24.dp)
-                    .padding(top = 32.dp, bottom = 8.dp),
+					.padding(horizontal = 24.dp)
+					.padding(top = 32.dp, bottom = 8.dp),
 				onClicked = { onApprove() },
 			)
 			SecondaryButtonWide(
 				label = stringResource(R.string.transaction_action_decline),
 				modifier = Modifier
-                    .padding(horizontal = 24.dp)
-                    .padding(bottom = 32.dp),
+					.padding(horizontal = 24.dp)
+					.padding(bottom = 32.dp),
 				onClicked = onBack,
 			)
 		}
@@ -240,15 +244,15 @@ private fun ActionButtons(
 			PrimaryButtonWide(
 				label = stringResource(R.string.transaction_action_import_keys),
 				modifier = Modifier
-                    .padding(horizontal = 24.dp)
-                    .padding(top = 32.dp, bottom = 8.dp),
+					.padding(horizontal = 24.dp)
+					.padding(top = 32.dp, bottom = 8.dp),
 				onClicked = onImportKeys,
 			)
 			SecondaryButtonWide(
 				label = stringResource(R.string.transaction_action_decline),
 				modifier = Modifier
-                    .padding(horizontal = 24.dp)
-                    .padding(bottom = 32.dp),
+					.padding(horizontal = 24.dp)
+					.padding(bottom = 32.dp),
 				onClicked = onBack,
 			)
 		}
@@ -308,5 +312,23 @@ private fun MTransaction.shouldShowAsSummaryTransaction(): Boolean {
 		TransactionType.IMPORT_DERIVATIONS -> {
 			return false
 		}
+	}
+}
+
+
+@Preview(
+	name = "light", group = "general", uiMode = Configuration.UI_MODE_NIGHT_NO,
+	showBackground = true, backgroundColor = 0xB0FFFFFF,
+)
+@Preview(
+	name = "dark", group = "general",
+	uiMode = Configuration.UI_MODE_NIGHT_YES,
+	showBackground = true, backgroundColor = 0xFF000000,
+)
+@Composable
+private fun PreviewTransactionsScreenFull() {
+	SignerNewTheme {
+		val transaction = UnifiiStubs.makeTransactionStubList()
+		TransactionsScreenFull(transaction, null, Modifier, {}, {}, {})
 	}
 }

--- a/android/src/main/java/io/parity/signer/screens/scan/transaction/transactionElements/TCAddNetwork.kt
+++ b/android/src/main/java/io/parity/signer/screens/scan/transaction/transactionElements/TCAddNetwork.kt
@@ -84,7 +84,7 @@ fun TCAddNetwork(specs: NetworkSpecs) {
 				)
 				Spacer(modifier = Modifier.weight(1f))
 				NetworkLabelWithIcon(
-					networkName = specs.logo.capitalize(),
+					networkName = specs.name.capitalize(),
 					networkLogo = specs.logo,
 				)
 			}


### PR DESCRIPTION
## Purpose
fix #1782

## Scope
- Network logo was broken for empty network logo value - was infinitly scaling up autosize text to fill all space in logo.
- created previews for affected transactions 
- increased version number to do hotfix

note - 60101 was uploaded for testing play store integration script and is skipped version.

I will cherry pick this fix to 6.1.0 branch and release from there.