### PR TITLE
feat: update qr code color

### DIFF
--- a/rust/constants/src/lib.rs
+++ b/rust/constants/src/lib.rs
@@ -160,7 +160,7 @@ pub const CHUNK_SIZE: u16 = 1072;
 pub const MAIN_COLOR: [u8; 3] = [0x00, 0x00, 0x00];
 
 /// Main color for **dangerous** QR codes (static only, in Vault)
-pub const MAIN_COLOR_DANGER: [u8; 3] = [0xfd, 0x49, 0x35];
+pub const MAIN_COLOR_DANGER: [u8; 3] = [0xf2, 0x72, 0xb6];
 
 /// Background color for QR codes (both static and animated ones)
 pub const BACK_COLOR: [u8; 3] = [0xff, 0xff, 0xff];

--- a/rust/constants/src/lib.rs
+++ b/rust/constants/src/lib.rs
@@ -160,7 +160,7 @@ pub const CHUNK_SIZE: u16 = 1072;
 pub const MAIN_COLOR: [u8; 3] = [0x00, 0x00, 0x00];
 
 /// Main color for **dangerous** QR codes (static only, in Vault)
-pub const MAIN_COLOR_DANGER: [u8; 3] = [0xf2, 0x72, 0xb6];
+pub const MAIN_COLOR_DANGER: [u8; 3] = [0xe6, 0x00, 0x7a];
 
 /// Background color for QR codes (both static and animated ones)
 pub const BACK_COLOR: [u8; 3] = [0xff, 0xff, 0xff];


### PR DESCRIPTION
## Purpose
update color for rust generated sensitive qr color to pink 300 as per new design
This API is used by android only while there is no platform generation


## Screenshots
| Left title, i.e. "Before" | Right title, i.e. "After" |
|-|-|
| ![red_key](https://user-images.githubusercontent.com/11879032/234292557-4a87b1ff-eb73-4d35-bff1-466103a413fe.png) | ![image](https://user-images.githubusercontent.com/11879032/234292249-024f0a8c-15ce-45a5-bcd7-ff13ba539ed4.png) |