### PR TITLE
fix: ios: #1855 - don't proceed with actions if passcode is not provided

### DIFF
--- a/ios/PolkadotVault/Core/Keychain/KeychainAccessAdapter.swift
+++ b/ios/PolkadotVault/Core/Keychain/KeychainAccessAdapter.swift
@@ -42,7 +42,7 @@ protocol KeychainAccessAdapting: AnyObject {
     ///            otherwise `.failure` with `KeychainError`
     func checkIfSeedPhraseAlreadyExists(seedPhrase: Data) -> Result<Bool, KeychainError>
     /// Remove all seeds from Keychain
-    func removeAllSeeds()
+    func removeAllSeeds() -> Bool
 }
 
 final class KeychainAccessAdapter: KeychainAccessAdapting {
@@ -176,8 +176,13 @@ final class KeychainAccessAdapter: KeychainAccessAdapting {
         return .success(false)
     }
 
-    func removeAllSeeds() {
+    func removeAllSeeds() -> Bool {
         let query = queryProvider.query(for: .deleteAll)
-        SecItemDelete(query)
+        let osStatus = SecItemDelete(query)
+        if osStatus == errSecSuccess {
+            return true
+        } else {
+            return false
+        }
     }
 }

--- a/ios/PolkadotVault/Core/Keychain/SeedsMediator.swift
+++ b/ios/PolkadotVault/Core/Keychain/SeedsMediator.swift
@@ -52,9 +52,9 @@ protocol SeedsMediating: AnyObject {
     /// - Parameter seedName: seed name to delete
     func removeSeed(seedName: String) -> Bool
     /// Clear all seeds from Keychain
-    func removeAllSeeds()
-
+    func removeAllSeeds() -> Bool
     func checkSeedPhraseCollision(seedPhrase: String) -> Bool
+    func removeStalledSeeds()
 }
 
 /// Class handling all seeds-related operations that require access to Keychain
@@ -186,8 +186,8 @@ final class SeedsMediator: SeedsMediating {
     }
 
     func removeSeed(seedName: String) -> Bool {
-        refreshSeeds()
-        guard authenticationStateMediator.authenticated else {
+        // Fetch item first, as this will trigger authentication if passcode is not cached
+        guard case .success = keychainAccessAdapter.retrieveSeed(with: seedName) else {
             return false
         }
         let result = keychainAccessAdapter.removeSeed(seedName: seedName)
@@ -203,9 +203,14 @@ final class SeedsMediator: SeedsMediating {
         }
     }
 
-    func removeAllSeeds() {
-        keychainAccessAdapter.removeAllSeeds()
+    func removeAllSeeds() -> Bool {
+        // Fetch seeds first, as this will trigger authentication if passcode is not cached
+        guard case .success = keychainAccessAdapter.retrieveSeeds(with: Set(seedNames)) else {
+            return false
+        }
+        guard keychainAccessAdapter.removeAllSeeds() else { return false }
         seedNames = []
+        return true
     }
 
     func checkSeedPhraseCollision(seedPhrase: String) -> Bool {
@@ -220,6 +225,11 @@ final class SeedsMediator: SeedsMediating {
             authenticationStateMediator.authenticated = false
             return false
         }
+    }
+
+    func removeStalledSeeds() {
+        guard keychainAccessAdapter.removeAllSeeds() else { return false }
+        seedNames = []
     }
 }
 

--- a/ios/PolkadotVault/StateMediators/AppLaunchMediator.swift
+++ b/ios/PolkadotVault/StateMediators/AppLaunchMediator.swift
@@ -35,7 +35,8 @@ final class AppLaunchMediator: ObservableObject, AppLaunchMediating {
     }
 
     private func initialiseFirstRun() {
-        localDataCleanup()
+        seedsMediator.removeStalledSeeds()
+        databaseMediator.wipeDatabase()
     }
 
     private func initialiseOnboardedUserRun() {
@@ -43,12 +44,5 @@ final class AppLaunchMediator: ObservableObject, AppLaunchMediating {
         do {
             try initNavigation(dbname: databaseMediator.databaseName, seedNames: seedsMediator.seedNames)
         } catch {}
-    }
-}
-
-private extension AppLaunchMediator {
-    func localDataCleanup() {
-        seedsMediator.removeAllSeeds()
-        databaseMediator.wipeDatabase()
     }
 }

--- a/ios/PolkadotVault/StateMediators/OnboardingMediator.swift
+++ b/ios/PolkadotVault/StateMediators/OnboardingMediator.swift
@@ -32,20 +32,11 @@ final class OnboardingMediator: ObservableObject {
     }
 
     func onboard(verifierRemoved: Bool = false) {
-        seedsMediator.refreshSeeds()
-        localDataCleanup()
+        guard seedsMediator.removeAllSeeds() else { return }
         databaseMediator.recreateDatabaseFile()
         navigationInitialisationService.initialiseNavigation(verifierRemoved: verifierRemoved)
-        seedsMediator.refreshSeeds()
         onboardingDone = true
         warningStateMediator.updateWarnings()
         initialisationService.initialiseAppSession()
-    }
-}
-
-private extension OnboardingMediator {
-    func localDataCleanup() {
-        seedsMediator.removeAllSeeds()
-        databaseMediator.wipeDatabase()
     }
 }


### PR DESCRIPTION
## Purpose
This PR aims to address issue: #1855

## Scope
Some actions trigger passcode check even though acton itself don't require it (i.e. removing item from keychain does not need passcode, but we fetch seed from keychain before that, just to trigger passcode screen if enough time has passed), hence from user perspective, not providing passcode should be considered action cancellation. 
