### PR TITLE
feat: ios: native navigation for Restore Key Set flow

### DIFF
--- a/ios/PolkadotVault.xcodeproj/project.pbxproj
+++ b/ios/PolkadotVault.xcodeproj/project.pbxproj
@@ -277,6 +277,7 @@
 		6DF3CFEC29936F41002DF203 /* EnterKeySetNameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DF3CFEB29936F41002DF203 /* EnterKeySetNameView.swift */; };
 		6DF3CFEE299370F7002DF203 /* CreateKeySetSeedPhraseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DF3CFED299370F7002DF203 /* CreateKeySetSeedPhraseView.swift */; };
 		6DF3CFF029937E48002DF203 /* AttributedTintInfoBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DF3CFEF29937E48002DF203 /* AttributedTintInfoBox.swift */; };
+		6DF5543629E952270078B8DC /* RecoverKeySetService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DF5543529E952270078B8DC /* RecoverKeySetService.swift */; };
 		6DF5E7A02922DDAD00F2B5B4 /* MTransaction+TransactionCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DF5E79F2922DDAD00F2B5B4 /* MTransaction+TransactionCards.swift */; };
 		6DF5E7A22923A08A00F2B5B4 /* AttributedString+Markdown.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DF5E7A12923A08A00F2B5B4 /* AttributedString+Markdown.swift */; };
 		6DF5E7A42923DD4400F2B5B4 /* Text+Markdown.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DF5E7A32923DD4400F2B5B4 /* Text+Markdown.swift */; };
@@ -604,6 +605,7 @@
 		6DF3CFEB29936F41002DF203 /* EnterKeySetNameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnterKeySetNameView.swift; sourceTree = "<group>"; };
 		6DF3CFED299370F7002DF203 /* CreateKeySetSeedPhraseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateKeySetSeedPhraseView.swift; sourceTree = "<group>"; };
 		6DF3CFEF29937E48002DF203 /* AttributedTintInfoBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributedTintInfoBox.swift; sourceTree = "<group>"; };
+		6DF5543529E952270078B8DC /* RecoverKeySetService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoverKeySetService.swift; sourceTree = "<group>"; };
 		6DF5E79F2922DDAD00F2B5B4 /* MTransaction+TransactionCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MTransaction+TransactionCards.swift"; sourceTree = "<group>"; };
 		6DF5E7A12923A08A00F2B5B4 /* AttributedString+Markdown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AttributedString+Markdown.swift"; sourceTree = "<group>"; };
 		6DF5E7A32923DD4400F2B5B4 /* Text+Markdown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Text+Markdown.swift"; sourceTree = "<group>"; };
@@ -979,6 +981,7 @@
 				6DA9DAE829E5831C009CC12C /* ManageNetworkDetailsService.swift */,
 				6DD4A6A329E9404200FA6746 /* CreateKeySetService.swift */,
 				6DD4A6A529E9480700FA6746 /* KeyListService.swift */,
+				6DF5543529E952270078B8DC /* RecoverKeySetService.swift */,
 			);
 			path = Backend;
 			sourceTree = "<group>";
@@ -2058,6 +2061,7 @@
 				6D850BE2292F85F200BA9017 /* SecuredTextField.swift in Sources */,
 				2DA5F87627566D7C00D8DD29 /* TransactionPreview.swift in Sources */,
 				6D7129252952C3D50048558C /* VerticalRoundedBackgroundContainer.swift in Sources */,
+				6DF5543629E952270078B8DC /* RecoverKeySetService.swift in Sources */,
 				6D03118F2937269100C38F61 /* TransactionErrorsView.swift in Sources */,
 				6D88CFF228C60AED001FB0A1 /* FullScreenRoundedModal.swift in Sources */,
 				6DD9FF1928C8C9B000FB6195 /* Animations.swift in Sources */,

--- a/ios/PolkadotVault/Backend/RecoverKeySetService.swift
+++ b/ios/PolkadotVault/Backend/RecoverKeySetService.swift
@@ -1,0 +1,45 @@
+//
+//  RecoverKeySetService.swift
+//  PolkadotVault
+//
+//  Created by Krzysztof Rodak on 18/04/2023.
+//
+
+import Foundation
+
+final class RecoverKeySetService {
+    private let navigation: NavigationCoordinator
+
+    init(
+        navigation: NavigationCoordinator = NavigationCoordinator()
+    ) {
+        self.navigation = navigation
+    }
+
+    func recoverKeySetStart(_ isFirstKeySet: Bool) -> MRecoverSeedName! {
+        navigation.performFake(navigation: .init(action: .start))
+        navigation.performFake(navigation: .init(action: .navbarKeys))
+        // We need to call this conditionally, as if there are no seeds,
+        // Rust does not expect `rightButtonAction` called before `addSeed` / `recoverSeed`
+        if !isFirstKeySet {
+            navigation.performFake(navigation: .init(action: .rightButtonAction))
+        }
+        guard case let .recoverSeedName(value) = navigation.performFake(navigation: .init(action: .recoverSeed))
+            .screenData else { return nil }
+        return value
+    }
+
+    func continueKeySetRecovery(_ seedName: String) -> MRecoverSeedPhrase! {
+        guard case let .recoverSeedPhrase(value) = navigation
+            .performFake(navigation: .init(action: .goForward, details: seedName)).screenData else { return nil }
+        return value
+    }
+
+    func finishKeySetRecover(_ seedPhrase: String) {
+        navigation.performFake(navigation: .init(
+            action: .goForward,
+            details: BackendConstants.true,
+            seedPhrase: seedPhrase
+        ))
+    }
+}

