### PR TITLE
fix: ios: - #1850 Cannot create/import account with the same name after deletion

### DIFF
--- a/ios/PolkadotVault/Screens/KeyDetails/Views/KeyDetails+ViewModel.swift
+++ b/ios/PolkadotVault/Screens/KeyDetails/Views/KeyDetails+ViewModel.swift
@@ -80,7 +80,7 @@ extension KeyDetailsView {
             warningStateMediator: WarningStateMediator = ServiceLocator.warningStateMediator,
             appState: AppState = ServiceLocator.appState,
             snackbarPresentation: BottomSnackbarPresentation = ServiceLocator.bottomSnackbarPresentation,
-            seedsMediator: SeedsMediating = SeedsMediator()
+            seedsMediator: SeedsMediating = ServiceLocator.seedsMediator
         ) {
             self.keyName = keyName
             self.keysData = keysData


### PR DESCRIPTION
## Purpose
This PR aims to address issue: #1850

## Scope
- fix dependency injection for `SeedsMediator` to use instance from `ServiceLocator` to properly update `seedName` collection