### PR TITLE
fix: ios: #1851 crash on network deletion

### DIFF
--- a/ios/PolkadotVault/Screens/Settings/Subviews/Networks/NetworkSelectionSettings.swift
+++ b/ios/PolkadotVault/Screens/Settings/Subviews/Networks/NetworkSelectionSettings.swift
@@ -50,7 +50,10 @@ struct NetworkSelectionSettings: View {
             }
             NavigationLink(
                 destination: NetworkSettingsDetails(
-                    viewModel: .init(networkKey: viewModel.selectedDetails)
+                    viewModel: .init(
+                        networkKey: viewModel.selectedDetailsKey,
+                        networkDetails: viewModel.selectedDetails
+                    )
                 )
                 .navigationBarHidden(true),
                 isActive: $viewModel.isPresentingDetails
@@ -95,21 +98,26 @@ extension NetworkSelectionSettings {
     final class ViewModel: ObservableObject {
         private let cancelBag = CancelBag()
         private let service: ManageNetworksService
+        private let networkDetailsService: ManageNetworkDetailsService
         @Published var networks: [MmNetwork] = []
-        @Published var selectedDetails: String!
+        @Published var selectedDetailsKey: String!
+        @Published var selectedDetails: MNetworkDetails!
         @Published var isPresentingDetails = false
         @Published var isShowingQRScanner: Bool = false
 
         init(
-            service: ManageNetworksService = ManageNetworksService()
+            service: ManageNetworksService = ManageNetworksService(),
+            networkDetailsService: ManageNetworkDetailsService = ManageNetworkDetailsService()
         ) {
             self.service = service
+            self.networkDetailsService = networkDetailsService
             updateNetworks()
             onDetailsDismiss()
         }
 
         func onTap(_ network: MmNetwork) {
-            selectedDetails = network.key
+            selectedDetailsKey = network.key
+            selectedDetails = networkDetailsService.refreshCurrentNavigationState(network.key)
             isPresentingDetails = true
         }
 

--- a/ios/PolkadotVault/Screens/Settings/Subviews/Networks/NetworkSettingsDetails.swift
+++ b/ios/PolkadotVault/Screens/Settings/Subviews/Networks/NetworkSettingsDetails.swift
@@ -331,13 +331,14 @@ extension NetworkSettingsDetails {
 
         init(
             networkKey: String,
+            networkDetails: MNetworkDetails,
             snackbarPresentation: BottomSnackbarPresentation = ServiceLocator.bottomSnackbarPresentation,
             networkDetailsService: ManageNetworkDetailsService = ManageNetworkDetailsService()
         ) {
             self.networkKey = networkKey
             self.snackbarPresentation = snackbarPresentation
             self.networkDetailsService = networkDetailsService
-            _networkDetails = .init(initialValue: networkDetailsService.refreshCurrentNavigationState(networkKey))
+            _networkDetails = .init(initialValue: networkDetails)
             listenToNavigationUpdates()
         }
 
@@ -396,6 +397,7 @@ extension NetworkSettingsDetails {
         }
 
         func removeNetwork() {
+            isPresentingRemoveNetworkConfirmation = false
             snackbarPresentation.viewModel = .init(
                 title: Localizable.Settings.NetworkDetails.DeleteNetwork.Label
                     .confirmation(networkDetails.title),
@@ -411,10 +413,13 @@ extension NetworkSettingsDetails {
         }
 
         private func updateView() {
-            networkDetails = networkDetailsService.refreshCurrentNavigationState(networkKey)
+            guard let updatedNetworkDetails = networkDetailsService.refreshCurrentNavigationState(networkKey)
+            else { return }
+            networkDetails = updatedNetworkDetails
         }
 
         private func listenToNavigationUpdates() {
+            guard cancelBag.subscriptions.isEmpty else { return }
             $isPresentingSignSpecList.sink { [weak self] isPresentingSignSpecList in
                 guard let self = self, !isPresentingSignSpecList else { return }
                 self.signSpecList = nil


### PR DESCRIPTION
## Purpose
This PR aims to address issue: #1851 

## Scope
With native navigation and modal dismissal, we need to update how we pass data to ViewModel initialisation for network details, to not trigger it on remove network confirmation modal
