### PR TITLE
feat: public key empty derivation placeholder added

### DIFF
--- a/android/src/main/java/io/parity/signer/screens/keydetails/KeyDetailsPublicKeyScreen.kt
+++ b/android/src/main/java/io/parity/signer/screens/keydetails/KeyDetailsPublicKeyScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.parity.signer.R
@@ -174,7 +175,8 @@ private fun BottomKeyPlate(
 					stringResource(R.string.derivation_key_empty_path_placeholder)
 				},
 				style = SignerTypeface.BodyL,
-				color = MaterialTheme.colors.primary
+				color = MaterialTheme.colors.primary,
+				textAlign = TextAlign.End
 			)
 		}
 		SignerDivider(sidePadding = 0.dp)

--- a/android/src/main/java/io/parity/signer/screens/keydetails/KeyDetailsPublicKeyScreen.kt
+++ b/android/src/main/java/io/parity/signer/screens/keydetails/KeyDetailsPublicKeyScreen.kt
@@ -167,9 +167,12 @@ private fun BottomKeyPlate(
 				style = SignerTypeface.BodyL,
 				color = MaterialTheme.colors.textTertiary
 			)
-			Spacer(modifier = Modifier.weight(1f))
+			Spacer(modifier = Modifier.padding(start = 16.dp).weight(1f))
+			val path = model.address.cardBase.path
 			Text(
-				text = model.address.cardBase.path,
+				text = path.ifEmpty {
+					stringResource(R.string.derivation_key_empty_path_placeholder)
+				},
 				style = SignerTypeface.BodyL,
 				color = MaterialTheme.colors.primary
 			)

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -368,8 +368,8 @@
 	<string name="confirm_factory_reset_title">Wipe All Data</string>
 	<string name="confirm_factory_reset_message">Reset the Vault app to factory settings.\nThis operation cannot be reversed!</string>
 	<string name="logs_add_comment_title">Add Note</string>
-    <string name="add_log_note_placeholder">Enter log note</string>
-    <string name="key_details_public_label_network">Network</string>
+	<string name="add_log_note_placeholder">Enter log note</string>
+  <string name="key_details_public_label_network">Network</string>
 	<string name="key_details_public_label_path">Derivation Path</string>
 	<string name="key_details_public_label_keyset">Key Set Name</string>
 


### PR DESCRIPTION
## Purpose
Add placeholder for empty derivation path in key details - same as used for small key items during export et.c.

## Screenshots
| Left title, i.e. "Before" | Right title, i.e. "After" |
|-|-|
| ![image](https://user-images.githubusercontent.com/11879032/234310085-cd06d162-b8bb-4982-bafd-5ebe83f87656.png) | . |

Note - new figma says "path name" - not sure if we need to change references of path to "path name"


