### PR TITLE
feat: ios: create key set native navigation

### DIFF
--- a/ios/PolkadotVault.xcodeproj/project.pbxproj
+++ b/ios/PolkadotVault.xcodeproj/project.pbxproj
@@ -235,6 +235,8 @@
 		6DC909F629C87C8C00AE6BAD /* LogsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DC909F529C87C8C00AE6BAD /* LogsService.swift */; };
 		6DC9C486294B7F57000E6899 /* NetworkSelectionSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DC9C485294B7F57000E6899 /* NetworkSelectionSettings.swift */; };
 		6DCC572728D8C0490014278A /* BackupModal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DCC572628D8C0490014278A /* BackupModal.swift */; };
+		6DD4A6A429E9404200FA6746 /* CreateKeySetService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DD4A6A329E9404200FA6746 /* CreateKeySetService.swift */; };
+		6DD4A6A629E9480700FA6746 /* KeyListService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DD4A6A529E9480700FA6746 /* KeyListService.swift */; };
 		6DD860E8299CAD140000D81E /* OnboadingAirgapView+Components.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DD860E7299CAD140000D81E /* OnboadingAirgapView+Components.swift */; };
 		6DD860EA299CED3F0000D81E /* AirgapMediator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DD860E9299CED3F0000D81E /* AirgapMediator.swift */; };
 		6DD9FF1628C8B85300FB6195 /* HorizontalActionsBottomModal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DD9FF1528C8B85300FB6195 /* HorizontalActionsBottomModal.swift */; };
@@ -556,6 +558,8 @@
 		6DC909F529C87C8C00AE6BAD /* LogsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogsService.swift; sourceTree = "<group>"; };
 		6DC9C485294B7F57000E6899 /* NetworkSelectionSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkSelectionSettings.swift; sourceTree = "<group>"; };
 		6DCC572628D8C0490014278A /* BackupModal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupModal.swift; sourceTree = "<group>"; };
+		6DD4A6A329E9404200FA6746 /* CreateKeySetService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateKeySetService.swift; sourceTree = "<group>"; };
+		6DD4A6A529E9480700FA6746 /* KeyListService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyListService.swift; sourceTree = "<group>"; };
 		6DD860E4299CAAA70000D81E /* OnboardingAirgapView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnboardingAirgapView.swift; sourceTree = "<group>"; };
 		6DD860E7299CAD140000D81E /* OnboadingAirgapView+Components.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OnboadingAirgapView+Components.swift"; sourceTree = "<group>"; };
 		6DD860E9299CED3F0000D81E /* AirgapMediator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AirgapMediator.swift; sourceTree = "<group>"; };
@@ -973,6 +977,8 @@
 				6DC909F529C87C8C00AE6BAD /* LogsService.swift */,
 				6DA9DAE629E57BE7009CC12C /* ManageNetworksService.swift */,
 				6DA9DAE829E5831C009CC12C /* ManageNetworkDetailsService.swift */,
+				6DD4A6A329E9404200FA6746 /* CreateKeySetService.swift */,
+				6DD4A6A529E9480700FA6746 /* KeyListService.swift */,
 			);
 			path = Backend;
 			sourceTree = "<group>";
@@ -2227,6 +2233,7 @@
 				6DDEF11C28AE2DF3004CA2FD /* TabViewModelBuilder.swift in Sources */,
 				6DBE12D828B3A80A005F3CCC /* KeySetList.swift in Sources */,
 				6DB9903B295EA7DE001101DC /* ActionableInfoBoxView.swift in Sources */,
+				6DD4A6A429E9404200FA6746 /* CreateKeySetService.swift in Sources */,
 				6D220A2C2963DBC300122DA8 /* EnterBananaSplitPasswordModal.swift in Sources */,
 				6DA2ACB0293A17DF00AAEADC /* Address+DisplayablePath.swift in Sources */,
 				6D2D244D28CE55A000862726 /* String+Utilities.swift in Sources */,
