### PR TITLE
fix: #1846 - Handle removed verifier certificate when there are existing key sets state properly

### DIFF
--- a/ios/PolkadotVault.xcodeproj/project.pbxproj
+++ b/ios/PolkadotVault.xcodeproj/project.pbxproj
@@ -227,7 +227,7 @@
 		6DBF6E2728E44DD700CC959F /* ErrorBottomModal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DBF6E2628E44DD700CC959F /* ErrorBottomModal.swift */; };
 		6DBF6E2928E47EE000CC959F /* ErrorBottomModalViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DBF6E2828E47EE000CC959F /* ErrorBottomModalViewModel.swift */; };
 		6DBF6E4328EACB7B00CC959F /* ConnectivityMediator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DBF6E4228EACB7B00CC959F /* ConnectivityMediator.swift */; };
-		6DBF6E4B28EC51D600CC959F /* GenericError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DBF6E4A28EC51D600CC959F /* GenericError.swift */; };
+		6DBF6E4B28EC51D600CC959F /* NavigationErrorPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DBF6E4A28EC51D600CC959F /* NavigationErrorPresentation.swift */; };
 		6DC0FC98296695D000A45883 /* SeedKeysPreview+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DC0FC97296695D000A45883 /* SeedKeysPreview+Helpers.swift */; };
 		6DC33717295559EA0067284B /* NetworkSettingsDetailsActionModal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DC33716295559EA0067284B /* NetworkSettingsDetailsActionModal.swift */; };
 		6DC33723295ACF2D0067284B /* CornerRadiusModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DC33722295ACF2D0067284B /* CornerRadiusModifier.swift */; };
@@ -561,7 +561,7 @@
 		6DBF6E2628E44DD700CC959F /* ErrorBottomModal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorBottomModal.swift; sourceTree = "<group>"; };
 		6DBF6E2828E47EE000CC959F /* ErrorBottomModalViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorBottomModalViewModel.swift; sourceTree = "<group>"; };
 		6DBF6E4228EACB7B00CC959F /* ConnectivityMediator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityMediator.swift; sourceTree = "<group>"; };
-		6DBF6E4A28EC51D600CC959F /* GenericError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericError.swift; sourceTree = "<group>"; };
+		6DBF6E4A28EC51D600CC959F /* NavigationErrorPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationErrorPresentation.swift; sourceTree = "<group>"; };
 		6DC0FC97296695D000A45883 /* SeedKeysPreview+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SeedKeysPreview+Helpers.swift"; sourceTree = "<group>"; };
 		6DC33716295559EA0067284B /* NetworkSettingsDetailsActionModal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkSettingsDetailsActionModal.swift; sourceTree = "<group>"; };
 		6DC33722295ACF2D0067284B /* CornerRadiusModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CornerRadiusModifier.swift; sourceTree = "<group>"; };
@@ -1554,7 +1554,7 @@
 		6DBF6E4928EC51A700CC959F /* Errors */ = {
 			isa = PBXGroup;
 			children = (
-				6DBF6E4A28EC51D600CC959F /* GenericError.swift */,
+				6DBF6E4A28EC51D600CC959F /* NavigationErrorPresentation.swift */,
 				6DB99036295C160D001101DC /* ConnectivityAlertOverlay.swift */,
 			);
 			path = Errors;
@@ -2168,7 +2168,7 @@
 				6D4F711929F913FC00729610 /* KeyDetailsPublicKeyViewModel.swift in Sources */,
 				2DA5F86A27566C3600D8DD29 /* TCNewSpecs.swift in Sources */,
 				6D2D244F28CE5C1B00862726 /* NavbarActionButton.swift in Sources */,
-				6DBF6E4B28EC51D600CC959F /* GenericError.swift in Sources */,
+				6DBF6E4B28EC51D600CC959F /* NavigationErrorPresentation.swift in Sources */,
 				6D932CE2292E0AF8008AD883 /* View+Placeholder.swift in Sources */,
 				6D850BDE292F7B4D00BA9017 /* EnterPasswordModal.swift in Sources */,
 				2D6A9F84278C8275000DAE64 /* TCNetworkInfo.swift in Sources */,

--- a/ios/PolkadotVault/Backend/KeyListService.swift
+++ b/ios/PolkadotVault/Backend/KeyListService.swift
@@ -16,10 +16,10 @@ final class KeyListService {
         self.navigation = navigation
     }
 
-    func getKeyList() -> MSeeds! {
+    func getKeyList() -> [SeedNameCard] {
         navigation.performFake(navigation: .init(action: .start))
         guard case let .seedSelector(value) = navigation
-            .performFake(navigation: .init(action: .navbarKeys))?.screenData else { return nil }
-        return value
+            .performFake(navigation: .init(action: .navbarKeys))?.screenData else { return [] }
+        return value.seedNameCards
     }
 }

--- a/ios/PolkadotVault/Backend/Navigation/NavigationCoordinator.swift
+++ b/ios/PolkadotVault/Backend/Navigation/NavigationCoordinator.swift
@@ -15,15 +15,14 @@ typealias NavigationRequest = (Navigation) -> Void
 /// We should keep this to minimum
 final class NavigationCoordinator: ObservableObject {
     private let backendActionPerformer: BackendNavigationPerforming
-
-    /// Responsible for presentation of generic error bottom sheet alert component
-    /// Currently error is based on `actionResult.alertData` component when app receives `.errorData(message)` value
-    @Published var genericError = GenericErrorViewModel()
+    @Published var navigationErrorPresentation: NavigationErrorPresentation
 
     init(
-        backendActionPerformer: BackendNavigationPerforming = BackendNavigationAdapter()
+        backendActionPerformer: BackendNavigationPerforming = BackendNavigationAdapter(),
+        navigationErrorPresentation: NavigationErrorPresentation = ServiceLocator.navigationErrorPresentation
     ) {
         self.backendActionPerformer = backendActionPerformer
+        _navigationErrorPresentation = .init(initialValue: navigationErrorPresentation)
     }
 }
 
@@ -40,8 +39,8 @@ extension NavigationCoordinator {
             updateGlobalViews(action)
             return action
         case let .failure(error):
-            genericError.errorMessage = error.description
-            genericError.isPresented = true
+            navigationErrorPresentation.errorMessage = error.description
+            navigationErrorPresentation.isPresented = true
             return nil
         }
     }
