### PR TITLE
fix: ios: #1852 Present snackbar only in context of current screen, not generic view modifiers

### DIFF
--- a/ios/PolkadotVault/Components/Modals/FullscreenModal.swift
+++ b/ios/PolkadotVault/Components/Modals/FullscreenModal.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct FullscreenModal<ModalContent: View>: ViewModifier {
-    @ObservedObject var snackBarPresentation = ServiceLocator.bottomSnackbarPresentation
     @Binding var isPresented: Bool
     let onDismiss: () -> Void
     let modalContent: () -> ModalContent
@@ -16,10 +15,6 @@ struct FullscreenModal<ModalContent: View>: ViewModifier {
     func body(content: Content) -> some View {
         content
             .fullScreenCover(isPresented: $isPresented, onDismiss: onDismiss, content: modalContent)
-            .bottomSnackbar(
-                snackBarPresentation.viewModel,
-                isPresented: $snackBarPresentation.isSnackbarPresented
-            )
     }
 }
 

--- a/ios/PolkadotVault/Core/ServiceLocator.swift
+++ b/ios/PolkadotVault/Core/ServiceLocator.swift
@@ -9,9 +9,6 @@ import Foundation
 
 /// We use this anti-pattern to work around some limitations of both SwiftUI and old architecture in the app
 enum ServiceLocator {
-    /// We store this in `ServiceLocator` as singleton, to be able to use it outside SwiftUI views which could use
-    /// `@EnvironmentalObject`
-    static var bottomSnackbarPresentation: BottomSnackbarPresentation = BottomSnackbarPresentation()
     /// As long as we have `SharedDataModel` as tech debt, we need to have seeds mediator as singleton which is
     /// unfortunate but necessary for now; to be able to use it outside SwiftUI views it can't be `@EnvironmentalObject`
     static var seedsMediator: SeedsMediating = SeedsMediator()

--- a/ios/PolkadotVault/Screens/DerivedKey/CreateKeyNetworkSelectionView.swift
+++ b/ios/PolkadotVault/Screens/DerivedKey/CreateKeyNetworkSelectionView.swift
@@ -133,6 +133,10 @@ struct CreateKeyNetworkSelectionView: View {
 }
 
 extension CreateKeyNetworkSelectionView {
+    enum OnCompletionAction: Equatable {
+        case derivedKeyCreated
+    }
+
     final class ViewModel: ObservableObject {
         private let cancelBag = CancelBag()
         private let networkService: GetAllNetworksService
@@ -151,17 +155,20 @@ extension CreateKeyNetworkSelectionView {
         }
 
         private let dismissRequest = PassthroughSubject<Void, Never>()
+        private let onCompletion: (OnCompletionAction) -> Void
 
         init(
             seedName: String,
             keyName: String,
             networkService: GetAllNetworksService = GetAllNetworksService(),
-            createKeyService: CreateDerivedKeyService = CreateDerivedKeyService()
+            createKeyService: CreateDerivedKeyService = CreateDerivedKeyService(),
+            onCompletion: @escaping (OnCompletionAction) -> Void
         ) {
             self.seedName = seedName
             self.keyName = keyName
             self.networkService = networkService
             self.createKeyService = createKeyService
+            self.onCompletion = onCompletion
             updateNetworks()
             listenToChanges()
         }
@@ -177,6 +184,7 @@ extension CreateKeyNetworkSelectionView {
         }
 
         func onKeyCreationComplete() {
+            onCompletion(.derivedKeyCreated)
             dismissRequest.send()
         }
 
@@ -211,7 +219,8 @@ private extension CreateKeyNetworkSelectionView.ViewModel {
             CreateKeyNetworkSelectionView(
                 viewModel: .init(
                     seedName: "seedName",
-                    keyName: "keyName"
+                    keyName: "keyName",
+                    onCompletion: { _ in }
                 )
             )
         }

--- a/ios/PolkadotVault/Screens/DerivedKey/Subviews/CreateDerivedKeyConfirmationView.swift
+++ b/ios/PolkadotVault/Screens/DerivedKey/Subviews/CreateDerivedKeyConfirmationView.swift
@@ -77,7 +77,6 @@ struct CreateDerivedKeyConfirmationView: View {
 
 extension CreateDerivedKeyConfirmationView {
     final class ViewModel: ObservableObject {
-        private let snackbarPresentation: BottomSnackbarPresentation
         private let onCompletion: () -> Void
         @Published var animateBackground: Bool = false
         @Published var isActionDisabled: Bool = true
@@ -87,11 +86,9 @@ extension CreateDerivedKeyConfirmationView {
 
         init(
             derivationPath: String,
-            snackbarPresentation: BottomSnackbarPresentation = ServiceLocator.bottomSnackbarPresentation,
             onCompletion: @escaping () -> Void
         ) {
             self.derivationPath = derivationPath
-            self.snackbarPresentation = snackbarPresentation
             self.onCompletion = onCompletion
         }
 
@@ -104,11 +101,7 @@ extension CreateDerivedKeyConfirmationView {
         }
 
         func confirmAction() {
-            snackbarPresentation.viewModel = .init(
-                title: Localizable.CreateDerivedKey.Snackbar.created.string,
-                style: .info
-            )
-            snackbarPresentation.isSnackbarPresented = true
+
             onCompletion()
         }
 

--- a/ios/PolkadotVault/Screens/KeyDetails/Views/KeyDetails+ViewModel.swift
+++ b/ios/PolkadotVault/Screens/KeyDetails/Views/KeyDetails+ViewModel.swift
@@ -10,6 +10,10 @@ import Foundation
 import SwiftUI
 
 extension KeyDetailsView {
+    enum OnCompletionAction: Equatable {
+        case keySetDeleted
+    }
+
     enum ViewState {
         case emptyState
         case list
@@ -23,7 +27,6 @@ extension KeyDetailsView {
 
         private let exportPrivateKeyService: PrivateKeyQRCodeService
         private let keyDetailsActionsService: KeyDetailsActionService
-        private let snackbarPresentation: BottomSnackbarPresentation
         private let seedsMediator: SeedsMediating
         let keyName: String
         /// `MKwysNew` will currently be `nil` when navigating through given navigation path:
@@ -56,6 +59,8 @@ extension KeyDetailsView {
         @Published var presentableError: ErrorBottomModalViewModel = .noNetworksAvailable()
         @Published var viewState: ViewState = .list
         @Published var backupModal: BackupModalViewModel?
+        var snackbarViewModel: SnackbarViewModel = .init(title: "")
+        @Published var isSnackbarPresented: Bool = false
 
         // Derive New Key
         @Published var isPresentingDeriveNewKey: Bool = false
@@ -66,7 +71,7 @@ extension KeyDetailsView {
         }
 
         private let dismissRequest = PassthroughSubject<Void, Never>()
-
+        private let onCompletion: (OnCompletionAction) -> Void
         /// Name of seed to be removed with `Remove Seed` action
         private var removeSeed: String = ""
 
@@ -79,8 +84,8 @@ extension KeyDetailsView {
             keyDetailsActionsService: KeyDetailsActionService = KeyDetailsActionService(),
             warningStateMediator: WarningStateMediator = ServiceLocator.warningStateMediator,
             appState: AppState = ServiceLocator.appState,
-            snackbarPresentation: BottomSnackbarPresentation = ServiceLocator.bottomSnackbarPresentation,
-            seedsMediator: SeedsMediating = ServiceLocator.seedsMediator
+            seedsMediator: SeedsMediating = ServiceLocator.seedsMediator,
+            onCompletion: @escaping (OnCompletionAction) -> Void
         ) {
             self.keyName = keyName
             self.keysData = keysData
@@ -90,8 +95,8 @@ extension KeyDetailsView {
             self.keyDetailsActionsService = keyDetailsActionsService
             self.warningStateMediator = warningStateMediator
             self.appState = appState
-            self.snackbarPresentation = snackbarPresentation
             self.seedsMediator = seedsMediator
+            self.onCompletion = onCompletion
             use(appState: appState)
             updateRenderables()
             subscribeToNetworkChanges()
@@ -148,19 +153,37 @@ extension KeyDetailsView {
         func onRemoveKeySetConfirmationTap() {
             let isRemoved = seedsMediator.removeSeed(seedName: removeSeed)
             guard isRemoved else { return }
-
             keyDetailsActionsService.forgetKeySetAction(keyName)
-            // Present snackbar from bottom as action confirmation
-            snackbarPresentation.viewModel = .init(
-                title: Localizable.KeySetsModal.Confirmation.snackbar.string,
-                style: .warning
-            )
-            snackbarPresentation.isSnackbarPresented = true
             dismissRequest.send()
+            onCompletion(.keySetDeleted)
         }
 
         func onRemoveKeySetModalDismiss() {
             keyDetailsActionsService.resetNavigationStateToKeyDetails(keyName)
+        }
+
+        func onPublicKeyCompletion(_ completionAction: KeyDetailsPublicKeyView.OnCompletionAction) {
+            switch completionAction {
+            case .derivedKeyDeleted:
+                refreshData()
+                snackbarViewModel = .init(
+                    title: Localizable.PublicKeyDetailsModal.Confirmation.snackbar.string,
+                    style: .warning
+                )
+                isSnackbarPresented = true
+            }
+        }
+
+        func onAddDerivedKeyCompletion(_ completionAction: CreateKeyNetworkSelectionView.OnCompletionAction) {
+            switch completionAction {
+            case .derivedKeyCreated:
+                refreshData()
+                snackbarViewModel = .init(
+                    title: Localizable.CreateDerivedKey.Snackbar.created.string,
+                    style: .info
+                )
+                isSnackbarPresented = true
+            }
         }
     }
 }

--- a/ios/PolkadotVault/Screens/KeyDetails/Views/KeyDetailsView.swift
+++ b/ios/PolkadotVault/Screens/KeyDetails/Views/KeyDetailsView.swift
@@ -176,12 +176,17 @@ struct KeyDetailsView: View {
                 CreateKeyNetworkSelectionView(viewModel: .init(
                     seedName: viewModel.keysData?.root?.address
                         .seedName ?? "",
-                    keyName: viewModel.keyName
+                    keyName: viewModel.keyName,
+                    onCompletion: viewModel.onAddDerivedKeyCompletion(_:)
                 ))
                 .navigationViewStyle(StackNavigationViewStyle())
                 .navigationBarHidden(true)
             }
         }
+        .bottomSnackbar(
+            viewModel.snackbarViewModel,
+            isPresented: $viewModel.isSnackbarPresented
+        )
     }
 
     var mainList: some View {
@@ -206,7 +211,7 @@ struct KeyDetailsView: View {
                         viewModel: .init(
                             keyDetails: viewModel.presentedKeyDetails,
                             publicKeyDetails: viewModel.presentedPublicKeyDetails,
-                            onCompletion: viewModel.refreshData
+                            onCompletion: viewModel.onPublicKeyCompletion(_:)
                         )
                     )
                     .navigationBarHidden(true),

--- a/ios/PolkadotVault/Screens/KeySetsList/KeySetList.swift
+++ b/ios/PolkadotVault/Screens/KeySetsList/KeySetList.swift
@@ -157,6 +157,10 @@ struct KeySetList: View {
                 isExportKeysSelected.toggle()
             }
         }
+        .bottomSnackbar(
+            viewModel.snackbarViewModel,
+            isPresented: $viewModel.isSnackbarPresented
+        )
     }
 
     func keyList() -> some View {
@@ -172,7 +176,8 @@ struct KeySetList: View {
                         KeyDetailsView(
                             viewModel: .init(
                                 keyName: $0.keyName,
-                                keysData: detailsToPresent
+                                keysData: detailsToPresent,
+                                onCompletion: viewModel.onKeyDetailsCompletion(_:)
                             )
                         )
                         .navigationBarHidden(true),
@@ -258,6 +263,8 @@ extension KeySetList {
         @Published var listViewModel: KeySetListViewModel = .init(list: [])
         let tabBarViewModel: TabBarView.ViewModel
         let keyDetailsService: KeyDetailsService
+        var snackbarViewModel: SnackbarViewModel = .init(title: "")
+        @Published var isSnackbarPresented: Bool = false
 
         init(
             keyDetailsService: KeyDetailsService = KeyDetailsService(),
@@ -294,6 +301,18 @@ extension KeySetList {
             _ completion: @escaping (Result<MKeysNew, ServiceError>) -> Void
         ) {
             keyDetailsService.getKeys(for: seedName, completion)
+        }
+
+        func onKeyDetailsCompletion(_ completionAction: KeyDetailsView.OnCompletionAction) {
+            switch completionAction {
+            case .keySetDeleted:
+                updateData()
+                snackbarViewModel = .init(
+                    title: Localizable.KeySetsModal.Confirmation.snackbar.string,
+                    style: .warning
+                )
+                isSnackbarPresented = true
+            }
         }
     }
 }

--- a/ios/PolkadotVault/Screens/Logs/Views/LogNoteModal.swift
+++ b/ios/PolkadotVault/Screens/Logs/Views/LogNoteModal.swift
@@ -75,6 +75,15 @@ struct LogNoteModal: View {
         .onAppear {
             focused = true
         }
+        .fullScreenModal(
+            isPresented: $viewModel.isPresentingError
+        ) {
+            ErrorBottomModal(
+                viewModel: viewModel.presentableError,
+                isShowingBottomAlert: $viewModel.isPresentingError
+            )
+            .clearModalBackground()
+        }
     }
 }
 
@@ -85,16 +94,15 @@ extension LogNoteModal {
         @Published var isActionDisabled: Bool = true
         private var cancelBag = CancelBag()
         private let logsService: LogsService
-        private let snackBarPresentation: BottomSnackbarPresentation
+        @Published var isPresentingError: Bool = false
+        @Published var presentableError: ErrorBottomModalViewModel = .noNetworksAvailable()
 
         init(
             isPresented: Binding<Bool>,
-            logsService: LogsService = LogsService(),
-            snackBarPresentation: BottomSnackbarPresentation = ServiceLocator.bottomSnackbarPresentation
+            logsService: LogsService = LogsService()
         ) {
             _isPresented = isPresented
             self.logsService = logsService
-            self.snackBarPresentation = snackBarPresentation
             subscribeToUpdates()
         }
 
@@ -109,8 +117,8 @@ extension LogNoteModal {
                 case .success:
                     self.isPresented = false
                 case let .failure(error):
-                    self.snackBarPresentation.viewModel = .init(title: error.description)
-                    self.snackBarPresentation.isSnackbarPresented = true
+                    self.presentableError = .init(title: error.description)
+                    self.isPresentingError = true
                 }
             }
         }

--- a/ios/PolkadotVault/Screens/Logs/Views/LogsListView.swift
+++ b/ios/PolkadotVault/Screens/Logs/Views/LogsListView.swift
@@ -74,6 +74,15 @@ struct LogsListView: View {
             LogNoteModal(viewModel: .init(isPresented: $viewModel.isPresentingAddNoteModal))
                 .clearModalBackground()
         }
+        .fullScreenModal(
+            isPresented: $viewModel.isPresentingError
+        ) {
+            ErrorBottomModal(
+                viewModel: viewModel.presentableError,
+                isShowingBottomAlert: $viewModel.isPresentingError
+            )
+            .clearModalBackground()
+        }
     }
 }
 
@@ -88,17 +97,16 @@ extension LogsListView {
         @Published var isPresentingAddNoteModal = false
         @Published var selectedDetails: MLogDetails!
         @Published var isPresentingDetails = false
+        @Published var isPresentingError: Bool = false
+        @Published var presentableError: ErrorBottomModalViewModel = .noNetworksAvailable()
         private let logsService: LogsService
-        private let snackBarPresentation: BottomSnackbarPresentation
         private let renderableBuilder: LogEntryRenderableBuilder
 
         init(
             logsService: LogsService = LogsService(),
-            snackBarPresentation: BottomSnackbarPresentation = ServiceLocator.bottomSnackbarPresentation,
             renderableBuilder: LogEntryRenderableBuilder = LogEntryRenderableBuilder()
         ) {
             self.logsService = logsService
-            self.snackBarPresentation = snackBarPresentation
             self.renderableBuilder = renderableBuilder
         }
 
@@ -110,8 +118,8 @@ extension LogsListView {
                     self.logs = logs
                     self.renderables = self.renderableBuilder.build(logs)
                 case let .failure(error):
-                    self.snackBarPresentation.viewModel = .init(title: error.description)
-                    self.snackBarPresentation.isSnackbarPresented = true
+                    self.presentableError = .init(title: error.description)
+                    self.isPresentingError = true
                 }
             }
         }
@@ -141,8 +149,8 @@ extension LogsListView {
                     self.isPresentingDetails = true
                 case let .failure(error):
                     self.selectedDetails = nil
-                    self.snackBarPresentation.viewModel = .init(title: error.description)
-                    self.snackBarPresentation.isSnackbarPresented = true
+                    self.presentableError = .init(title: error.description)
+                    self.isPresentingError = true
                 }
             }
         }
@@ -158,8 +166,8 @@ extension LogsListView {
                 case .success:
                     self.loadData()
                 case let .failure(error):
-                    self.snackBarPresentation.viewModel = .init(title: error.description)
-                    self.snackBarPresentation.isSnackbarPresented = true
+                    self.presentableError = .init(title: error.description)
+                    self.isPresentingError = true
                 }
             }
         }

--- a/ios/PolkadotVault/Screens/Settings/Subviews/Networks/NetworkSelectionSettings.swift
+++ b/ios/PolkadotVault/Screens/Settings/Subviews/Networks/NetworkSelectionSettings.swift
@@ -52,7 +52,8 @@ struct NetworkSelectionSettings: View {
                 destination: NetworkSettingsDetails(
                     viewModel: .init(
                         networkKey: viewModel.selectedDetailsKey,
-                        networkDetails: viewModel.selectedDetails
+                        networkDetails: viewModel.selectedDetails,
+                        onCompletion: viewModel.onNetworkDetailsCompletion(_:)
                     )
                 )
                 .navigationBarHidden(true),
@@ -70,6 +71,10 @@ struct NetworkSelectionSettings: View {
                 )
             )
         }
+        .bottomSnackbar(
+            viewModel.snackbarViewModel,
+            isPresented: $viewModel.isSnackbarPresented
+        )
     }
 
     @ViewBuilder
@@ -104,6 +109,8 @@ extension NetworkSelectionSettings {
         @Published var selectedDetails: MNetworkDetails!
         @Published var isPresentingDetails = false
         @Published var isShowingQRScanner: Bool = false
+        var snackbarViewModel: SnackbarViewModel = .init(title: "")
+        @Published var isSnackbarPresented: Bool = false
 
         init(
             service: ManageNetworksService = ManageNetworksService(),
@@ -127,6 +134,18 @@ extension NetworkSelectionSettings {
 
         func onQRScannerDismiss() {
             updateNetworks()
+        }
+
+        func onNetworkDetailsCompletion(_ completionAction: NetworkSettingsDetails.OnCompletionAction) {
+            switch completionAction {
+            case let .networkDeleted(networkTitle):
+                snackbarViewModel = .init(
+                    title: Localizable.Settings.NetworkDetails.DeleteNetwork.Label
+                        .confirmation(networkTitle),
+                    style: .warning
+                )
+                isSnackbarPresented = true
+            }
         }
     }
 }


### PR DESCRIPTION
## Purpose
This PR aims to address issue: #1852

## Discussion
After refactor to native navigation, current snackbar presentation approach needed to be revisited - centralised singleton-style modifier applied on main navigation is no more viable and workaround used to attach snackbar view modifier to full screen modal and main nav resulted in doubled snackbars for some of the flows.
Current solution fully prevents from that as snackbar is applied per-screen basis; moreover presentation logic is now moved to screen that actually is presenting snackbar (i.e. when deleting network from Network Details, Network Selection List will handle presentation based on completion closure called from Network Details)