@@ -2250,6 +2257,7 @@
 				6DF3CFEC29936F41002DF203 /* EnterKeySetNameView.swift in Sources */,
 				6DF91F4029C06B70000A6BB2 /* VerifierValue+Show.swift in Sources */,
 				6D2D245228CE5F2D00862726 /* KeyDetailsPublicKeyView.swift in Sources */,
+				6DD4A6A629E9480700FA6746 /* KeyListService.swift in Sources */,
 				6D95E97328B4F42300E28A11 /* ActionButton.swift in Sources */,
 				2DAA829D27885A67002917C0 /* TCMeta.swift in Sources */,
 				6D2779CA28B3E58600570055 /* KeySetListViewModelBuilder.swift in Sources */,
@@ -2386,7 +2394,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -2442,7 +2450,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
@@ -2469,7 +2477,7 @@
 				INFOPLIST_FILE = PolkadotVault/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.finance";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2504,7 +2512,7 @@
 				INFOPLIST_FILE = PolkadotVault/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.finance";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2534,7 +2542,7 @@
 				DEVELOPMENT_TEAM = 4GK8JWU7P9;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				INFOPLIST_FILE = PolkadotVaultTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2559,7 +2567,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 4GK8JWU7P9;
 				INFOPLIST_FILE = PolkadotVaultTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/ios/PolkadotVault/Backend/CreateKeySetService.swift
+++ b/ios/PolkadotVault/Backend/CreateKeySetService.swift
@@ -1,0 +1,40 @@
+//
+//  CreateKeySetService.swift
+//  PolkadotVault
+//
+//  Created by Krzysztof Rodak on 14/04/2023.
+//
+
+import Foundation
+
+final class CreateKeySetService {
+    private let navigation: NavigationCoordinator
+
+    init(
+        navigation: NavigationCoordinator = NavigationCoordinator()
+    ) {
+        self.navigation = navigation
+    }
+
+    func createKeySet(_ isFirstKeySet: Bool, seedName: String) -> MNewSeedBackup! {
+        navigation.performFake(navigation: .init(action: .start))
+        navigation.performFake(navigation: .init(action: .navbarKeys))
+        // We need to call this conditionally, as if there are no seeds,
+        // Rust does not expect `rightButtonAction` called before `addSeed` / `recoverSeed`
+        if !isFirstKeySet {
+            navigation.performFake(navigation: .init(action: .rightButtonAction))
+        }
+        navigation.performFake(navigation: .init(action: .newSeed))
+        guard case let .newSeedBackup(value) = navigation
+            .performFake(navigation: .init(action: .goForward, details: seedName)).modalData else { return nil }
+        return value
+    }
+
+    func confirmKeySetCreation(_ seedPhrase: String) {
+        navigation.performFake(navigation: .init(
+            action: .goForward,
+            details: BackendConstants.true,
+            seedPhrase: seedPhrase
+        ))
+    }
+}

--- a/ios/PolkadotVault/Backend/KeyListService.swift
+++ b/ios/PolkadotVault/Backend/KeyListService.swift
@@ -1,0 +1,25 @@
+//
+//  KeyListService.swift
+//  PolkadotVault
+//
+//  Created by Krzysztof Rodak on 14/04/2023.
+//
+
+import Foundation
+
+final class KeyListService {
+    private let navigation: NavigationCoordinator
+
+    init(
+        navigation: NavigationCoordinator = NavigationCoordinator()
+    ) {
+        self.navigation = navigation
+    }
+
+    func getKeyList() -> MSeeds! {
+        navigation.performFake(navigation: .init(action: .start))
+        guard case let .seedSelector(value) = navigation
+            .performFake(navigation: .init(action: .navbarKeys)).screenData else { return nil }
+        return value
+    }
+}

--- a/ios/PolkadotVault/Screens/Factories/MainScreensFactory.swift
+++ b/ios/PolkadotVault/Screens/Factories/MainScreensFactory.swift
@@ -27,8 +27,6 @@ final class MainScreensFactory {
             } else {
                 EmptyView()
             }
-        case .newSeed:
-            EnterKeySetNameView(viewModel: .init())
         case let .recoverSeedName(value):
             RecoverKeySetNameView(viewModel: .init(content: value))
         case let .recoverSeedPhrase(value):