@@ -50,8 +49,8 @@ extension NavigationCoordinator {
 private extension NavigationCoordinator {
     func updateGlobalViews(_ actionResult: ActionResult) {
         if case let .errorData(message) = actionResult.alertData {
-            genericError.errorMessage = message
-            genericError.isPresented = true
+            navigationErrorPresentation.errorMessage = message
+            navigationErrorPresentation.isPresented = true
         }
     }
 }

--- a/ios/PolkadotVault/Components/Errors/NavigationErrorPresentation.swift
+++ b/ios/PolkadotVault/Components/Errors/NavigationErrorPresentation.swift
@@ -1,5 +1,5 @@
 //
-//  GenericError.swift
+//  NavigationErrorPresentation.swift
 //  Polkadot Vault
 //
 //  Created by Krzysztof Rodak on 5/10/2022.
@@ -7,7 +7,7 @@
 
 import Foundation
 
-final class GenericErrorViewModel: ObservableObject {
+final class NavigationErrorPresentation: ObservableObject {
     @Published var errorMessage: String = ""
     @Published var isPresented: Bool = false
 }

--- a/ios/PolkadotVault/Core/ServiceLocator.swift
+++ b/ios/PolkadotVault/Core/ServiceLocator.swift
@@ -12,6 +12,10 @@ enum ServiceLocator {
     /// We store this in `ServiceLocator` as singleton, to be able to use it outside SwiftUI views which could use
     /// `@EnvironmentalObject`
     static var bottomSnackbarPresentation: BottomSnackbarPresentation = BottomSnackbarPresentation()
+    /// Responsible for presentation of generic error bottom sheet alert component
+    /// Currently error is based on `actionResult.alertData` component when app receives `.errorData(message)` value
+    static var navigationErrorPresentation: NavigationErrorPresentation = NavigationErrorPresentation()
+
     /// As long as we have `SharedDataModel` as tech debt, we need to have seeds mediator as singleton which is
     /// unfortunate but necessary for now; to be able to use it outside SwiftUI views it can't be `@EnvironmentalObject`
     static var seedsMediator: SeedsMediating = SeedsMediator()

--- a/ios/PolkadotVault/Screens/Containers/AuthenticatedScreenContainer.swift
+++ b/ios/PolkadotVault/Screens/Containers/AuthenticatedScreenContainer.swift
@@ -35,12 +35,12 @@ struct AuthenticatedScreenContainer: View {
             )
         }
         .fullScreenModal(
-            isPresented: $navigation.genericError.isPresented
+            isPresented: $navigation.navigationErrorPresentation.isPresented
         ) {
             ErrorBottomModal(
-                viewModel: .alertError(message: navigation.genericError.errorMessage),
+                viewModel: .alertError(message: navigation.navigationErrorPresentation.errorMessage),
                 dismissAction: viewModel.onDismissErrorTap(),
-                isShowingBottomAlert: $navigation.genericError.isPresented
+                isShowingBottomAlert: $navigation.navigationErrorPresentation.isPresented
             )
             .clearModalBackground()
         }

--- a/ios/PolkadotVault/Screens/KeySetsList/KeySetList.swift
+++ b/ios/PolkadotVault/Screens/KeySetsList/KeySetList.swift
@@ -253,7 +253,7 @@ extension KeySetList {
         private let cancelBag = CancelBag()
         private let modelBuilder: KeySetListViewModelBuilder
         private weak var appState: AppState!
-        @Published var dataModel: MSeeds = .init(seedNameCards: [])
+        @Published var dataModel: [SeedNameCard] = []
         @Published var isShowingKeysExportModal = false
         @Published var listViewModel: KeySetListViewModel = .init(list: [])
         let tabBarViewModel: TabBarView.ViewModel
@@ -280,7 +280,7 @@ extension KeySetList {
             }.store(in: cancelBag)
         }
 
-        func updateView(_ dataModel: MSeeds) {
+        func updateView(_ dataModel: [SeedNameCard]) {
             listViewModel = modelBuilder.build(for: dataModel)
         }
 

--- a/ios/PolkadotVault/Screens/KeySetsList/KeySetListViewModelBuilder.swift
+++ b/ios/PolkadotVault/Screens/KeySetsList/KeySetListViewModelBuilder.swift
@@ -38,9 +38,9 @@ struct KeySetViewModel: Equatable, Identifiable {
 
 /// Builds view model for `KeySetList` table view
 final class KeySetListViewModelBuilder {
-    func build(for seed: MSeeds) -> KeySetListViewModel {
+    func build(for seeds: [SeedNameCard]) -> KeySetListViewModel {
         KeySetListViewModel(
-            list: seed.seedNameCards.map {
+            list: seeds.map {
                 KeySetViewModel(
                     seed: $0,
                     keyName: $0.seedName,

--- a/ios/PolkadotVaultTests/Core/Navigation/NavigationCoordinatorTests.swift
+++ b/ios/PolkadotVaultTests/Core/Navigation/NavigationCoordinatorTests.swift
@@ -63,14 +63,14 @@ final class NavigationCoordinatorTests: XCTestCase {
         let navigationError = NavigationError(message: message)
         let navigation = Navigation(action: .navbarLog)
         backendActionPerformer.performBackendReturnValue = .failure(navigationError)
-        XCTAssertEqual(subject.genericError.isPresented, false)
+        XCTAssertEqual(subject.navigationErrorPresentation.isPresented, false)
 
         // When
         subject.performFake(navigation: navigation)
 
         // Then
-        XCTAssertEqual(subject.genericError.errorMessage, navigationError.description)
-        XCTAssertEqual(subject.genericError.isPresented, true)
+        XCTAssertEqual(subject.navigationErrorPresentation.errorMessage, navigationError.description)
+        XCTAssertEqual(subject.navigationErrorPresentation.isPresented, true)
     }
 }
 

--- a/ios/PolkadotVaultTests/Screens/KeySetList/KeySetListViewModelBuilderTests.swift
+++ b/ios/PolkadotVaultTests/Screens/KeySetList/KeySetListViewModelBuilderTests.swift
@@ -29,7 +29,7 @@ final class KeySetListViewModelBuilderTests: XCTestCase {
         )
 
         // When
-        let result = subject.build(for: MSeeds(seedNameCards: [seedNameCard]))
+        let result = subject.build(for: [seedNameCard])
 
         // Then
         XCTAssertEqual(result.list.first?.seed, seedNameCard)
@@ -51,7 +51,7 @@ final class KeySetListViewModelBuilderTests: XCTestCase {
         )
 
         // When
-        let result = subject.build(for: MSeeds(seedNameCards: [seedNameCard]))
+        let result = subject.build(for: [seedNameCard])
 
         // Then
         XCTAssertEqual(result.list.first?.seed, seedNameCard)
@@ -73,7 +73,7 @@ final class KeySetListViewModelBuilderTests: XCTestCase {
         )
 
         // When
-        let result = subject.build(for: MSeeds(seedNameCards: [seedNameCard]))
+        let result = subject.build(for: [seedNameCard])
 
         // Then
         XCTAssertEqual(result.list.first?.seed, seedNameCard)

--- a/rust/db_handling/src/cold_default.rs
+++ b/rust/db_handling/src/cold_default.rs
@@ -237,8 +237,13 @@ pub fn signer_init_with_cert(database: &sled::Db) -> Result<()> {
 
 /// Initiate Vault database with general verifier set up to `Verifier(None)`.
 ///
+/// Remove any default metadata and network specs from the database.
+///
 /// Function is applied during `Remove general certificate` procedure.
 pub fn signer_init_no_cert(database: &sled::Db) -> Result<()> {
+    use constants::{METATREE, SPECSTREE};
+    database.drop_tree(SPECSTREE)?;
+    database.drop_tree(METATREE)?;
     init_db(database, Verifier { v: None })
 }
 


### PR DESCRIPTION
## Purpose
This PR aims to address issue: #1846

## Scope
- avoid crash when not receiving `MSeeds`
- fix navigation error state rendering for iOS

- remove default networks when general verifier is removed