--- a/ios/PolkadotVault/Screens/DerivedKey/Subviews/DerivationPathNameView.swift
+++ b/ios/PolkadotVault/Screens/DerivedKey/Subviews/DerivationPathNameView.swift
@@ -308,11 +308,11 @@ extension DerivationPathNameView {
                 .map { validators -> Bool in
                     let (isPassworded, isPasswordValid, derivationPathError) = validators
                     if isPassworded {
-                        return (
+                        return
                             !isPasswordValid ||
-                                !self.isPasswordConfirmationValid() ||
-                                self.derivationPathError != nil
-                        )
+                            !self.isPasswordConfirmationValid() ||
+                            self.derivationPathError != nil
+
                     } else {
                         return derivationPathError != nil || self.isInitialEntry()
                     }

--- a/ios/PolkadotVault/Screens/Factories/MainScreensFactory.swift
+++ b/ios/PolkadotVault/Screens/Factories/MainScreensFactory.swift
@@ -27,16 +27,14 @@ final class MainScreensFactory {
             } else {
                 EmptyView()
             }
-        case let .recoverSeedName(value):
-            RecoverKeySetNameView(viewModel: .init(content: value))
-        case let .recoverSeedPhrase(value):
-            RecoverKeySetSeedPhraseView(viewModel: .init(content: value))
         case .deriveKey:
             CreateDerivedKeyView(viewModel: .init())
         // Screens handled outside of Rust navigation
         case .documents,
              .selectSeedForBackup,
              .newSeed,
+             .recoverSeedName,
+             .recoverSeedPhrase,
              .vVerifier,
              .scan,
              .transaction,

--- a/ios/PolkadotVault/Screens/KeySetsList/AddKeySetModal.swift
+++ b/ios/PolkadotVault/Screens/KeySetsList/AddKeySetModal.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct AddKeySetModal: View {
     @Binding var isShowingNewSeedMenu: Bool
     @Binding var shouldShowCreateKeySet: Bool
+    @Binding var shouldShowRecoverKeySet: Bool
     @State private var animateBackground: Bool = false
     @EnvironmentObject private var navigation: NavigationCoordinator
 
@@ -40,7 +41,7 @@ struct AddKeySetModal: View {
                     ActionSheetButton(
                         action: {
                             animateDismissal {
-                                navigation.perform(navigation: .init(action: .recoverSeed))
+                                shouldShowRecoverKeySet = true
                             }
                         },
                         icon: Asset.recover.swiftUIImage,

--- a/ios/PolkadotVault/Screens/KeySetsList/KeySetList.swift
+++ b/ios/PolkadotVault/Screens/KeySetsList/KeySetList.swift
@@ -16,6 +16,8 @@ struct KeySetList: View {
     @State private var isShowingMoreMenu = false
     @State private var isExportKeysSelected = false
     @State private var shouldShowCreateKeySet = false
+    @State private var shouldShowRecoverKeySet = false
+    @State private var isShowingRecoverKeySet = false
 
     @State var selectedItems: [KeySetViewModel] = []
 
@@ -73,11 +75,6 @@ struct KeySetList: View {
                         ConnectivityAlertOverlay(viewModel: .init())
                         PrimaryButton(
                             action: {
-                                // We need to call this conditionally, as if there are no seeds,
-                                // Rust does not expect `rightButtonAction` called before `addSeed` / `recoverSeed`
-                                if !viewModel.listViewModel.list.isEmpty {
-                                    navigation.performFake(navigation: .init(action: .rightButtonAction))
-                                }
                                 isShowingNewSeedMenu.toggle()
                             },
                             text: Localizable.KeySets.Action.add.key
@@ -103,12 +100,21 @@ struct KeySetList: View {
                         shouldShowCreateKeySet = false
                         isShowingCreateKeySet = true
                     }
+                    if shouldShowRecoverKeySet {
+                        shouldShowRecoverKeySet = false
+                        isShowingRecoverKeySet = true
+                    }
+                    if shouldShowRecoverKeySet {
+                        shouldShowRecoverKeySet = false
+                        isShowingRecoverKeySet = true
+                    }
                 }
             }
         ) {
             AddKeySetModal(
                 isShowingNewSeedMenu: $isShowingNewSeedMenu,
-                shouldShowCreateKeySet: $shouldShowCreateKeySet
+                shouldShowCreateKeySet: $shouldShowCreateKeySet,
+                shouldShowRecoverKeySet: $shouldShowRecoverKeySet
             )
             .clearModalBackground()
         }
@@ -117,6 +123,12 @@ struct KeySetList: View {
             onDismiss: viewModel.updateData
         ) {
             EnterKeySetNameView(viewModel: .init(isPresented: $isShowingCreateKeySet))
+        }
+        .fullScreenCover(
+            isPresented: $isShowingRecoverKeySet,
+            onDismiss: viewModel.updateData
+        ) {
+            RecoverKeySetNameView(viewModel: .init(isPresented: $isShowingRecoverKeySet))
         }
         .fullScreenCover(isPresented: $isShowingMoreMenu) {
             KeyListMoreMenuModal(


### PR DESCRIPTION
## Purpose
This PR adds native navigation for Restore Key Set flow and services to fake required Rust navigation state machine transitions

## Screenshots

| Native navigation |  |
|-|-|
|<img src="https://user-images.githubusercontent.com/1955364/233019282-ff890403-2ad8-4e76-8470-ab9019aa01eb.gif" width="320px">||