@@ -38,6 +36,7 @@ final class MainScreensFactory {
         // Screens handled outside of Rust navigation
         case .documents,
              .selectSeedForBackup,
+             .newSeed,
              .vVerifier,
              .scan,
              .transaction,

--- a/ios/PolkadotVault/Screens/KeyDetails/Views/KeyDetails+ViewModel.swift
+++ b/ios/PolkadotVault/Screens/KeyDetails/Views/KeyDetails+ViewModel.swift
@@ -186,24 +186,22 @@ extension KeyDetailsView.ViewModel {
 extension KeyDetailsView.ViewModel {
     func onActionSheetDismissal() {
         let isAlertVisible = warningStateMediator.alert
-        DispatchQueue.main.async {
-            if self.shouldPresentRemoveConfirmationModal {
-                self.shouldPresentRemoveConfirmationModal.toggle()
-                self.isShowingRemoveConfirmation.toggle()
+        if shouldPresentRemoveConfirmationModal {
+            shouldPresentRemoveConfirmationModal.toggle()
+            isShowingRemoveConfirmation.toggle()
+        }
+        if shouldPresentBackupModal {
+            shouldPresentBackupModal.toggle()
+            if isAlertVisible {
+                isPresentingConnectivityAlert.toggle()
+            } else {
+                updateBackupModel()
+                isShowingBackupModal = true
             }
-            if self.shouldPresentBackupModal {
-                self.shouldPresentBackupModal.toggle()
-                if isAlertVisible {
-                    self.isPresentingConnectivityAlert.toggle()
-                } else {
-                    self.updateBackupModel()
-                    self.isShowingBackupModal = true
-                }
-            }
-            if self.shouldPresentSelectionOverlay {
-                self.shouldPresentSelectionOverlay.toggle()
-                self.isPresentingSelectionOverlay.toggle()
-            }
+        }
+        if shouldPresentSelectionOverlay {
+            shouldPresentSelectionOverlay.toggle()
+            isPresentingSelectionOverlay.toggle()
         }
     }
 

--- a/ios/PolkadotVault/Screens/KeyDetails/Views/KeyDetailsView.swift
+++ b/ios/PolkadotVault/Screens/KeyDetails/Views/KeyDetailsView.swift
@@ -75,7 +75,10 @@ struct KeyDetailsView: View {
         }
         .fullScreenCover(
             isPresented: $viewModel.isShowingActionSheet,
-            onDismiss: viewModel.onActionSheetDismissal
+            onDismiss: {
+                // iOS 15 handling of following .fullscreen presentation after dismissal, we need to dispatch this async
+                DispatchQueue.main.async { viewModel.onActionSheetDismissal() }
+            }
         ) {
             KeyDetailsActionsModal(
                 isShowingActionSheet: $viewModel.isShowingActionSheet,
@@ -113,7 +116,10 @@ struct KeyDetailsView: View {
         }
         .fullScreenCover(
             isPresented: $viewModel.isPresentingConnectivityAlert,
-            onDismiss: viewModel.onActionSheetDismissal
+            onDismiss: {
+                // iOS 15 handling of following .fullscreen presentation after dismissal, we need to dispatch this async
+                DispatchQueue.main.async { viewModel.onActionSheetDismissal() }
+            }
         ) {
             ErrorBottomModal(
                 viewModel: connectivityMediator.isConnectivityOn ? .connectivityOn() : .connectivityWasOn(

--- a/ios/PolkadotVault/Screens/KeySetsList/AddKeySetModal.swift
+++ b/ios/PolkadotVault/Screens/KeySetsList/AddKeySetModal.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct AddKeySetModal: View {
     @Binding var isShowingNewSeedMenu: Bool
+    @Binding var shouldShowCreateKeySet: Bool
     @State private var animateBackground: Bool = false
     @EnvironmentObject private var navigation: NavigationCoordinator
 
@@ -30,7 +31,7 @@ struct AddKeySetModal: View {
                     ActionSheetButton(
                         action: {
                             animateDismissal {
-                                navigation.perform(navigation: .init(action: .newSeed))
+                                shouldShowCreateKeySet = true
                             }
                         },
                         icon: Asset.add.swiftUIImage,

--- a/ios/PolkadotVault/Screens/Logs/Views/LogDetailsView.swift
+++ b/ios/PolkadotVault/Screens/Logs/Views/LogDetailsView.swift
@@ -16,8 +16,7 @@ struct LogDetailsView: View {
             NavigationBarView(
                 viewModel: .init(
                     title: Localizable.LogDetails.Label.title.string,
-                    leftButtons: [.init(type: .arrow, action: { mode.wrappedValue.dismiss() })],
-                    rightButtons: []
+                    leftButtons: [.init(type: .arrow, action: { mode.wrappedValue.dismiss() })]
                 )
             )
             Text(viewModel.details.timestamp)

--- a/ios/PolkadotVault/Screens/Logs/Views/LogsListView.swift
+++ b/ios/PolkadotVault/Screens/Logs/Views/LogsListView.swift
@@ -49,7 +49,10 @@ struct LogsListView: View {
         }
         .fullScreenCover(
             isPresented: $viewModel.isShowingActionSheet,
-            onDismiss: { viewModel.onMoreActionSheetDismissal() }
+            onDismiss: {
+                // iOS 15 handling of following .fullscreen presentation after dismissal, we need to dispatch this async
+                DispatchQueue.main.async { viewModel.onMoreActionSheetDismissal() }
+            }
         ) {
             LogsMoreActionsModal(
                 isShowingActionSheet: $viewModel.isShowingActionSheet,

--- a/ios/PolkadotVault/Screens/PublicKey/KeyDetailsPublicKeyView.swift
+++ b/ios/PolkadotVault/Screens/PublicKey/KeyDetailsPublicKeyView.swift
@@ -111,7 +111,10 @@ struct KeyDetailsPublicKeyView: View {
         // Action sheet
         .fullScreenCover(
             isPresented: $viewModel.isShowingActionSheet,
-            onDismiss: viewModel.checkForActionsPresentation
+            onDismiss: {
+                // iOS 15 handling of following .fullscreen presentation after dismissal, we need to dispatch this async
+                DispatchQueue.main.async { viewModel.checkForActionsPresentation() }
+            }
         ) {
             PublicKeyActionsModal(
                 shouldPresentExportKeysWarningModal: $viewModel.shouldPresentExportKeysWarningModal,
@@ -123,7 +126,10 @@ struct KeyDetailsPublicKeyView: View {
         // Export private key warning
         .fullScreenCover(
             isPresented: $viewModel.isPresentingExportKeysWarningModal,
-            onDismiss: viewModel.onWarningDismissal
+            onDismiss: {
+                // iOS 15 handling of following .fullscreen presentation after dismissal, we need to dispatch this async
+                DispatchQueue.main.async { viewModel.onWarningDismissal() }
+            }
         ) {
             ExportPrivateKeyWarningModal(
                 isPresentingExportKeysWarningModal: $viewModel.isPresentingExportKeysWarningModal,
@@ -154,7 +160,10 @@ struct KeyDetailsPublicKeyView: View {
         }
         .fullScreenCover(
             isPresented: $viewModel.isPresentingConnectivityAlert,
-            onDismiss: viewModel.checkForActionsPresentation
+            onDismiss: {
+                // iOS 15 handling of following .fullscreen presentation after dismissal, we need to dispatch this async
+                DispatchQueue.main.async { viewModel.checkForActionsPresentation() }
+            }
         ) {
             ErrorBottomModal(
                 viewModel: connectivityMediator.isConnectivityOn ? .connectivityOn() : .connectivityWasOn(

--- a/ios/PolkadotVault/Screens/Scan/CameraView.swift
+++ b/ios/PolkadotVault/Screens/Scan/CameraView.swift
@@ -144,9 +144,12 @@ struct CameraView: View {
             isPresented: $viewModel.isPresentingEnterBananaSplitPassword,
             onDismiss: {
                 model.start()
+
                 // User entered invalid password too many times, present error
                 if viewModel.shouldPresentError {
-                    viewModel.isPresentingError = true
+                    // iOS 15 handling of following .fullscreen presentation after dismissal, we need to dispatch this
+                    // async
+                    DispatchQueue.main.async { viewModel.isPresentingError = true }
                     return
                 }
                 viewModel.clearTransactionState()
@@ -176,12 +179,16 @@ struct CameraView: View {
                 // User forgot password
                 if viewModel.shouldPresentError {
                     viewModel.presentableError = .signingForgotPassword()
-                    viewModel.isPresentingError = true
+                    // iOS 15 handling of following .fullscreen presentation after dismissal, we need to dispatch this
+                    // async
+                    DispatchQueue.main.async { viewModel.isPresentingError = true }
                     return
                 }
                 // User entered valid password, signature is ready
                 if viewModel.signature != nil {
-                    viewModel.continueWithSignature()
+                    // iOS 15 handling of following .fullscreen presentation after dismissal, we need to dispatch this
+                    // async
+                    DispatchQueue.main.async { viewModel.continueWithSignature() }
                     return
                 }
                 // Dismissed by user

--- a/ios/PolkadotVault/Screens/Settings/SettingsView.swift
+++ b/ios/PolkadotVault/Screens/Settings/SettingsView.swift
@@ -13,8 +13,8 @@ struct SettingsView: View {
     @EnvironmentObject private var appState: AppState
 
     var body: some View {
-        ZStack(alignment: .bottom) {
-            NavigationView {
+        NavigationView {
+            ZStack(alignment: .bottom) {
                 VStack(spacing: 0) {
                     NavigationBarView(
                         viewModel: NavigationBarViewModel(
@@ -46,16 +46,17 @@ struct SettingsView: View {
                                 .padding(.bottom, Spacing.extraSmall)
                         }
                     }
+                    Spacer()
                     TabBarView(
                         selectedTab: $navigation.selectedTab
                     )
                 }
-                .background(Asset.backgroundPrimary.swiftUIColor)
+                .navigationViewStyle(StackNavigationViewStyle())
+                .navigationBarHidden(true)
+                ConnectivityAlertOverlay(viewModel: .init())
             }
-            ConnectivityAlertOverlay(viewModel: .init())
         }
-        .navigationViewStyle(StackNavigationViewStyle())
-        .navigationBarHidden(true)
+        .background(Asset.backgroundPrimary.swiftUIColor)
         .onAppear {
             viewModel.use(navigation: navigation)
             viewModel.use(appState: appState)

--- a/ios/PolkadotVault/Screens/Settings/Subviews/Networks/NetworkSettingsDetails.swift
+++ b/ios/PolkadotVault/Screens/Settings/Subviews/Networks/NetworkSettingsDetails.swift
@@ -121,7 +121,11 @@ struct NetworkSettingsDetails: View {
             }
             .fullScreenCover(
                 isPresented: $viewModel.isShowingActionSheet,
-                onDismiss: { viewModel.onMoreActionSheetDismissal() }
+                onDismiss: {
+                    // iOS 15 handling of following .fullscreen presentation after dismissal, we need to dispatch this
+                    // async
+                    DispatchQueue.main.async { viewModel.onMoreActionSheetDismissal() }
+                }
             ) {
                 NetworkSettingsDetailsActionModal(
                     isShowingActionSheet: $viewModel.isShowingActionSheet,
@@ -380,6 +384,7 @@ extension NetworkSettingsDetails {
         func onMoreActionSheetDismissal() {
             if shouldSignSpecs {
                 signSpecList = networkDetailsService.signSpecList(networkKey)
+                shouldSignSpecs = false
                 isPresentingSignSpecList = true
             }
             if shouldPresentRemoveNetworkConfirmation {


### PR DESCRIPTION
## Purpose
This PR introduces native navigation for Create Key Set interaction

## Scope
- `NavigationView` for create key set interaction
- dedicated services for Key List to fake Rust navigation to get data
- dedicated services for Create Key Set to fake Rust navigation to create key set

## Screenshots

| Example |  |
|-|-|
|<img src="https://user-images.githubusercontent.com/1955364/232495615-2e9b1c99-48a7-4fff-9c58-afcf227d23c5.gif" width="320px">||
