### PR TITLE
feat: ios: create keys for networks on key set creation / recovery

### DIFF
--- a/ios/PolkadotVault.xcodeproj/project.pbxproj
+++ b/ios/PolkadotVault.xcodeproj/project.pbxproj
@@ -215,6 +215,7 @@
 		6DB9903B295EA7DE001101DC /* ActionableInfoBoxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DB9903A295EA7DE001101DC /* ActionableInfoBoxView.swift */; };
 		6DB9903D2962A619001101DC /* MTransaction+ImportDerivedKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DB9903C2962A619001101DC /* MTransaction+ImportDerivedKeys.swift */; };
 		6DB9903F2962A97E001101DC /* ImportDerivedKeysService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DB9903E2962A97E001101DC /* ImportDerivedKeysService.swift */; };
+		6DBA658C2A2656CC00F04492 /* CreateKeysForNetworksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DBA658B2A2656CC00F04492 /* CreateKeysForNetworksView.swift */; };
 		6DBBC1F2298CB09C00368638 /* NetworkIdenticon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DBBC1F1298CB09C00368638 /* NetworkIdenticon.swift */; };
 		6DBBC1F4298CB0D700368638 /* ChainIcons.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6DBBC1F3298CB0D700368638 /* ChainIcons.xcassets */; };
 		6DBD21F2289A74EE005D539B /* FileManagingProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DBD21F1289A74EE005D539B /* FileManagingProtocol.swift */; };
@@ -549,6 +550,7 @@
 		6DB9903A295EA7DE001101DC /* ActionableInfoBoxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionableInfoBoxView.swift; sourceTree = "<group>"; };
 		6DB9903C2962A619001101DC /* MTransaction+ImportDerivedKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MTransaction+ImportDerivedKeys.swift"; sourceTree = "<group>"; };
 		6DB9903E2962A97E001101DC /* ImportDerivedKeysService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportDerivedKeysService.swift; sourceTree = "<group>"; };
+		6DBA658B2A2656CC00F04492 /* CreateKeysForNetworksView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateKeysForNetworksView.swift; sourceTree = "<group>"; };
 		6DBBC1F1298CB09C00368638 /* NetworkIdenticon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkIdenticon.swift; sourceTree = "<group>"; };
 		6DBBC1F3298CB0D700368638 /* ChainIcons.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ChainIcons.xcassets; sourceTree = "<group>"; };
 		6DBD21F1289A74EE005D539B /* FileManagingProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManagingProtocol.swift; sourceTree = "<group>"; };
@@ -1505,6 +1507,14 @@
 			path = Data;
 			sourceTree = "<group>";
 		};
+		6DBA658A2A2656B400F04492 /* CreateKeysForNetworks */ = {
+			isa = PBXGroup;
+			children = (
+				6DBA658B2A2656CC00F04492 /* CreateKeysForNetworksView.swift */,
+			);
+			path = CreateKeysForNetworks;
+			sourceTree = "<group>";
+		};
 		6DBD21F5289A7983005D539B /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
@@ -1790,6 +1800,7 @@
 		6DF3CFEA29936D33002DF203 /* CreateKey */ = {
 			isa = PBXGroup;
 			children = (
+				6DBA658A2A2656B400F04492 /* CreateKeysForNetworks */,
 				6DA08B8C29B614F20027CFCB /* RecoverKeySet */,
 				6DA08B8B29B614EA0027CFCB /* NewKeySet */,
 				6DA08B8529AC88D50027CFCB /* WrappingHStack.swift */,
@@ -2119,6 +2130,7 @@
 				2DA5F85F27566C3600D8DD29 /* TCTypesInfo.swift in Sources */,
 				6DC33725295BFA4D0067284B /* RootKeyDetailsModal.swift in Sources */,
 				6D971AC5294229AE00121A36 /* UIFont+Roboto.swift in Sources */,
+				6DBA658C2A2656CC00F04492 /* CreateKeysForNetworksView.swift in Sources */,
 				6DC5643328B68FC5003D540B /* AccessControlProvider.swift in Sources */,
 				6D8045DC28D0840F00237F8C /* MKeyDetails+Helpers.swift in Sources */,
 				6DA2ACAA2939E85700AAEADC /* Event+EventTitle.swift in Sources */,

--- a/ios/PolkadotVault.xcodeproj/project.pbxproj
+++ b/ios/PolkadotVault.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		6D16685D28F5C15C008C664A /* CameraVideoOutputDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D16685C28F5C15C008C664A /* CameraVideoOutputDelegate.swift */; };
 		6D16687D28F84953008C664A /* EnvironmentValues+SafeAreaInsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D16687C28F84953008C664A /* EnvironmentValues+SafeAreaInsets.swift */; };
 		6D16687F28F86DE0008C664A /* CameraButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D16687E28F86DE0008C664A /* CameraButton.swift */; };
+		6D17D2A12A2E7DF70023B3A7 /* ErrorDisplayed+LocalizedDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D17D2A02A2E7DF70023B3A7 /* ErrorDisplayed+LocalizedDescription.swift */; };
 		6D17EF8328EDC951008626E9 /* Encryption+RawRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D17EF8228EDC951008626E9 /* Encryption+RawRepresentable.swift */; };
 		6D17EF8628EEEDDA008626E9 /* CameraPreviewUIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D17EF8528EEEDDA008626E9 /* CameraPreviewUIView.swift */; };
 		6D199C9F292A8D1100E79113 /* TransactionDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D199C9E292A8D1100E79113 /* TransactionDetailsView.swift */; };
@@ -402,6 +403,7 @@
 		6D16685C28F5C15C008C664A /* CameraVideoOutputDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraVideoOutputDelegate.swift; sourceTree = "<group>"; };
 		6D16687C28F84953008C664A /* EnvironmentValues+SafeAreaInsets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EnvironmentValues+SafeAreaInsets.swift"; sourceTree = "<group>"; };
 		6D16687E28F86DE0008C664A /* CameraButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraButton.swift; sourceTree = "<group>"; };
+		6D17D2A02A2E7DF70023B3A7 /* ErrorDisplayed+LocalizedDescription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ErrorDisplayed+LocalizedDescription.swift"; sourceTree = "<group>"; };
 		6D17EF8228EDC951008626E9 /* Encryption+RawRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encryption+RawRepresentable.swift"; sourceTree = "<group>"; };
 		6D17EF8528EEEDDA008626E9 /* CameraPreviewUIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPreviewUIView.swift; sourceTree = "<group>"; };
 		6D199C9E292A8D1100E79113 /* TransactionDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionDetailsView.swift; sourceTree = "<group>"; };
@@ -1042,6 +1044,7 @@
 			children = (
 				6D8F813B2994C64E000ED0BA /* ErrorDisplayed+TransactionSigning.swift */,
 				6D3423342994F0D200F3BA27 /* ErrorBottomModalViewModel+TransactionErrors.swift */,
+				6D17D2A02A2E7DF70023B3A7 /* ErrorDisplayed+LocalizedDescription.swift */,
 			);
 			path = Errors;
 			sourceTree = "<group>";
@@ -2155,6 +2158,7 @@
 				6DDF43952987853000881AFF /* OnboardingOverviewView.swift in Sources */,
 				6DBD21FA289A7A26005D539B /* DatabaseMediator.swift in Sources */,
 				6D971AC32941CDF600121A36 /* Identicon.swift in Sources */,
+				6D17D2A12A2E7DF70023B3A7 /* ErrorDisplayed+LocalizedDescription.swift in Sources */,
 				6DEA1B1528D4587200D170B7 /* SeedPhraseView.swift in Sources */,
 				6D8973AB2A08EE1E0046A2F3 /* SignSpecService.swift in Sources */,
 				6D6430EF28CB30A000342E37 /* BottoEdgeOverlay.swift in Sources */,

