### PR TITLE
fix: new clippy warning

### DIFF
--- a/rust/navigator/src/tests.rs
+++ b/rust/navigator/src/tests.rs
@@ -725,6 +725,8 @@ fn export_import_addrs() {
 
 #[test]
 #[ignore]
+// Redundant clone clippy warning is a lie; https://github.com/rust-lang/rust-clippy/issues/10870
+#[allow(clippy::redundant_clone)]
 fn flow_test_1() {
     let dbname = &tempdir().unwrap().into_path().to_str().unwrap().to_string();
     let db = sled::open(dbname).unwrap();


### PR DESCRIPTION
small PR to fix new 1.70 clippy regression:
https://github.com/rust-lang/rust-clippy/issues/10870