### PR TITLE
feat: ios: native navigation for Sign Sufficient

### DIFF
--- a/ios/PolkadotVault/Backend/ManageNetworkDetailsService.swift
+++ b/ios/PolkadotVault/Backend/ManageNetworkDetailsService.swift
@@ -25,6 +25,7 @@ final class ManageNetworkDetailsService {
         return value
     }
 
+    @discardableResult
     func signSpecList(_ networkKey: String) -> MSignSufficientCrypto! {
         navigation.performFake(navigation: .init(action: .start))
         navigation.performFake(navigation: .init(action: .navbarSettings))
@@ -65,5 +66,12 @@ final class ManageNetworkDetailsService {
         guard case let .nNetworkDetails(value) = navigation
             .performFake(navigation: .init(action: .removeMetadata)).screenData else { return nil }
         return value
+    }
+
+    func restartNavigationState(_ networkKey: String) {
+        navigation.performFake(navigation: .init(action: .start))
+        navigation.performFake(navigation: .init(action: .navbarSettings))
+        navigation.performFake(navigation: .init(action: .manageNetworks))
+        navigation.performFake(navigation: .init(action: .goForward, details: networkKey))
     }
 }

--- a/ios/PolkadotVault/Core/Data/AppState.swift
+++ b/ios/PolkadotVault/Core/Data/AppState.swift
@@ -20,18 +20,15 @@ extension AppState {
         var allNetworks: [MmNetwork] = []
         var selectedNetworks: [MmNetwork] = []
         var verifierDetails: MVerifierDetails!
-        var manageNetworks: MManageNetworks!
 
         init(
             allNetworks: [MmNetwork] = [],
             selectedNetworks: [MmNetwork] = [],
-            verifierDetails: MVerifierDetails! = nil,
-            manageNetworks: MManageNetworks! = nil
+            verifierDetails: MVerifierDetails! = nil
         ) {
             self.allNetworks = allNetworks
             self.selectedNetworks = selectedNetworks
             self.verifierDetails = verifierDetails
-            self.manageNetworks = manageNetworks
         }
     }
 }

--- a/ios/PolkadotVault/Screens/Containers/AuthenticatedScreenContainer.swift
+++ b/ios/PolkadotVault/Screens/Containers/AuthenticatedScreenContainer.swift
@@ -82,7 +82,7 @@ extension AuthenticatedScreenContainer {
         }
 
         func onDismissErrorTap() {
-            navigation.perform(navigation: .init(action: .goBack))
+            navigation.performFake(navigation: .init(action: .goBack))
         }
     }
 }

--- a/ios/PolkadotVault/Screens/Logs/Views/LogEntryView.swift
+++ b/ios/PolkadotVault/Screens/Logs/Views/LogEntryView.swift
@@ -33,7 +33,7 @@ struct LogEntryView: View {
                             .font(PrimaryFont.titleS.font)
                         Spacer()
                         HStack(spacing: 0) {
-                            Text(DateFormatter.hourMinutes(viewModel.renderable.timestamp))
+                            Text(viewModel.renderable.timestamp)
                                 .padding(.leading, Spacing.extraSmall)
                             if viewModel.renderable.type != .basic {
                                 Asset.chevronRight.swiftUIImage

--- a/ios/PolkadotVault/Screens/Settings/SettingsView.swift
+++ b/ios/PolkadotVault/Screens/Settings/SettingsView.swift
@@ -152,9 +152,6 @@ extension SettingsView {
                 detailScreen = .backup
                 isDetailsPresented = true
             case .networks:
-                guard case let .manageNetworks(value) = navigation
-                    .performFake(navigation: .init(action: .manageNetworks)).screenData else { return }
-                appState.userData.manageNetworks = value
                 detailScreen = .networks
                 isDetailsPresented = true
             case .verifier:

--- a/ios/PolkadotVault/Screens/Settings/Subviews/SignSpecs/SignSpecDetailsView.swift
+++ b/ios/PolkadotVault/Screens/Settings/Subviews/SignSpecs/SignSpecDetailsView.swift
@@ -142,6 +142,7 @@ struct SignSpecDetails: View {
 extension SignSpecDetails {
     final class ViewModel: ObservableObject {
         var content: MSufficientCryptoReady
+        private let onComplete: () -> Void
         private weak var navigation: NavigationCoordinator!
         var dismissViewRequest: AnyPublisher<Void, Never> {
             dismissRequest.eraseToAnyPublisher()
@@ -150,9 +151,11 @@ extension SignSpecDetails {
         private let dismissRequest = PassthroughSubject<Void, Never>()
 
         init(
-            content: MSufficientCryptoReady
+            content: MSufficientCryptoReady,
+            onComplete: @escaping () -> Void
         ) {
             self.content = content
+            self.onComplete = onComplete
         }
 
         func use(navigation: NavigationCoordinator) {
@@ -160,8 +163,8 @@ extension SignSpecDetails {
         }
 
         func onBackTap() {
-            navigation.performFake(navigation: .init(action: .goBack))
             dismissRequest.send()
+            onComplete()
         }
     }
 }

--- a/ios/PolkadotVault/Screens/Settings/Subviews/SignSpecs/SignSpecEnterPasswordModal.swift
+++ b/ios/PolkadotVault/Screens/Settings/Subviews/SignSpecs/SignSpecEnterPasswordModal.swift
@@ -153,6 +153,7 @@ extension SignSpecEnterPasswordModal {
         }
 
         func onCancelTap() {
+            navigation.performFake(navigation: .init(action: .goBack))
             isPresented = false
         }
 
@@ -171,6 +172,7 @@ extension SignSpecEnterPasswordModal {
                 isPresented = false
                 shouldPresentError = false
             default:
+                navigation.performFake(navigation: .init(action: .goBack))
                 proceedtoErrorState()
             }
         }


### PR DESCRIPTION
## Purpose
Full support for native navigation for Sign Sufficient functionality.
Previously going back to list and selecting another key was not working, also cancelling password modal would trigger navigation state lock

## Screenshots

| Example |  |
|-|-|
|<img src="https://user-images.githubusercontent.com/1955364/235096754-2eb2eb4c-ef22-4172-8335-39acefc5254b.gif" width="320px">| |