--- a/ios/PolkadotVault/Backend/CreateDerivedKeyService.swift
+++ b/ios/PolkadotVault/Backend/CreateDerivedKeyService.swift
@@ -53,7 +53,7 @@ final class CreateDerivedKeyService {
         completion: @escaping (Result<Void, CreateDerivedKeyError>) -> Void
     ) {
         let pathAndNetworks: [(path: String, network: MmNetwork)] = networks
-            .map { (path: "//\($0.title)", network: $0) }
+            .map { (path: $0.pathId, network: $0) }
         var occuredErrors: [(network: MmNetwork, error: String)] = []
         callQueue.async {
             let result: Result<Void, CreateDerivedKeyError>

--- a/ios/PolkadotVault/Backend/CreateKeySetService.swift
+++ b/ios/PolkadotVault/Backend/CreateKeySetService.swift
@@ -40,12 +40,17 @@ final class CreateKeySetService {
     func confirmKeySetCreation(
         seedName: String,
         seedPhrase: String,
+        networks: [MmNetwork],
         _ completion: @escaping (Result<Void, Error>) -> Void
     ) {
         callQueue.async {
             let result: Result<Void, Error>
             do {
-                try PolkadotVault.createKeySet(seedName: seedName, seedPhrase: seedPhrase, networks: [])
+                try PolkadotVault.createKeySet(
+                    seedName: seedName,
+                    seedPhrase: seedPhrase,
+                    networks: networks.map(\.key)
+                )
                 result = .success(())
             } catch {
                 result = .failure(error)

--- a/ios/PolkadotVault/Components/NavigationBarView.swift
+++ b/ios/PolkadotVault/Components/NavigationBarView.swift
@@ -18,6 +18,13 @@ enum NavigationButton {
     case questionmark
 }
 
+enum NavigationBarTitle {
+    case empty
+    case title(String)
+    case subtitle(title: String, subtitle: String)
+    case progress(current: Int, upTo: Int)
+}
+
 struct NavigationButtonModel: Identifiable {
     let id = UUID()
     let type: NavigationButton
@@ -33,21 +40,18 @@ struct NavigationButtonModel: Identifiable {
 }
 
 struct NavigationBarViewModel {
-    let title: String?
-    let subtitle: String?
+    let title: NavigationBarTitle
     let leftButtons: [NavigationButtonModel]
     let rightButtons: [NavigationButtonModel]
     let backgroundColor: Color
 
     init(
-        title: String? = nil,
-        subtitle: String? = nil,
+        title: NavigationBarTitle = .empty,
         leftButtons: [NavigationButtonModel] = [],
         rightButtons: [NavigationButtonModel] = [],
         backgroundColor: Color = Asset.backgroundPrimary.swiftUIColor
     ) {
         self.title = title
-        self.subtitle = subtitle
         self.leftButtons = leftButtons
         self.rightButtons = rightButtons
         self.backgroundColor = backgroundColor
@@ -79,22 +83,7 @@ struct NavigationBarView: View {
                     }
                 }
                 .padding([.leading, .trailing], Spacing.extraExtraSmall)
-                HStack(alignment: .center, spacing: 0) {
-                    Spacer()
-                    VStack {
-                        if let title = viewModel.title {
-                            Text(title)
-                                .font(PrimaryFont.titleS.font)
-                                .foregroundColor(Asset.textAndIconsPrimary.swiftUIColor).lineLimit(1)
-                        }
-                        if let subtitle = viewModel.subtitle {
-                            Text(subtitle)
-                                .font(PrimaryFont.captionM.font)
-                                .foregroundColor(Asset.textAndIconsSecondary.swiftUIColor)
-                        }
-                    }
-                    Spacer()
-                }
+                titleView(viewModel.title)
             }
             .frame(maxWidth: .infinity)
             .frame(height: Heights.navigationBarHeight)
@@ -145,6 +134,52 @@ struct NavigationBarView: View {
             )
         }
     }
+
+    @ViewBuilder
+    func titleView(_ title: NavigationBarTitle) -> some View {
+        HStack(alignment: .center, spacing: 0) {
+            Spacer()
+            switch title {
+            case .empty:
+                EmptyView()
+            case let .title(title):
+                VStack {
+                    Text(title)
+                        .font(PrimaryFont.titleS.font)
+                        .foregroundColor(Asset.textAndIconsPrimary.swiftUIColor).lineLimit(1)
+                }
+            case let .subtitle(title, subtitle):
+                VStack {
+                    Text(title)
+                        .font(PrimaryFont.titleS.font)
+                        .foregroundColor(Asset.textAndIconsPrimary.swiftUIColor).lineLimit(1)
+                    Text(subtitle)
+                        .font(PrimaryFont.captionM.font)
+                        .foregroundColor(Asset.textAndIconsSecondary.swiftUIColor)
+                }
+            case let .progress(current, upTo):
+                progressView(current, upTo: upTo)
+            }
+            Spacer()
+        }
+    }
+
+    @ViewBuilder
+    func progressView(_ current: Int, upTo: Int) -> some View {
+        ForEach(Array(0 ..< upTo).indices, id: \.self) { index in
+            progressViewElement(isActive: index < current)
+                .padding(.leading, index != 0 ? Spacing.extraExtraSmall : 0)
+        }
+    }
+
+    @ViewBuilder
+    func progressViewElement(isActive: Bool) -> some View {
+        RoundedRectangle(cornerRadius: CornerRadius.extraLarge)
+            .frame(width: Heights.navigationBarProgressViewWidth, height: Heights.navigationBarProgressViewHeight)
+            .foregroundColor(
+                isActive ? Asset.pink500.swiftUIColor : Asset.fill12.swiftUIColor
+            )
+    }
 }
 
 #if DEBUG
@@ -153,43 +188,42 @@ struct NavigationBarView: View {
             VStack {
                 NavigationBarView(
                     viewModel: NavigationBarViewModel(
-                        title: "Key Sets",
+                        title: .title("Key Sets"),
                         leftButtons: [.init(type: .empty)],
                         rightButtons: [.init(type: .empty)]
                     )
                 )
                 NavigationBarView(
                     viewModel: NavigationBarViewModel(
-                        title: "Key Sets",
+                        title: .title("Key Sets"),
                         leftButtons: [.init(type: .arrow)],
                         rightButtons: [.init(type: .more)]
                     )
                 )
                 NavigationBarView(
                     viewModel: NavigationBarViewModel(
-                        title: "Key Sets",
+                        title: .title("Key Sets"),
                         leftButtons: [.init(type: .arrow)],
                         rightButtons: [.init(type: .empty)]
                     )
                 )
                 NavigationBarView(
                     viewModel: NavigationBarViewModel(
-                        title: "Key Sets",
+                        title: .title("Key Sets"),
                         leftButtons: [.init(type: .empty)],
                         rightButtons: [.init(type: .more)]
                     )
                 )
                 NavigationBarView(
                     viewModel: NavigationBarViewModel(
-                        title: "Public Key",
-                        subtitle: "Derived Key",
+                        title: .subtitle(title: "Key Sets", subtitle: "Derived Key"),
                         leftButtons: [.init(type: .xmark)],
                         rightButtons: [.init(type: .plus), .init(type: .more)]
                     )
                 )
                 NavigationBarView(
                     viewModel: NavigationBarViewModel(
-                        title: "Create Derived Key",
+                        title: .title("Create Derived Key"),
                         leftButtons: [.init(type: .xmark)],
                         rightButtons: [.init(type: .action("Done"))]
                     )

--- a/ios/PolkadotVault/Components/Text/InfoBoxView.swift
+++ b/ios/PolkadotVault/Components/Text/InfoBoxView.swift
@@ -14,6 +14,7 @@ struct InfoBoxView: View {
         HStack {
             Text(text)
                 .frame(maxWidth: .infinity, alignment: .leading)
+                .fixedSize(horizontal: false, vertical: true)
                 .foregroundColor(Asset.textAndIconsTertiary.swiftUIColor)
             Spacer().frame(maxWidth: Spacing.medium)
             Asset.infoIconBold.swiftUIImage

--- a/ios/PolkadotVault/Core/Keychain/KeychainAccessAdapter.swift
+++ b/ios/PolkadotVault/Core/Keychain/KeychainAccessAdapter.swift
@@ -179,7 +179,7 @@ final class KeychainAccessAdapter: KeychainAccessAdapting {
     func removeAllSeeds() -> Bool {
         let query = queryProvider.query(for: .deleteAll)
         let osStatus = SecItemDelete(query)
-        if osStatus == errSecSuccess {
+        if osStatus == errSecSuccess || osStatus == errSecItemNotFound {
             return true
         } else {
             return false

--- a/ios/PolkadotVault/Design/Heights.swift
+++ b/ios/PolkadotVault/Design/Heights.swift
@@ -71,6 +71,9 @@ enum Heights {
 
     static let createKeyNetworkItemHeight: CGFloat = 64
     static let createKeysForNetworkItemHeight: CGFloat = 64
+
+    static let navigationBarProgressViewHeight: CGFloat = 6
+    static let navigationBarProgressViewWidth: CGFloat = 40
 }
 
 enum Sizes {

--- a/ios/PolkadotVault/Design/Heights.swift
+++ b/ios/PolkadotVault/Design/Heights.swift
@@ -70,6 +70,7 @@ enum Heights {
     static let signSpecsListRowHeight: CGFloat = 96
 
     static let createKeyNetworkItemHeight: CGFloat = 64
+    static let createKeysForNetworkItemHeight: CGFloat = 64
 }
 
 enum Sizes {

--- a/ios/PolkadotVault/Modals/Alerts/HorizontalActionsBottomModal.swift
+++ b/ios/PolkadotVault/Modals/Alerts/HorizontalActionsBottomModal.swift
@@ -12,6 +12,8 @@ struct HorizontalActionsBottomModalViewModel {
     let content: String?
     let dismissActionLabel: LocalizedStringKey
     let mainActionLabel: LocalizedStringKey
+    var mainActionStyle: ActionButtonStyle = .primaryDestructive()
+    var alignment: HorizontalAlignment = .center
 
     static let forgetKeySet = HorizontalActionsBottomModalViewModel(
         title: Localizable.KeySetsModal.Confirmation.Label.title.string,
@@ -54,6 +56,15 @@ struct HorizontalActionsBottomModalViewModel {
         dismissActionLabel: Localizable.Settings.NetworkDetails.More.Delete.Action.cancel.key,
         mainActionLabel: Localizable.Settings.NetworkDetails.More.Delete.Action.remove.key
     )
+
+    static let createEmptyKeySet = HorizontalActionsBottomModalViewModel(
+        title: Localizable.CreateKeysForNetwork.Modal.title.string,
+        content: Localizable.CreateKeysForNetwork.Modal.content.string,
+        dismissActionLabel: Localizable.CreateKeysForNetwork.Modal.cancel.key,
+        mainActionLabel: Localizable.CreateKeysForNetwork.Modal.done.key,
+        mainActionStyle: .primary(),
+        alignment: .leading
+    )
 }
 
 struct HorizontalActionsBottomModal: View {
@@ -81,14 +92,14 @@ struct HorizontalActionsBottomModal: View {
             animateBackground: $animateBackground,
             safeAreaInsetsMode: .full,
             content: {
-                VStack(alignment: .center, spacing: Spacing.medium) {
+                VStack(alignment: viewModel.alignment, spacing: Spacing.medium) {
                     Text(viewModel.title)
                         .font(PrimaryFont.titleL.font)
                     if let content = viewModel.content {
                         Text(content)
                             .font(PrimaryFont.bodyL.font)
                             .lineSpacing(Spacing.extraExtraSmall)
-                            .multilineTextAlignment(.center)
+                            .multilineTextAlignment(viewModel.alignment == .center ? .center : .leading)
                             .foregroundColor(Asset.textAndIconsSecondary.swiftUIColor)
                     }
                     HStack {
@@ -99,7 +110,7 @@ struct HorizontalActionsBottomModal: View {
                         PrimaryButton(
                             action: { animateDismissal(mainAction()) },
                             text: viewModel.mainActionLabel,
-                            style: .primaryDestructive()
+                            style: viewModel.mainActionStyle
                         )
                     }
                     .padding(.top, Spacing.medium)

--- a/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
+++ b/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
@@ -582,7 +582,6 @@
 "CreateKeysForNetwork.Label.Footer" = "Please note that keys with custom named derivation path name can be created from the key set screen separately.";
 "CreateKeysForNetwork.Error.DerivedKeyForNetwork" = "Derived key for %@ could not be created: %@";
 "CreateKeysForNetwork.Action.SelectAll" = "Select All";
-"CreateKeysForNetwork.Action.Create" = "Add Keys to Key Set";
-"CreateKeysForNetwork.Action.Skip" = "Skip";
+"CreateKeysForNetwork.Action.Create" = "Create Key Set";
 "ErrorDisplayed.DbNotInitialized" = "Database not initialized";
 "ErrorDisplayed.MutexPoisoned" = "Mutex poisoned";

--- a/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
+++ b/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
@@ -77,9 +77,9 @@
 "Seed" = "Seed";
 "seed_name" = "Enter Key Set Name";
 "SEED PHRASE" = "Secret Recovery Phrase";
-"RecoverSeedPhrase.Action.Done" = "Done";
-"RecoverSeedPhrase.Label.Title" = "Recover Key Set";
-"RecoverSeedPhrase.Label.Header" = "Secret Recovery Phrase";
+"RecoverSeedPhrase.Action.Next" = "Next";
+"RecoverSeedPhrase.Label.Title" = "Enter a Secret Recovery Phrase";
+"RecoverSeedPhrase.Label.Header" = "Enter a 24-word phrase you were given when you created your key set";
 "RecoverSeedPhrase.Error.IncorrectPhrase.Title" = "Please enter the correct Secret Recovery phrase";
 "RecoverSeedPhrase.Error.IncorrectPhrase.Message" = "Please edit your secret recovery phrase and try again.";
 
@@ -568,7 +568,7 @@
 "NewSeed.Name.Label.Footer" = "Name examples: Main account, My validator, Dotsama crowdloans, etc";
 "NewSeed.Name.Action.Next" = "Next";
 "NewSeed.Backup.Label.Header" = "Write down your Secret\nRecovery Phrase";
-"NewSeed.Backup.Action.Create" = "Create Key Set";
+"NewSeed.Backup.Action.Create" = "Next";
 "NewSeed.Backup.Label.Info" = "Write it down on a piece of paper and keep it in a safe place. You can also use Banana Split for maximum security";
 "NewSeed.Backup.Label.Info.Underline" = "Banana Split";
 "NewSeed.Backup.Label.Confirmation" = "I’ve written down my secret\nrecovery phrase";
@@ -577,11 +577,20 @@
 "NewSeed.Backup.BananaSplit.Label.Content.Highlight.1" = "Shamir's secret sharing scheme.";
 "NewSeed.Backup.BananaSplit.Label.Content.Highlight.2" = "https://bs.parity.io";
 
-"CreateKeysForNetwork.Label.Title" = "Create Keys";
-"CreateKeysForNetwork.Label.Header" = "Choose networks for the keys to be created ";
+"CreateKeysForNetwork.Label.Title.Create" = "Create Keys";
+"CreateKeysForNetwork.Label.Header.Create" = "Choose networks for the keys to be created";
+"CreateKeysForNetwork.Label.Title.Recover" = "Recover Keys";
+"CreateKeysForNetwork.Label.Header.Recover" = "Choose networks for the keys to be recovered";
+"CreateKeysForNetwork.Label.Title.BananaSplit" = "Recover Keys";
+"CreateKeysForNetwork.Label.Header.BananaSplit" = "Choose networks for the keys to be recovered";
 "CreateKeysForNetwork.Label.Footer" = "Please note that keys with custom named derivation path name can be created from the key set screen separately.";
 "CreateKeysForNetwork.Error.DerivedKeyForNetwork" = "Derived key for %@ could not be created: %@";
 "CreateKeysForNetwork.Action.SelectAll" = "Select All";
-"CreateKeysForNetwork.Action.Create" = "Create Key Set";
+"CreateKeysForNetwork.Action.Create" = "Done";
+"CreateKeysForNetwork.Modal.Title" = "Proceed with the Empty Key Set?";
+"CreateKeysForNetwork.Modal.Content" = "Since you haven't selected any keys, you key set will be empty. Are you sure?";
+"CreateKeysForNetwork.Modal.Cancel" = "Cancel";
+"CreateKeysForNetwork.Modal.Done" = "Done";
+
 "ErrorDisplayed.DbNotInitialized" = "Database not initialized";
 "ErrorDisplayed.MutexPoisoned" = "Mutex poisoned";

--- a/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
+++ b/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
@@ -576,3 +576,10 @@
 "NewSeed.Backup.BananaSplit.Label.Content" = "Banana Split is a self-contained HTML page, which makes your paper backups more resilient and secure using Shamir's secret sharing scheme. You can encrypt and split particularly sensitive information so that it's not physically stored in one place — your master password, seed phrase, etc.\n\nFor more details visit\nhttps://bs.parity.io";
 "NewSeed.Backup.BananaSplit.Label.Content.Highlight.1" = "Shamir's secret sharing scheme.";
 "NewSeed.Backup.BananaSplit.Label.Content.Highlight.2" = "https://bs.parity.io";
+
+"CreateKeysForNetwork.Label.Title" = "Create Keys";
+"CreateKeysForNetwork.Label.Header" = "Choose networks for the keys to be created ";
+"CreateKeysForNetwork.Label.Footer" = "Please note that keys with custom named derivation path name can be created from the key set screen separately.";
+"CreateKeysForNetwork.Action.SelectAll" = "Select All";
+"CreateKeysForNetwork.Action.Create" = "Add Keys to Key Set";
+

--- a/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
+++ b/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
@@ -580,6 +580,9 @@
 "CreateKeysForNetwork.Label.Title" = "Create Keys";
 "CreateKeysForNetwork.Label.Header" = "Choose networks for the keys to be created ";
 "CreateKeysForNetwork.Label.Footer" = "Please note that keys with custom named derivation path name can be created from the key set screen separately.";
+"CreateKeysForNetwork.Error.DerivedKeyForNetwork" = "Derived key for %@ could not be created: %@";
 "CreateKeysForNetwork.Action.SelectAll" = "Select All";
 "CreateKeysForNetwork.Action.Create" = "Add Keys to Key Set";
-
+"CreateKeysForNetwork.Action.Skip" = "Skip";
+"ErrorDisplayed.DbNotInitialized" = "Database not initialized";
+"ErrorDisplayed.MutexPoisoned" = "Mutex poisoned";

--- a/ios/PolkadotVault/Screens/Containers/MainScreenContainer.swift
+++ b/ios/PolkadotVault/Screens/Containers/MainScreenContainer.swift
@@ -17,10 +17,7 @@ struct MainScreenContainer: View {
         case .authenticated:
             AuthenticatedScreenContainer(viewModel: .init())
         case .deviceLocked:
-            UnlockDeviceView(viewModel: .init(
-                passwordProtectionStatePublisher: viewModel
-                    .passwordProtectionStatePublisher
-            ))
+            UnlockDeviceView(viewModel: .init())
         case .onboarding:
             onboarding.currentView()
         case .noPincode:
@@ -40,7 +37,7 @@ extension MainScreenContainer {
     final class ViewModel: ObservableObject {
         private let authenticationStateMediator: AuthenticatedStateMediator
         private let onboardingMediator: OnboardingMediator
-        let passwordProtectionStatePublisher: PasswordProtectionStatePublisher
+        private let passwordProtectionStatePublisher: PasswordProtectionStatePublisher
         private let cancelBag = CancelBag()
         @Published var viewState: ViewState = .deviceLocked
 

--- a/ios/PolkadotVault/Screens/CreateKey/CreateKeysForNetworks/CreateKeysForNetworksView.swift
+++ b/ios/PolkadotVault/Screens/CreateKey/CreateKeysForNetworks/CreateKeysForNetworksView.swift
@@ -1,0 +1,248 @@
+//
+//  CreateKeysForNetworksView.swift
+//  PolkadotVault
+//
+//  Created by Krzysztof Rodak on 30/05/2023.
+//
+
+import Combine
+import SwiftUI
+
+struct CreateKeysForNetworksView: View {
+    @StateObject var viewModel: ViewModel
+    @Environment(\.presentationMode) var presentationMode
+
+    var body: some View {
+        GeometryReader { geo in
+            VStack(alignment: .leading, spacing: 0) {
+                // Navigation Bar
+                NavigationBarView(
+                    viewModel: NavigationBarViewModel(
+                        leftButtons: [.init(
+                            type: .arrow,
+                            action: { presentationMode.wrappedValue.dismiss() }
+                        )],
+                        backgroundColor: Asset.backgroundPrimary.swiftUIColor
+                    )
+                )
+                // Network List
+                ScrollView(showsIndicators: false) {
+                    VStack(alignment: .leading, spacing: 0) {
+                        // Title + Header
+                        mainContent()
+                        VStack(alignment: .leading, spacing: Spacing.extraSmall) {
+                            networkSelection()
+                            footer()
+                        }
+                        PrimaryButton(
+                            action: viewModel.onDoneTap,
+                            text: Localizable.CreateKeysForNetwork.Action.create.key,
+                            style: .primary()
+                        )
+                        .padding(Spacing.large)
+                    }
+                }
+                .padding(Spacing.extraSmall)
+            }
+            .frame(
+                minWidth: geo.size.width,
+                minHeight: geo.size.height
+            )
+            .background(Asset.backgroundPrimary.swiftUIColor)
+            .onReceive(viewModel.dismissViewRequest) { _ in
+                presentationMode.wrappedValue.dismiss()
+            }
+            .fullScreenModal(
+                isPresented: $viewModel.isNetworkTutorialPresented,
+                onDismiss: viewModel.updateNetworks
+            ) {
+                NavigationView {
+                    AddKeySetUpNetworksStepOneView(viewModel: .init())
+                        .navigationBarBackButtonHidden(true)
+                        .navigationViewStyle(.stack)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    func mainContent() -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Localizable.CreateKeysForNetwork.Label.title.text
+                .foregroundColor(Asset.textAndIconsPrimary.swiftUIColor)
+                .font(PrimaryFont.titleL.font)
+                .padding(.top, Spacing.extraSmall)
+            Localizable.CreateKeysForNetwork.Label.header.text
+                .foregroundColor(Asset.textAndIconsPrimary.swiftUIColor)
+                .font(PrimaryFont.bodyL.font)
+                .padding(.vertical, Spacing.extraSmall)
+        }
+        .padding(.horizontal, Spacing.large)
+    }
+
+    @ViewBuilder
+    func footer() -> some View {
+        InfoBoxView(text: Localizable.CreateKeysForNetwork.Label.footer.string)
+            .onTapGesture {
+                viewModel.onInfoBoxTap()
+            }
+            .padding(.bottom, Spacing.large)
+    }
+
+    @ViewBuilder
+    func networkSelection() -> some View {
+        LazyVStack(spacing: 0) {
+            ForEach(
+                viewModel.networks,
+                id: \.key
+            ) {
+                item(for: $0)
+                Divider()
+                    .padding(.horizontal, Spacing.medium)
+            }
+            selectAllNetworks()
+        }
+        .containerBackground()
+    }
+
+    @ViewBuilder
+    func item(for network: MmNetwork) -> some View {
+        HStack(alignment: .center, spacing: 0) {
+            NetworkLogoIcon(networkName: network.logo)
+                .padding(.trailing, Spacing.small)
+            Text(network.title.capitalized)
+                .foregroundColor(Asset.textAndIconsPrimary.swiftUIColor)
+                .font(PrimaryFont.titleS.font)
+            Spacer()
+            if viewModel.isSelected(network) {
+                Asset.checkmarkChecked.swiftUIImage
+            } else {
+                Asset.checkmarkUnchecked.swiftUIImage
+            }
+        }
+        .contentShape(Rectangle())
+        .padding(.horizontal, Spacing.medium)
+        .frame(height: Heights.createKeysForNetworkItemHeight)
+        .onTapGesture {
+            viewModel.toggleSelection(network)
+        }
+    }
+
+    @ViewBuilder
+    func selectAllNetworks() -> some View {
+        HStack(alignment: .center, spacing: 0) {
+            Localizable.CreateKeysForNetwork.Action.selectAll.text
+                .foregroundColor(Asset.textAndIconsPrimary.swiftUIColor)
+                .font(PrimaryFont.titleS.font)
+            Spacer()
+        }
+        .contentShape(Rectangle())
+        .padding(.horizontal, Spacing.medium)
+        .frame(height: Heights.createKeysForNetworkItemHeight)
+        .onTapGesture {
+            viewModel.selectAllNetworks()
+        }
+    }
+}
+
+extension CreateKeysForNetworksView {
+    enum OnCompletionAction: Equatable {
+        case derivedKeysCreated
+    }
+
+    final class ViewModel: ObservableObject {
+        private let cancelBag = CancelBag()
+        private let networkService: GetAllNetworksService
+        private let keyName: String
+        private let createKeyService: CreateDerivedKeyService
+        let seedName: String
+        @Published var isPresentingDerivationPath: Bool = false
+        @Published var networks: [MmNetwork] = MmNetwork.stubList
+        @Published var selectedNetworks: [MmNetwork] = []
+
+        // Tutorial
+        @Published var isNetworkTutorialPresented: Bool = false
+        var dismissViewRequest: AnyPublisher<Void, Never> {
+            dismissRequest.eraseToAnyPublisher()
+        }
+
+        private let dismissRequest = PassthroughSubject<Void, Never>()
+        private let onCompletion: (OnCompletionAction) -> Void
+
+        init(
+            seedName: String,
+            keyName: String,
+            networkService: GetAllNetworksService = GetAllNetworksService(),
+            createKeyService: CreateDerivedKeyService = CreateDerivedKeyService(),
+            onCompletion: @escaping (OnCompletionAction) -> Void
+        ) {
+            self.seedName = seedName
+            self.keyName = keyName
+            self.networkService = networkService
+            self.createKeyService = createKeyService
+            self.onCompletion = onCompletion
+            updateNetworks()
+            listenToChanges()
+        }
+
+        func selectAllNetworks() {
+            selectedNetworks = networks
+        }
+
+        func isSelected(_ network: MmNetwork) -> Bool {
+            selectedNetworks.contains(network)
+        }
+
+        func toggleSelection(_ network: MmNetwork) {
+            if selectedNetworks.contains(network) {
+                selectedNetworks.removeAll { $0 == network }
+            } else {
+                selectedNetworks.append(network)
+            }
+        }
+
+        func onKeyCreationComplete() {
+            onCompletion(.derivedKeysCreated)
+            dismissRequest.send()
+        }
+
+        func onInfoBoxTap() {
+            isNetworkTutorialPresented = true
+        }
+
+        func onDoneTap() {}
+    }
+}
+
+private extension CreateKeysForNetworksView.ViewModel {
+    func updateNetworks() {
+        networkService.getNetworks {
+            if case let .success(networks) = $0 {
+                self.networks = networks
+            }
+        }
+    }
+
+    func listenToChanges() {
+        $isNetworkTutorialPresented.sink { [weak self] isPresented in
+            guard let self = self, !isPresented else { return }
+            self.createKeyService.resetNavigationState(self.keyName)
+            self.updateNetworks()
+        }
+        .store(in: cancelBag)
+    }
+}
+
+#if DEBUG
+    struct CreateKeysForNetworksView_Previews: PreviewProvider {
+        static var previews: some View {
+            CreateKeysForNetworksView(
+                viewModel: .init(
+                    seedName: "seedName",
+                    keyName: "keyName",
+                    onCompletion: { _ in }
+                )
+            )
+        }
+    }
+#endif

--- a/ios/PolkadotVault/Screens/CreateKey/CreateKeysForNetworks/CreateKeysForNetworksView.swift
+++ b/ios/PolkadotVault/Screens/CreateKey/CreateKeysForNetworks/CreateKeysForNetworksView.swift
@@ -130,12 +130,16 @@ extension CreateKeysForNetworksView {
     }
 
     final class ViewModel: ObservableObject {
+        private enum Constants {
+            static let preselectedNetworks: [String] = ["polkadot", "kusama", "westend"]
+        }
+
         private let cancelBag = CancelBag()
         private let networkService: GetAllNetworksService
         private let createKeyService: CreateDerivedKeyService
         let seedName: String
         @Published var isPresentingDerivationPath: Bool = false
-        @Published var networks: [MmNetwork] = MmNetwork.stubList
+        @Published var networks: [MmNetwork] = []
         @Published var selectedNetworks: [MmNetwork] = []
         @Binding var isPresented: Bool
 
@@ -185,6 +189,7 @@ private extension CreateKeysForNetworksView.ViewModel {
         networkService.getNetworks {
             if case let .success(networks) = $0 {
                 self.networks = networks
+                self.selectedNetworks = networks.filter { Constants.preselectedNetworks.contains($0.title) }
             }
         }
     }

--- a/ios/PolkadotVault/Screens/CreateKey/CreateKeysForNetworks/CreateKeysForNetworksView.swift
+++ b/ios/PolkadotVault/Screens/CreateKey/CreateKeysForNetworks/CreateKeysForNetworksView.swift
@@ -20,15 +20,15 @@ struct CreateKeysForNetworksView: View {
                         backgroundColor: Asset.backgroundPrimary.swiftUIColor
                     )
                 )
-                // Network List
                 ScrollView(showsIndicators: false) {
                     VStack(alignment: .leading, spacing: 0) {
                         // Title + Header
                         mainContent()
-                        VStack(alignment: .leading, spacing: Spacing.extraSmall) {
-                            networkSelection()
-                            footer()
-                        }
+                            .padding(.bottom, Spacing.medium)
+                        // Network List
+                        networkSelection()
+                            .padding(.bottom, Spacing.medium)
+                        footer()
                     }
                 }
                 .padding(Spacing.extraSmall)

--- a/ios/PolkadotVault/Screens/CreateKey/NewKeySet/CreateKeySetSeedPhraseView.swift
+++ b/ios/PolkadotVault/Screens/CreateKey/NewKeySet/CreateKeySetSeedPhraseView.swift
@@ -71,6 +71,14 @@ struct CreateKeySetSeedPhraseView: View {
                     .padding(Spacing.large)
                 }
             }
+            NavigationLink(
+                destination:
+                CreateKeysForNetworksView(
+                    viewModel: viewModel.createDerivedKeys()
+                )
+                .navigationBarHidden(true),
+                isActive: $viewModel.isPresentingDetails
+            ) { EmptyView() }
         }
         .background(Asset.backgroundPrimary.swiftUIColor)
         .fullScreenModal(
@@ -91,6 +99,7 @@ extension CreateKeySetSeedPhraseView {
 
         let dataModel: MNewSeedBackup
         @Binding var isPresented: Bool
+        @Published var isPresentingDetails: Bool = false
         @Published var confirmBackup = false
         @Published var isPresentingInfo: Bool = false
         @Published var presentableInfo: ErrorBottomModalViewModel = .bananaSplitExplanation()
@@ -115,11 +124,15 @@ extension CreateKeySetSeedPhraseView {
                 shouldCheckForCollision: true
             )
             service.confirmKeySetCreation(dataModel.seedPhrase)
-            isPresented = false
+            isPresentingDetails = true
         }
 
         func onInfoBoxTap() {
             isPresentingInfo = true
+        }
+
+        func createDerivedKeys() -> CreateKeysForNetworksView.ViewModel {
+            .init(seedName: dataModel.seed, isPresented: $isPresented)
         }
     }
 }

--- a/ios/PolkadotVault/Screens/CreateKey/NewKeySet/CreateKeySetSeedPhraseView.swift
+++ b/ios/PolkadotVault/Screens/CreateKey/NewKeySet/CreateKeySetSeedPhraseView.swift
@@ -99,8 +99,8 @@ extension CreateKeySetSeedPhraseView {
 
         let dataModel: MNewSeedBackup
         @Binding var isPresented: Bool
-        @Published var isPresentingDetails: Bool = false
         @Published var confirmBackup = false
+        @Published var isPresentingDetails: Bool = false
         @Published var isPresentingInfo: Bool = false
         @Published var presentableInfo: ErrorBottomModalViewModel = .bananaSplitExplanation()
         private let service: CreateKeySetService
@@ -118,32 +118,19 @@ extension CreateKeySetSeedPhraseView {
         }
 
         func onCreateTap() {
-            seedsMediator.createSeed(
-                seedName: dataModel.seed,
-                seedPhrase: dataModel.seedPhrase,
-                shouldCheckForCollision: true
-            )
-            service.confirmKeySetCreation(
-                seedName: dataModel.seed,
-                seedPhrase: dataModel.seedPhrase
-            ) { result in
-                switch result {
-                case .success:
-                    self.isPresented = false
-                case let .failure(error):
-                    self.presentableInfo = .alertError(message: error.localizedDescription)
-                    self.isPresentingInfo = true
-                }
-            }
+            isPresentingDetails = true
         }
 
         func onInfoBoxTap() {
-            presentableInfo = .bananaSplitExplanation()
             isPresentingInfo = true
         }
 
         func createDerivedKeys() -> CreateKeysForNetworksView.ViewModel {
-            .init(seedName: dataModel.seed, isPresented: $isPresented)
+            .init(
+                seedName: dataModel.seed,
+                mode: .createKeySet(seedPhrase: dataModel.seedPhrase),
+                isPresented: $isPresented
+            )
         }
     }
 }

--- a/ios/PolkadotVault/Screens/CreateKey/NewKeySet/CreateKeySetSeedPhraseView.swift
+++ b/ios/PolkadotVault/Screens/CreateKey/NewKeySet/CreateKeySetSeedPhraseView.swift
@@ -10,85 +10,94 @@ import SwiftUI
 struct CreateKeySetSeedPhraseView: View {
     @StateObject var viewModel: ViewModel
     @Environment(\.presentationMode) var mode: Binding<PresentationMode>
+    @Environment(\.safeAreaInsets) private var safeAreaInsets
 
     var body: some View {
-        VStack(spacing: 0) {
-            NavigationBarView(
-                viewModel: .init(
-                    title: nil,
-                    leftButtons: [.init(type: .arrow, action: { mode.wrappedValue.dismiss() })]
+        GeometryReader { geo in
+            VStack(spacing: 0) {
+                NavigationBarView(
+                    viewModel: .init(
+                        title: .progress(current: 2, upTo: 3),
+                        leftButtons: [.init(type: .arrow, action: { mode.wrappedValue.dismiss() })]
+                    )
                 )
-            )
-            ScrollView(showsIndicators: false) {
-                VStack(alignment: .leading, spacing: 0) {
-                    Localizable.NewSeed.Backup.Label.header.text
-                        .foregroundColor(Asset.textAndIconsPrimary.swiftUIColor)
-                        .font(PrimaryFont.titleM.font)
-                        .multilineTextAlignment(.leading)
-                        .lineSpacing(Spacing.extraSmall)
-                    HStack {
-                        Spacer()
-                    }
-                }
-                .padding(.top, Spacing.extraExtraSmall)
-                .padding(.bottom, Spacing.medium)
-                .padding(.horizontal, Spacing.large)
-                VStack(alignment: .leading, spacing: 0) {
-                    SeedPhraseView(viewModel: .init(dataModel: .init(seedPhrase: viewModel.dataModel.seedPhrase)))
-                        .padding(.bottom, Spacing.extraSmall)
-                        .padding(.horizontal, Spacing.medium)
-                    AttributedTintInfoBox(text: Localizable.createKeySetSeedPhraseInfo())
-                        .padding(.horizontal, Spacing.medium)
-                        .padding(.bottom, Spacing.large)
-                        .contentShape(Rectangle())
-                        .onTapGesture { viewModel.onInfoBoxTap() }
-                    Button(
-                        action: {
-                            viewModel.confirmBackup.toggle()
-                        },
-                        label: {
-                            HStack {
-                                (
-                                    viewModel.confirmBackup ? Asset.checkboxChecked.swiftUIImage : Asset.checkboxEmpty
-                                        .swiftUIImage
-                                )
-                                .foregroundColor(Asset.accentPink300.swiftUIColor)
-                                Localizable.NewSeed.Backup.Label.confirmation.text
-                                    .multilineTextAlignment(.leading)
-                                    .foregroundColor(Asset.textAndIconsSecondary.swiftUIColor)
-                                Spacer()
-                            }
+                ScrollView(showsIndicators: false) {
+                    VStack(alignment: .leading, spacing: 0) {
+                        Localizable.NewSeed.Backup.Label.header.text
+                            .foregroundColor(Asset.textAndIconsPrimary.swiftUIColor)
+                            .font(PrimaryFont.titleM.font)
+                            .multilineTextAlignment(.leading)
+                            .lineSpacing(Spacing.extraSmall)
+                        HStack {
+                            Spacer()
                         }
-                    )
+                    }
+                    .padding(.top, Spacing.extraExtraSmall)
+                    .padding(.bottom, Spacing.medium)
                     .padding(.horizontal, Spacing.large)
-                    .padding(.bottom, Spacing.extraSmall)
-                    Spacer()
-                    PrimaryButton(
-                        action: viewModel.onCreateTap,
-                        text: Localizable.NewSeed.Backup.Action.create.key,
-                        style: .primary(isDisabled: .constant(!viewModel.confirmBackup))
+                    VStack(alignment: .leading, spacing: 0) {
+                        SeedPhraseView(viewModel: .init(dataModel: .init(seedPhrase: viewModel.dataModel.seedPhrase)))
+                            .padding(.bottom, Spacing.extraSmall)
+                            .padding(.horizontal, Spacing.medium)
+                        AttributedTintInfoBox(text: Localizable.createKeySetSeedPhraseInfo())
+                            .padding(.horizontal, Spacing.medium)
+                            .padding(.bottom, Spacing.large)
+                            .contentShape(Rectangle())
+                            .onTapGesture { viewModel.onInfoBoxTap() }
+                        Button(
+                            action: {
+                                viewModel.confirmBackup.toggle()
+                            },
+                            label: {
+                                HStack {
+                                    (
+                                        viewModel.confirmBackup ? Asset.checkboxChecked.swiftUIImage : Asset
+                                            .checkboxEmpty
+                                            .swiftUIImage
+                                    )
+                                    .foregroundColor(Asset.accentPink300.swiftUIColor)
+                                    Localizable.NewSeed.Backup.Label.confirmation.text
+                                        .multilineTextAlignment(.leading)
+                                        .foregroundColor(Asset.textAndIconsSecondary.swiftUIColor)
+                                    Spacer()
+                                }
+                            }
+                        )
+                        .padding(.horizontal, Spacing.large)
+                        .padding(.bottom, Spacing.extraSmall)
+                        Spacer()
+                        PrimaryButton(
+                            action: viewModel.onCreateTap,
+                            text: Localizable.NewSeed.Backup.Action.create.key,
+                            style: .primary(isDisabled: .constant(!viewModel.confirmBackup))
+                        )
+                        .padding(Spacing.large)
+                    }
+                    .frame(
+                        minWidth: geo.size.width,
+                        minHeight: geo.size.height - Heights.navigationBarHeight - safeAreaInsets.top - safeAreaInsets
+                            .bottom
                     )
-                    .padding(Spacing.large)
                 }
+                NavigationLink(
+                    destination:
+                    CreateKeysForNetworksView(
+                        viewModel: viewModel.createDerivedKeys()
+                    )
+                    .navigationBarHidden(true),
+                    isActive: $viewModel.isPresentingDetails
+                ) { EmptyView() }
             }
-            NavigationLink(
-                destination:
-                CreateKeysForNetworksView(
-                    viewModel: viewModel.createDerivedKeys()
+            .background(Asset.backgroundPrimary.swiftUIColor)
+            .fullScreenModal(
+                isPresented: $viewModel.isPresentingInfo
+            ) {
+                ErrorBottomModal(
+                    viewModel: viewModel.presentableInfo,
+                    isShowingBottomAlert: $viewModel.isPresentingInfo
                 )
-                .navigationBarHidden(true),
-                isActive: $viewModel.isPresentingDetails
-            ) { EmptyView() }
-        }
-        .background(Asset.backgroundPrimary.swiftUIColor)
-        .fullScreenModal(
-            isPresented: $viewModel.isPresentingInfo
-        ) {
-            ErrorBottomModal(
-                viewModel: viewModel.presentableInfo,
-                isShowingBottomAlert: $viewModel.isPresentingInfo
-            )
-            .clearModalBackground()
+                .clearModalBackground()
+            }
         }
     }
 }

--- a/ios/PolkadotVault/Screens/CreateKey/NewKeySet/EnterKeySetNameView.swift
+++ b/ios/PolkadotVault/Screens/CreateKey/NewKeySet/EnterKeySetNameView.swift
@@ -16,7 +16,7 @@ struct EnterKeySetNameView: View {
             VStack(alignment: .leading, spacing: 0) {
                 NavigationBarView(
                     viewModel: .init(
-                        title: nil,
+                        title: .progress(current: 1, upTo: 3),
                         leftButtons: [.init(
                             type: .xmark,
                             action: viewModel.onBackTap

--- a/ios/PolkadotVault/Screens/CreateKey/RecoverKeySet/RecoverKeySetNameView.swift
+++ b/ios/PolkadotVault/Screens/CreateKey/RecoverKeySet/RecoverKeySetNameView.swift
@@ -16,7 +16,6 @@ struct RecoverKeySetNameView: View {
             VStack(alignment: .leading, spacing: 0) {
                 NavigationBarView(
                     viewModel: .init(
-                        title: nil,
                         leftButtons: [.init(
                             type: .xmark,
                             action: viewModel.onBackTap

--- a/ios/PolkadotVault/Screens/CreateKey/RecoverKeySet/RecoverKeySetNameView.swift
+++ b/ios/PolkadotVault/Screens/CreateKey/RecoverKeySet/RecoverKeySetNameView.swift
@@ -16,6 +16,7 @@ struct RecoverKeySetNameView: View {
             VStack(alignment: .leading, spacing: 0) {
                 NavigationBarView(
                     viewModel: .init(
+                        title: .progress(current: 1, upTo: 3),
                         leftButtons: [.init(
                             type: .xmark,
                             action: viewModel.onBackTap

--- a/ios/PolkadotVault/Screens/CreateKey/RecoverKeySet/RecoverKeySetNameView.swift
+++ b/ios/PolkadotVault/Screens/CreateKey/RecoverKeySet/RecoverKeySetNameView.swift
@@ -48,6 +48,7 @@ struct RecoverKeySetNameView: View {
             }
             .navigationViewStyle(StackNavigationViewStyle())
             .navigationBarHidden(true)
+            .background(Asset.backgroundPrimary.swiftUIColor)
         }
     }
 

--- a/ios/PolkadotVault/Screens/CreateKey/RecoverKeySet/RecoverKeySetSeedPhraseView.swift
+++ b/ios/PolkadotVault/Screens/CreateKey/RecoverKeySet/RecoverKeySetSeedPhraseView.swift
@@ -70,6 +70,7 @@ struct RecoverKeySetSeedPhraseView: View {
             .onAppear {
                 focus = true
             }
+            .background(Asset.backgroundPrimary.swiftUIColor)
             .fullScreenModal(
                 isPresented: $viewModel.isPresentingError
             ) {

--- a/ios/PolkadotVault/Screens/CreateKey/RecoverKeySet/RecoverKeySetSeedPhraseView.swift
+++ b/ios/PolkadotVault/Screens/CreateKey/RecoverKeySet/RecoverKeySetSeedPhraseView.swift
@@ -16,11 +16,11 @@ struct RecoverKeySetSeedPhraseView: View {
         VStack(alignment: .leading, spacing: 0) {
             NavigationBarView(
                 viewModel: .init(
-                    title: .title(Localizable.RecoverSeedPhrase.Label.title.string),
+                    title: .progress(current: 2, upTo: 3),
                     leftButtons: [.init(type: .arrow, action: { mode.wrappedValue.dismiss() })],
                     rightButtons: [.init(
                         type: .activeAction(
-                            Localizable.RecoverSeedPhrase.Action.done.key,
+                            Localizable.RecoverSeedPhrase.Action.next.key,
                             .constant(viewModel.content.readySeed == nil)
                         ),
                         action: viewModel.onDoneTap
@@ -29,12 +29,22 @@ struct RecoverKeySetSeedPhraseView: View {
             )
             ScrollView(showsIndicators: false) {
                 VStack(alignment: .leading, spacing: 0) {
+                    Localizable.RecoverSeedPhrase.Label.title.text
+                        .foregroundColor(Asset.textAndIconsPrimary.swiftUIColor)
+                        .font(PrimaryFont.titleL.font)
+                        .padding(.top, Spacing.extraSmall)
                     Localizable.RecoverSeedPhrase.Label.header.text
                         .foregroundColor(Asset.textAndIconsPrimary.swiftUIColor)
                         .font(PrimaryFont.bodyL.font)
-                        .padding(.leading, Spacing.large)
-                        .padding(.top, Spacing.large)
-                        .padding(.bottom, Spacing.small)
+                        .padding(.vertical, Spacing.extraSmall)
+                    HStack {
+                        Spacer()
+                    }
+                }
+                .padding(.top, Spacing.extraExtraSmall)
+                .padding(.bottom, Spacing.medium)
+                .padding(.horizontal, Spacing.large)
+                VStack(alignment: .leading, spacing: 0) {
                     VStack(alignment: .leading, spacing: 0) {
                         WrappingHStack(models: viewModel.seedPhraseGrid) { gridElement in
                             switch gridElement {

--- a/ios/PolkadotVault/Screens/CreateKey/RecoverKeySet/RecoverKeySetSeedPhraseView.swift
+++ b/ios/PolkadotVault/Screens/CreateKey/RecoverKeySet/RecoverKeySetSeedPhraseView.swift
@@ -242,11 +242,11 @@ extension RecoverKeySetSeedPhraseView {
                 shouldCheckForCollision: false
             )
             service.finishKeySetRecover(seedPhrase)
-            isPresented = false
+            isPresentingDetails = true
         }
 
         func createDerivedKeys() -> CreateKeysForNetworksView.ViewModel {
-            .init(seedName: content.seedName, isPresented: $isPresented)
+            .init(seedName: content.seedName, mode: .recoverKeySet, isPresented: $isPresented)
         }
     }
 }

--- a/ios/PolkadotVault/Screens/CreateKey/RecoverKeySet/RecoverKeySetSeedPhraseView.swift
+++ b/ios/PolkadotVault/Screens/CreateKey/RecoverKeySet/RecoverKeySetSeedPhraseView.swift
@@ -16,7 +16,7 @@ struct RecoverKeySetSeedPhraseView: View {
         VStack(alignment: .leading, spacing: 0) {
             NavigationBarView(
                 viewModel: .init(
-                    title: Localizable.RecoverSeedPhrase.Label.title.string,
+                    title: .title(Localizable.RecoverSeedPhrase.Label.title.string),
                     leftButtons: [.init(type: .arrow, action: { mode.wrappedValue.dismiss() })],
                     rightButtons: [.init(
                         type: .activeAction(

--- a/ios/PolkadotVault/Screens/CreateKey/RecoverKeySet/RecoverKeySetSeedPhraseView.swift
+++ b/ios/PolkadotVault/Screens/CreateKey/RecoverKeySet/RecoverKeySetSeedPhraseView.swift
@@ -79,6 +79,14 @@ struct RecoverKeySetSeedPhraseView: View {
                 )
                 .clearModalBackground()
             }
+            NavigationLink(
+                destination:
+                CreateKeysForNetworksView(
+                    viewModel: viewModel.createDerivedKeys()
+                )
+                .navigationBarHidden(true),
+                isActive: $viewModel.isPresentingDetails
+            ) { EmptyView() }
         }
     }
 
@@ -171,6 +179,7 @@ extension RecoverKeySetSeedPhraseView {
         private var shouldSkipUpdate = false
         private let service: RecoverKeySetService
         @Binding var isPresented: Bool
+        @Published var isPresentingDetails: Bool = false
         @Published var seedPhraseGrid: [GridElement] = []
         @Published var userInput: String = " "
         @Published var previousUserInput: String = " "
@@ -236,16 +245,22 @@ extension RecoverKeySetSeedPhraseView {
             isPresented = false
         }
 
-        private func regenerateGrid() {
-            var updatedGrid: [GridElement] = content.draft.enumerated()
-                .map { .seedPhraseElement(.init(position: String($0.offset + 1), word: $0.element)) }
-            updatedGrid.append(.input(textInput))
-            seedPhraseGrid = updatedGrid
+        func createDerivedKeys() -> CreateKeysForNetworksView.ViewModel {
+            .init(seedName: content.seedName, isPresented: $isPresented)
         }
+    }
+}
 
-        private func shouldPresentError() {
-            isPresentingError = content.draft.count == 24 && (content.readySeed?.isEmpty ?? true)
-        }
+private extension RecoverKeySetSeedPhraseView.ViewModel {
+    func regenerateGrid() {
+        var updatedGrid: [RecoverKeySetSeedPhraseView.GridElement] = content.draft.enumerated()
+            .map { .seedPhraseElement(.init(position: String($0.offset + 1), word: $0.element)) }
+        updatedGrid.append(.input(textInput))
+        seedPhraseGrid = updatedGrid
+    }
+
+    func shouldPresentError() {
+        isPresentingError = content.draft.count == 24 && (content.readySeed?.isEmpty ?? true)
     }
 }
 

--- a/ios/PolkadotVault/Screens/DerivedKey/CreateKeyNetworkSelectionView.swift
+++ b/ios/PolkadotVault/Screens/DerivedKey/CreateKeyNetworkSelectionView.swift
@@ -22,7 +22,7 @@ struct CreateKeyNetworkSelectionView: View {
             // Navigation Bar
             NavigationBarView(
                 viewModel: NavigationBarViewModel(
-                    title: Localizable.CreateDerivedKey.Label.title.string,
+                    title: .title(Localizable.CreateDerivedKey.Label.title.string),
                     leftButtons: [.init(
                         type: .xmark,
                         action: { presentationMode.wrappedValue.dismiss() }

--- a/ios/PolkadotVault/Screens/DerivedKey/Subviews/AddKeySetUpNetworksStepOneView.swift
+++ b/ios/PolkadotVault/Screens/DerivedKey/Subviews/AddKeySetUpNetworksStepOneView.swift
@@ -17,7 +17,6 @@ struct AddKeySetUpNetworksStepOneView: View {
             VStack(alignment: .leading, spacing: 0) {
                 NavigationBarView(
                     viewModel: .init(
-                        title: nil,
                         leftButtons: [.init(
                             type: .xmark,
                             action: { presentationMode.wrappedValue.dismiss() }

--- a/ios/PolkadotVault/Screens/DerivedKey/Subviews/AddKeySetUpNetworksStepTwoView.swift
+++ b/ios/PolkadotVault/Screens/DerivedKey/Subviews/AddKeySetUpNetworksStepTwoView.swift
@@ -17,7 +17,6 @@ struct AddKeySetUpNetworksStepTwoView: View {
             VStack(alignment: .leading, spacing: 0) {
                 NavigationBarView(
                     viewModel: .init(
-                        title: nil,
                         leftButtons: [.init(
                             type: .arrow,
                             action: { presentationMode.wrappedValue.dismiss() }

--- a/ios/PolkadotVault/Screens/DerivedKey/Subviews/DerivationPathNameView.swift
+++ b/ios/PolkadotVault/Screens/DerivedKey/Subviews/DerivationPathNameView.swift
@@ -20,7 +20,7 @@ struct DerivationPathNameView: View {
         VStack(alignment: .leading, spacing: 0) {
             NavigationBarView(
                 viewModel: NavigationBarViewModel(
-                    title: Localizable.CreateDerivedKey.Modal.Path.title.string,
+                    title: .title(Localizable.CreateDerivedKey.Modal.Path.title.string),
                     leftButtons: [.init(
                         type: .arrow,
                         action: { presentationMode.wrappedValue.dismiss() }

--- a/ios/PolkadotVault/Screens/DerivedKey/Subviews/DerivationPathNameView.swift
+++ b/ios/PolkadotVault/Screens/DerivedKey/Subviews/DerivationPathNameView.swift
@@ -136,6 +136,15 @@ struct DerivationPathNameView: View {
             )
             .clearModalBackground()
         }
+        .fullScreenModal(
+            isPresented: $viewModel.isPresentingInfoModal
+        ) {
+            ErrorBottomModal(
+                viewModel: viewModel.presentableInfoModal,
+                isShowingBottomAlert: $viewModel.isPresentingInfoModal
+            )
+            .clearModalBackground()
+        }
     }
 
     @ViewBuilder

--- a/ios/PolkadotVault/Screens/Errors/UnlockDeviceView.swift
+++ b/ios/PolkadotVault/Screens/Errors/UnlockDeviceView.swift
@@ -42,22 +42,18 @@ extension UnlockDeviceView {
     final class ViewModel: ObservableObject {
         private let seedsMediator: SeedsMediating
         private let warningStateMediator: WarningStateMediator
-        private let passwordProtectionStatePublisher: PasswordProtectionStatePublisher
 
         init(
             seedsMediator: SeedsMediating = ServiceLocator.seedsMediator,
-            warningStateMediator: WarningStateMediator = ServiceLocator.warningStateMediator,
-            passwordProtectionStatePublisher: PasswordProtectionStatePublisher
+            warningStateMediator: WarningStateMediator = ServiceLocator.warningStateMediator
         ) {
             self.seedsMediator = seedsMediator
             self.warningStateMediator = warningStateMediator
-            self.passwordProtectionStatePublisher = passwordProtectionStatePublisher
         }
 
         func onUnlockTap() {
             seedsMediator.refreshSeeds()
             warningStateMediator.updateWarnings()
-            passwordProtectionStatePublisher.isProtected = true
         }
     }
 }
@@ -65,7 +61,7 @@ extension UnlockDeviceView {
 #if DEBUG
     struct UnlockDeviceView_Previews: PreviewProvider {
         static var previews: some View {
-            UnlockDeviceView(viewModel: .init(passwordProtectionStatePublisher: PasswordProtectionStatePublisher()))
+            UnlockDeviceView(viewModel: .init())
         }
     }
 #endif

--- a/ios/PolkadotVault/Screens/KeySetsList/KeySetList.swift
+++ b/ios/PolkadotVault/Screens/KeySetsList/KeySetList.swift
@@ -19,7 +19,7 @@ struct KeySetList: View {
                     // Navigation Bar
                     NavigationBarView(
                         viewModel: NavigationBarViewModel(
-                            title: Localizable.KeySets.title.string,
+                            title: .title(Localizable.KeySets.title.string),
                             leftButtons: [.init(
                                 type: viewModel.isExportKeysSelected ? .xmark : .empty,
                                 action: viewModel.onCancelExportTap

--- a/ios/PolkadotVault/Screens/Logs/Views/LogDetailsView.swift
+++ b/ios/PolkadotVault/Screens/Logs/Views/LogDetailsView.swift
@@ -15,7 +15,7 @@ struct LogDetailsView: View {
         VStack(alignment: .center, spacing: 0) {
             NavigationBarView(
                 viewModel: .init(
-                    title: Localizable.LogDetails.Label.title.string,
+                    title: .title(Localizable.LogDetails.Label.title.string),
                     leftButtons: [.init(type: .arrow, action: { mode.wrappedValue.dismiss() })]
                 )
             )

--- a/ios/PolkadotVault/Screens/Logs/Views/LogsListView.swift
+++ b/ios/PolkadotVault/Screens/Logs/Views/LogsListView.swift
@@ -22,7 +22,7 @@ struct LogsListView: View {
             VStack(spacing: 0) {
                 NavigationBarView(
                     viewModel: NavigationBarViewModel(
-                        title: Localizable.LogsList.Label.title.string,
+                        title: .title(Localizable.LogsList.Label.title.string),
                         leftButtons: [.init(type: .arrow, action: { mode.wrappedValue.dismiss() })],
                         rightButtons: [.init(type: .more, action: viewModel.onMoreMenuTap)],
                         backgroundColor: Asset.backgroundPrimary.swiftUIColor

--- a/ios/PolkadotVault/Screens/Onboarding/SetUpNetworks/SetUpNetworksStepOneView.swift
+++ b/ios/PolkadotVault/Screens/Onboarding/SetUpNetworks/SetUpNetworksStepOneView.swift
@@ -15,7 +15,6 @@ struct SetUpNetworksStepOneView: View {
             VStack(alignment: .leading, spacing: 0) {
                 NavigationBarView(
                     viewModel: .init(
-                        title: nil,
                         leftButtons: [.init(
                             type: .arrow,
                             action: viewModel.onBackButtonTap

--- a/ios/PolkadotVault/Screens/Onboarding/SetUpNetworks/SetUpNetworksStepTwoView.swift
+++ b/ios/PolkadotVault/Screens/Onboarding/SetUpNetworks/SetUpNetworksStepTwoView.swift
@@ -15,7 +15,6 @@ struct SetUpNetworksStepTwoView: View {
             VStack(alignment: .leading, spacing: 0) {
                 NavigationBarView(
                     viewModel: .init(
-                        title: nil,
                         leftButtons: [.init(
                             type: .arrow,
                             action: viewModel.onBackButtonTap

--- a/ios/PolkadotVault/Screens/PublicKey/KeyDetailsPublicKeyView.swift
+++ b/ios/PolkadotVault/Screens/PublicKey/KeyDetailsPublicKeyView.swift
@@ -19,8 +19,7 @@ struct KeyDetailsPublicKeyView: View {
                 // Navigation bar
                 NavigationBarView(
                     viewModel: .init(
-                        title: Localizable.PublicKeyDetails.Label.title.string,
-                        subtitle: viewModel.navigationSubtitle(),
+                        title: viewModel.navigationTitle(),
                         leftButtons: [.init(type: .arrow, action: { presentationMode.wrappedValue.dismiss() })],
                         rightButtons: [.init(type: .more, action: viewModel.onMoreButtonTap)]
                     )
@@ -261,8 +260,12 @@ extension KeyDetailsPublicKeyView {
             isShowingActionSheet.toggle()
         }
 
-        func navigationSubtitle() -> String? {
-            renderable.isRootKey ? nil : Localizable.PublicKeyDetails.Label.subtitle.string
+        func navigationTitle() -> NavigationBarTitle {
+            renderable.isRootKey ? .title(Localizable.PublicKeyDetails.Label.title.string) :
+                .subtitle(
+                    title: Localizable.PublicKeyDetails.Label.title.string,
+                    subtitle: Localizable.PublicKeyDetails.Label.subtitle.string
+                )
         }
 
         func checkForActionsPresentation() {

--- a/ios/PolkadotVault/Screens/Scan/Errors/ErrorDisplayed+LocalizedDescription.swift
+++ b/ios/PolkadotVault/Screens/Scan/Errors/ErrorDisplayed+LocalizedDescription.swift
@@ -1,0 +1,33 @@
+//
+//  ErrorDisplayed+LocalizedDescription.swift
+//  PolkadotVault
+//
+//  Created by Krzysztof Rodak on 05/06/2023.
+//
+
+import Foundation
+
+extension ErrorDisplayed {
+    var localizedDescription: String {
+        switch self {
+        case .DbNotInitialized:
+            return Localizable.ErrorDisplayed.dbNotInitialized.string
+        case let .LoadMetaUnknownNetwork(name):
+            return Localizable.TransactionSign.Error.MetadataUnknownNetwork.message(name)
+        case let .MetadataKnown(name, version):
+            return Localizable.TransactionSign.Error.MetadataAlreadyAdded.title(name, version)
+        case .MutexPoisoned:
+            return Localizable.ErrorDisplayed.mutexPoisoned.string
+        case let .SpecsKnown(name, _):
+            return Localizable.TransactionSign.Error.NetworkAlreadyAdded.title(name)
+        case .UnknownNetwork:
+            return Localizable.TransactionSign.Error.UnknownNetwork.message.string
+        case let .MetadataOutdated(name, have, want):
+            return Localizable.TransactionSign.Error.OutdatedMetadata.message(name, String(have), String(want))
+        case let .NoMetadata(name):
+            return Localizable.TransactionSign.Error.NoMetadataForNetwork.message(name)
+        case let .Str(errorMessage):
+            return errorMessage
+        }
+    }
+}

--- a/ios/PolkadotVault/Screens/Scan/TransactionDetailsView.swift
+++ b/ios/PolkadotVault/Screens/Scan/TransactionDetailsView.swift
@@ -14,7 +14,7 @@ struct TransactionDetailsView: View {
         VStack(spacing: 0) {
             NavigationBarView(
                 viewModel: .init(
-                    title: Localizable.TransactionPreview.Label.title.string,
+                    title: .title(Localizable.TransactionPreview.Label.title.string),
                     leftButtons: [.init(type: .xmark, action: viewModel.onBackButtonTap)],
                     rightButtons: [.init(type: .empty)]
                 )

--- a/ios/PolkadotVault/Screens/Scan/TransactionPreview.swift
+++ b/ios/PolkadotVault/Screens/Scan/TransactionPreview.swift
@@ -24,10 +24,10 @@ struct TransactionPreview: View {
         VStack {
             NavigationBarView(
                 viewModel: .init(
-                    title: title(
+                    title: .title(title(
                         viewModel.dataModel.count,
                         previewType: viewModel.dataModel.first?.content.previewType
-                    ),
+                    )),
                     leftButtons: [.init(type: .xmark, action: viewModel.onBackButtonTap)],
                     rightButtons: [.init(type: .empty)]
                 )

--- a/ios/PolkadotVault/Screens/Settings/SettingsView.swift
+++ b/ios/PolkadotVault/Screens/Settings/SettingsView.swift
@@ -17,7 +17,7 @@ struct SettingsView: View {
                 VStack(spacing: 0) {
                     NavigationBarView(
                         viewModel: NavigationBarViewModel(
-                            title: Localizable.Settings.Label.title.string,
+                            title: .title(Localizable.Settings.Label.title.string),
                             leftButtons: [.init(type: .empty)],
                             rightButtons: [.init(type: .empty)],
                             backgroundColor: Asset.backgroundPrimary.swiftUIColor

--- a/ios/PolkadotVault/Screens/Settings/Subviews/Backup/BackupSelectKeyView.swift
+++ b/ios/PolkadotVault/Screens/Settings/Subviews/Backup/BackupSelectKeyView.swift
@@ -16,7 +16,7 @@ struct BackupSelectKeyView: View {
         VStack(spacing: 0) {
             NavigationBarView(
                 viewModel: NavigationBarViewModel(
-                    title: Localizable.Settings.SelectKey.title.string,
+                    title: .title(Localizable.Settings.SelectKey.title.string),
                     leftButtons: [.init(
                         type: .arrow,
                         action: { presentationMode.wrappedValue.dismiss() }

--- a/ios/PolkadotVault/Screens/Settings/Subviews/Networks/NetworkSelectionSettings.swift
+++ b/ios/PolkadotVault/Screens/Settings/Subviews/Networks/NetworkSelectionSettings.swift
@@ -15,7 +15,7 @@ struct NetworkSelectionSettings: View {
         VStack(spacing: 0) {
             NavigationBarView(
                 viewModel: NavigationBarViewModel(
-                    title: Localizable.Settings.Networks.Label.title.string,
+                    title: .title(Localizable.Settings.Networks.Label.title.string),
                     leftButtons: [.init(
                         type: .arrow,
                         action: { presentationMode.wrappedValue.dismiss() }

--- a/ios/PolkadotVault/Screens/Settings/Subviews/SignSpecs/SignSpecDetailsView.swift
+++ b/ios/PolkadotVault/Screens/Settings/Subviews/SignSpecs/SignSpecDetailsView.swift
@@ -17,7 +17,7 @@ struct SignSpecDetails: View {
         VStack {
             NavigationBarView(
                 viewModel: NavigationBarViewModel(
-                    title: Localizable.SignSpecsDetails.Label.title.string,
+                    title: .title(Localizable.SignSpecsDetails.Label.title.string),
                     leftButtons: [.init(
                         type: .arrow,
                         action: viewModel.onBackTap

--- a/ios/PolkadotVault/Screens/Settings/Subviews/SignSpecs/SignSpecsListView.swift
+++ b/ios/PolkadotVault/Screens/Settings/Subviews/SignSpecs/SignSpecsListView.swift
@@ -16,7 +16,7 @@ struct SignSpecsListView: View {
         VStack {
             NavigationBarView(
                 viewModel: NavigationBarViewModel(
-                    title: Localizable.SignSpecsList.Label.title.string,
+                    title: .title(Localizable.SignSpecsList.Label.title.string),
                     leftButtons: [.init(
                         type: .arrow,
                         action: {

--- a/ios/PolkadotVault/Screens/Settings/Subviews/VerifierCertificate/VerifierCertificateView.swift
+++ b/ios/PolkadotVault/Screens/Settings/Subviews/VerifierCertificate/VerifierCertificateView.swift
@@ -17,7 +17,7 @@ struct VerifierCertificateView: View {
         VStack(alignment: .leading, spacing: 0) {
             NavigationBarView(
                 viewModel: NavigationBarViewModel(
-                    title: Localizable.VerifierCertificate.Label.title.string,
+                    title: .title(Localizable.VerifierCertificate.Label.title.string),
                     leftButtons: [.init(
                         type: .arrow,
                         action: {

--- a/ios/PolkadotVault/Screens/Terms/PrivacyPolicyView.swift
+++ b/ios/PolkadotVault/Screens/Terms/PrivacyPolicyView.swift
@@ -15,7 +15,7 @@ struct PrivacyPolicyView: View {
         VStack(spacing: 0) {
             NavigationBarView(
                 viewModel: NavigationBarViewModel(
-                    title: Localizable.Settings.PrivacyPolicy.Label.title.string,
+                    title: .title(Localizable.Settings.PrivacyPolicy.Label.title.string),
                     leftButtons: [.init(
                         type: .arrow,
                         action: { viewModel.onBackTap?() ?? presentationMode.wrappedValue.dismiss() }

--- a/ios/PolkadotVault/Screens/Terms/TermsOfServiceView.swift
+++ b/ios/PolkadotVault/Screens/Terms/TermsOfServiceView.swift
@@ -15,7 +15,7 @@ struct TermsOfServiceView: View {
         VStack(spacing: 0) {
             NavigationBarView(
                 viewModel: NavigationBarViewModel(
-                    title: Localizable.Settings.TermsOfService.Label.title.string,
+                    title: .title(Localizable.Settings.TermsOfService.Label.title.string),
                     leftButtons: [.init(
                         type: .arrow,
                         action: { viewModel.onBackTap?() ?? presentationMode.wrappedValue.dismiss() }

--- a/ios/PolkadotVault/StateMediators/OnboardingMediator.swift
+++ b/ios/PolkadotVault/StateMediators/OnboardingMediator.swift
@@ -35,6 +35,7 @@ final class OnboardingMediator: ObservableObject {
         guard seedsMediator.removeAllSeeds() else { return }
         databaseMediator.recreateDatabaseFile()
         navigationInitialisationService.initialiseNavigation(verifierRemoved: verifierRemoved)
+        seedsMediator.refreshSeeds()
         onboardingDone = true
         warningStateMediator.updateWarnings()
         initialisationService.initialiseAppSession()


### PR DESCRIPTION
## Purpose
Update logic for creating / recovering key set by adding additional step to create derived keys with network title-based name for selected networks 

| Create Empty Key Set | Create Key Set with networks |
|-|-|
|<img src="https://github.com/paritytech/parity-signer/assets/1955364/172a2290-671f-47a8-99c3-43721fcda384" width="320px">|<img src="https://github.com/paritytech/parity-signer/assets/1955364/980adf2e-9937-431e-9b8a-14fe86056faa" width="320px">|
