### PR TITLE
feat: ios: banana split derived keys

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   check:
     name:                     Check on MacOS
-    runs-on:                  macos-12
+    runs-on:                  macos-13
     steps:
 
       - name:                 Cancel Previous Runs

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -25,7 +25,7 @@ jobs:
           submodules:         'recursive'
 
       - name:                 Setup - Xcode
-        run:                  sudo xcode-select -switch '/Applications/Xcode_14.2.app/Contents/Developer' && /usr/bin/xcodebuild -version
+        run:                  sudo xcode-select -switch '/Applications/Xcode_14.3.app/Contents/Developer' && /usr/bin/xcodebuild -version
 
       - name:                 Install dependencies
         run:                  |

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -25,7 +25,7 @@ jobs:
           bundler-cache:      true
 
       - name:                 Setup - Xcode
-        run:                  sudo xcode-select -switch '/Applications/Xcode_14.2.app/Contents/Developer' && /usr/bin/xcodebuild -version
+        run:                  sudo xcode-select -switch '/Applications/Xcode_14.3.app/Contents/Developer' && /usr/bin/xcodebuild -version
 
       - name:                 Install dependencies
         run:                  |

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   distribute_testflight:
     if: contains('["krodak","prybalko", "montekki"]', github.actor)
-    runs-on:                  macos-12
+    runs-on:                  macos-13
     name:                     Distribute TestFlight Build
 
     steps:

--- a/ios/PolkadotVault/Backend/BananaSplitRecoveryService.swift
+++ b/ios/PolkadotVault/Backend/BananaSplitRecoveryService.swift
@@ -16,17 +16,10 @@ final class BananaSplitRecoveryService {
         self.navigation = navigation
     }
 
-    func startBananaSplitRecover(_ seedName: String, isFirstSeed: Bool) {
+    func startBananaSplitRecover(_ seedName: String) {
         navigation.performFake(navigation: .init(action: .start))
         navigation.performFake(navigation: .init(action: .navbarKeys))
-        // Key Set List state has different "modalData" state depending on whether user has at least one key
-        // or not
-        // So we need to check whether we should actually "pretend" to open "more" navigation bar menu by
-        // calling
-        // .rightButtonAction
-        if !isFirstSeed {
-            navigation.performFake(navigation: .init(action: .rightButtonAction))
-        }
+        navigation.performFake(navigation: .init(action: .rightButtonAction))
         navigation.performFake(navigation: .init(action: .recoverSeed))
         navigation.performFake(navigation: .init(action: .goForward, details: seedName))
     }

--- a/ios/PolkadotVault/Backend/CreateDerivedKeyService.swift
+++ b/ios/PolkadotVault/Backend/CreateDerivedKeyService.swift
@@ -49,6 +49,7 @@ final class CreateDerivedKeyService {
 
     func createDerivedKeys(
         _ seedName: String,
+        _ seedPhrase: String,
         networks: [MmNetwork],
         completion: @escaping (Result<Void, CreateDerivedKeyError>) -> Void
     ) {
@@ -57,7 +58,6 @@ final class CreateDerivedKeyService {
         var occuredErrors: [(network: MmNetwork, error: String)] = []
         callQueue.async {
             let result: Result<Void, CreateDerivedKeyError>
-            let seedPhrase = self.seedsMediator.getSeed(seedName: seedName)
             pathAndNetworks.forEach {
                 do {
                     try tryCreateAddress(

--- a/ios/PolkadotVault/Backend/NavigationInitialisationService.swift
+++ b/ios/PolkadotVault/Backend/NavigationInitialisationService.swift
@@ -10,26 +10,37 @@ import Foundation
 final class NavigationInitialisationService {
     private let seedsMediator: SeedsMediating
     private let databaseMediator: DatabaseMediating
+    private let callQueue: Dispatching
+    private let callbackQueue: Dispatching
 
     init(
         databaseMediator: DatabaseMediating = DatabaseMediator(),
+        callQueue: Dispatching = DispatchQueue(label: "NavigationInitialisationService", qos: .userInitiated),
+        callbackQueue: Dispatching = DispatchQueue.main,
         seedsMediator: SeedsMediating = ServiceLocator.seedsMediator
     ) {
         self.databaseMediator = databaseMediator
+        self.callQueue = callQueue
+        self.callbackQueue = callbackQueue
         self.seedsMediator = seedsMediator
     }
 
-    func initialiseNavigation(verifierRemoved: Bool) {
-        do {
-            try initNavigation(
-                dbname: databaseMediator.databaseName,
-                seedNames: seedsMediator.seedNames
-            )
-            if verifierRemoved {
-                try historyInitHistoryNoCert()
-            } else {
-                try historyInitHistoryWithCert()
+    func initialiseNavigation(verifierRemoved: Bool, completion: @escaping () -> Void) {
+        callQueue.async {
+            do {
+                try initNavigation(
+                    dbname: self.databaseMediator.databaseName,
+                    seedNames: self.seedsMediator.seedNames
+                )
+                if verifierRemoved {
+                    try historyInitHistoryNoCert()
+                } else {
+                    try historyInitHistoryWithCert()
+                }
+            } catch {}
+            self.callbackQueue.async {
+                completion()
             }
-        } catch {}
+        }
     }
 }

--- a/ios/PolkadotVault/Modals/Errors/ErrorBottomModalViewModel.swift
+++ b/ios/PolkadotVault/Modals/Errors/ErrorBottomModalViewModel.swift
@@ -144,8 +144,8 @@ struct ErrorBottomModalViewModel {
     static func seedPhraseAlreadyExists(_ action: @escaping @autoclosure () -> Void = {}())
         -> ErrorBottomModalViewModel {
         ErrorBottomModalViewModel(
-            title: Localizable.EnterBananaSplitPasswordModal.Error.SeedPhraseExists.title.string,
-            content: Localizable.EnterBananaSplitPasswordModal.Error.SeedPhraseExists.message.string,
+            title: Localizable.EnterBananaSplitPasswordView.Error.SeedPhraseExists.title.string,
+            content: Localizable.EnterBananaSplitPasswordView.Error.SeedPhraseExists.message.string,
             secondaryAction: .init(label: Localizable.ErrorModal.Action.ok.key, action: action)
         )
     }

--- a/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
+++ b/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
@@ -441,16 +441,17 @@
 "NetworkFilter.Action.Reset" = "Reset";
 "NetworkFilter.Action.Done" = "Done";
 
-"EnterBananaSplitPasswordModal.Label.Title" = "Banana Split Recovery";
-"EnterBananaSplitPasswordModal.Label.EnterName" = "Enter display name for recovered key set";
-"EnterBananaSplitPasswordModal.Label.EnterPassword" = "Enter Banana split password";
-"EnterBananaSplitPasswordModal.Placeholder.EnterName" = "Display name";
-"EnterBananaSplitPasswordModal.Placeholder.EnterPassword" = "Password";
-"EnterBananaSplitPasswordModal.Error.Label.InvalidPassword" = "The password you entered is incorrect.\nPlease try again.";
-"EnterBananaSplitPasswordModal.Error.Label.InvalidSeedName" = "Given display name already exists.\nPlease try again.";
-"EnterBananaSplitPasswordModal.Error.SeedPhraseExists.Title" = "Seed phrase already exists";
-"EnterBananaSplitPasswordModal.Error.SeedPhraseExists.Message" = "Seed phrase that you are trying to recover already exists in the app.";
-"EnterBananaSplitPasswordModal.Error.LocalRestoreFailed.Message" = "Given combination of seed phrase and seed name couldn't be saved.";
+"EnterBananaSplitPasswordView.Label.Title" = "Banana Split Recovery";
+"EnterBananaSplitPasswordView.Label.EnterName" = "Enter display name for recovered key set";
+"EnterBananaSplitPasswordView.Label.EnterPassword" = "Enter Banana split password";
+"EnterBananaSplitPasswordView.Placeholder.EnterName" = "Display name";
+"EnterBananaSplitPasswordView.Placeholder.EnterPassword" = "Password";
+"EnterBananaSplitPasswordView.Error.Label.InvalidPassword" = "The password you entered is incorrect.\nPlease try again.";
+"EnterBananaSplitPasswordView.Error.Label.InvalidSeedName" = "Given display name already exists.\nPlease try again.";
+"EnterBananaSplitPasswordView.Error.SeedPhraseExists.Title" = "Seed phrase already exists";
+"EnterBananaSplitPasswordView.Error.SeedPhraseExists.Message" = "Seed phrase that you are trying to recover already exists in the app.";
+"EnterBananaSplitPasswordView.Error.LocalRestoreFailed.Message" = "Given combination of seed phrase and seed name couldn't be saved.";
+"EnterBananaSplitPasswordView.Action.Next" = "Next";
 
 "CreateDerivedKey.Label.Title" = "Select Network";
 "CreateDerivedKey.Label.Footer.Network" = "Learn more about How to Set up networks";
@@ -591,6 +592,8 @@
 "CreateKeysForNetwork.Modal.Content" = "Since you haven't selected any keys, you key set will be empty. Are you sure?";
 "CreateKeysForNetwork.Modal.Cancel" = "Cancel";
 "CreateKeysForNetwork.Modal.Done" = "Done";
+"CreateKeysForNetwork.Snackbar.KeySetCreated" = " %@ Key Set Has Been Added";
+"CreateKeysForNetwork.Snackbar.KeySetRecovered" = "%@ Key Set Has Been Recovered";
 
 "ErrorDisplayed.DbNotInitialized" = "Database not initialized";
 "ErrorDisplayed.MutexPoisoned" = "Mutex poisoned";

--- a/ios/PolkadotVault/Screens/CreateKey/CreateKeysForNetworks/CreateKeysForNetworksView.swift
+++ b/ios/PolkadotVault/Screens/CreateKey/CreateKeysForNetworks/CreateKeysForNetworksView.swift
@@ -46,7 +46,8 @@ struct CreateKeysForNetworksView: View {
 
             .background(Asset.backgroundPrimary.swiftUIColor)
             .fullScreenModal(
-                isPresented: $viewModel.isPresentingError
+                isPresented: $viewModel.isPresentingError,
+                onDismiss: { viewModel.onErrorDismiss?() }
             ) {
                 ErrorBottomModal(
                     viewModel: viewModel.errorViewModel,
@@ -174,6 +175,7 @@ extension CreateKeysForNetworksView {
         private let seedPhrase: String
         private let mode: Mode
         private let onCompletion: (OnCompletionAction) -> Void
+        var onErrorDismiss: (() -> Void)?
 
         @Binding var isPresented: Bool
 
@@ -324,6 +326,7 @@ private extension CreateKeysForNetworksView.ViewModel {
                 self.isPresented = false
                 self.onCompletion(.recoveredKeySet(seedName: self.seedName))
             case let .failure(error):
+                self.onErrorDismiss = { self.isPresented = false }
                 self.errorViewModel = .alertError(message: error.localizedDescription)
                 self.isPresentingError = true
             }
@@ -370,6 +373,7 @@ private extension CreateKeysForNetworksView.ViewModel {
                 self.isPresented = false
                 self.onCompletion(.bananaSplitRecovery(seedName: self.seedName))
             case let .failure(error):
+                self.onErrorDismiss = { self.isPresented = false }
                 self.errorViewModel = .alertError(message: error.localizedDescription)
                 self.isPresentingError = true
             }

--- a/ios/PolkadotVault/Screens/CreateKey/CreateKeysForNetworks/CreateKeysForNetworksView.swift
+++ b/ios/PolkadotVault/Screens/CreateKey/CreateKeysForNetworks/CreateKeysForNetworksView.swift
@@ -14,16 +14,16 @@ struct CreateKeysForNetworksView: View {
     @Environment(\.safeAreaInsets) private var safeAreaInsets
 
     var body: some View {
-        GeometryReader { geo in
-            VStack(alignment: .leading, spacing: 0) {
-                // Navigation Bar
-                NavigationBarView(
-                    viewModel: NavigationBarViewModel(
-                        title: .progress(current: 3, upTo: 3),
-                        leftButtons: [.init(type: .arrow, action: { mode.wrappedValue.dismiss() })],
-                        backgroundColor: Asset.backgroundPrimary.swiftUIColor
-                    )
+        VStack(alignment: .leading, spacing: 0) {
+            // Navigation Bar
+            NavigationBarView(
+                viewModel: NavigationBarViewModel(
+                    title: .progress(current: 3, upTo: 3),
+                    leftButtons: [.init(type: .arrow, action: { mode.wrappedValue.dismiss() })],
+                    backgroundColor: Asset.backgroundPrimary.swiftUIColor
                 )
+            )
+            GeometryReader { geo in
                 ScrollView(showsIndicators: false) {
                     VStack(alignment: .leading, spacing: 0) {
                         mainContent()
@@ -39,11 +39,11 @@ struct CreateKeysForNetworksView: View {
                     }
                     .frame(
                         minWidth: geo.size.width,
-                        minHeight: geo.size.height - Heights.navigationBarHeight - safeAreaInsets.top - safeAreaInsets
-                            .bottom
+                        minHeight: geo.size.height
                     )
                 }
             }
+
             .background(Asset.backgroundPrimary.swiftUIColor)
             .fullScreenModal(
                 isPresented: $viewModel.isPresentingError

--- a/ios/PolkadotVault/Screens/CreateKey/CreateKeysForNetworks/CreateKeysForNetworksView.swift
+++ b/ios/PolkadotVault/Screens/CreateKey/CreateKeysForNetworks/CreateKeysForNetworksView.swift
@@ -18,7 +18,7 @@ struct CreateKeysForNetworksView: View {
             // Navigation Bar
             NavigationBarView(
                 viewModel: NavigationBarViewModel(
-                    title: .progress(current: 3, upTo: 3),
+                    title: .progress(current: viewModel.step, upTo: viewModel.step),
                     leftButtons: [.init(type: .arrow, action: { mode.wrappedValue.dismiss() })],
                     backgroundColor: Asset.backgroundPrimary.swiftUIColor
                 )
@@ -146,14 +146,16 @@ struct CreateKeysForNetworksView: View {
 }
 
 extension CreateKeysForNetworksView {
-    enum Mode: Equatable {
-        case createKeySet(seedPhrase: String)
-        case recoverKeySet
-        case bananaSplit
+    enum OnCompletionAction: Equatable {
+        case createKeySet(seedName: String)
+        case recoveredKeySet(seedName: String)
+        case bananaSplitRecovery(seedName: String)
     }
 
-    enum OnCompletionAction: Equatable {
-        case derivedKeysCreated
+    enum Mode: Equatable {
+        case createKeySet
+        case recoverKeySet
+        case bananaSplit
     }
 
     final class ViewModel: ObservableObject {
@@ -165,9 +167,14 @@ extension CreateKeysForNetworksView {
         private let networkService: GetAllNetworksService
         private let createKeySetService: CreateKeySetService
         private let createKeyService: CreateDerivedKeyService
+        private let recoveryKeySetService: RecoverKeySetService
+        private let bananaSplitRecoveryService: BananaSplitRecoveryService
         private let seedsMediator: SeedsMediating
         private let seedName: String
+        private let seedPhrase: String
         private let mode: Mode
+        private let onCompletion: (OnCompletionAction) -> Void
+
         @Binding var isPresented: Bool
 
         @Published var isPresentingDerivationPath: Bool = false
@@ -179,21 +186,40 @@ extension CreateKeysForNetworksView {
         // Confirmation presentation
         @Published var isPresentingConfirmation: Bool = false
 
+        var step: Int {
+            switch mode {
+            case .bananaSplit:
+                return 2
+            case .createKeySet:
+                return 3
+            case .recoverKeySet:
+                return 3
+            }
+        }
+
         init(
             seedName: String,
+            seedPhrase: String,
             mode: Mode,
             networkService: GetAllNetworksService = GetAllNetworksService(),
             createKeyService: CreateDerivedKeyService = CreateDerivedKeyService(),
             createKeySetService: CreateKeySetService = CreateKeySetService(),
+            recoveryKeySetService: RecoverKeySetService = RecoverKeySetService(),
+            bananaSplitRecoveryService: BananaSplitRecoveryService = BananaSplitRecoveryService(),
             seedsMediator: SeedsMediating = ServiceLocator.seedsMediator,
-            isPresented: Binding<Bool>
+            isPresented: Binding<Bool>,
+            onCompletion: @escaping (OnCompletionAction) -> Void
         ) {
             self.seedName = seedName
+            self.seedPhrase = seedPhrase
             self.mode = mode
             self.networkService = networkService
             self.createKeyService = createKeyService
             self.createKeySetService = createKeySetService
+            self.recoveryKeySetService = recoveryKeySetService
+            self.bananaSplitRecoveryService = bananaSplitRecoveryService
             self.seedsMediator = seedsMediator
+            self.onCompletion = onCompletion
             _isPresented = isPresented
             updateNetworks()
         }
@@ -222,12 +248,12 @@ extension CreateKeysForNetworksView {
             if selectedNetworks.isEmpty {
                 isPresentingConfirmation = true
             } else {
-                createKeySet()
+                continueKeySetAction()
             }
         }
 
         func onCreateEmptyKeySetTap() {
-            createKeySet()
+            continueKeySetAction()
         }
     }
 }
@@ -265,40 +291,87 @@ private extension CreateKeysForNetworksView.ViewModel {
         }
     }
 
-    func createKeySet() {
+    func continueKeySetAction() {
+        if seedsMediator.checkSeedPhraseCollision(seedPhrase: seedPhrase) {
+            errorViewModel = .seedPhraseAlreadyExists()
+            isPresentingError = true
+            return
+        }
         switch mode {
-        case let .createKeySet(seedPhrase):
-            seedsMediator.createSeed(
-                seedName: seedName,
-                seedPhrase: seedPhrase,
-                shouldCheckForCollision: true
-            )
-            createKeySetService.confirmKeySetCreation(
-                seedName: seedName,
-                seedPhrase: seedPhrase,
-                networks: selectedNetworks
-            ) { result in
-                switch result {
-                case .success:
-                    self.isPresented = false
-                case let .failure(error):
-                    self.errorViewModel = .alertError(message: error.localizedDescription)
-                    self.isPresentingError = true
-                }
+        case .createKeySet:
+            createKeySet(seedPhrase)
+        case .recoverKeySet:
+            recoverKeySet(seedPhrase)
+        case .bananaSplit:
+            bananaSplitRecovery(seedPhrase)
+        }
+    }
+
+    func recoverKeySet(_ seedPhrase: String) {
+        seedsMediator.createSeed(
+            seedName: seedName,
+            seedPhrase: seedPhrase,
+            shouldCheckForCollision: false
+        )
+        recoveryKeySetService.finishKeySetRecover(seedPhrase)
+        createKeyService.createDerivedKeys(
+            seedName,
+            seedPhrase,
+            networks: selectedNetworks
+        ) { result in
+            switch result {
+            case .success:
+                self.isPresented = false
+                self.onCompletion(.recoveredKeySet(seedName: self.seedName))
+            case let .failure(error):
+                self.errorViewModel = .alertError(message: error.localizedDescription)
+                self.isPresentingError = true
             }
-        case .recoverKeySet,
-             .bananaSplit:
-            createKeyService.createDerivedKeys(
-                seedName,
-                networks: selectedNetworks
-            ) { result in
-                switch result {
-                case .success:
-                    self.isPresented = false
-                case let .failure(error):
-                    self.errorViewModel = .alertError(message: error.localizedDescription)
-                    self.isPresentingError = true
-                }
+        }
+    }
+
+    func createKeySet(_ seedPhrase: String) {
+        seedsMediator.createSeed(
+            seedName: seedName,
+            seedPhrase: seedPhrase,
+            shouldCheckForCollision: false
+        )
+        createKeySetService.confirmKeySetCreation(
+            seedName: seedName,
+            seedPhrase: seedPhrase,
+            networks: selectedNetworks
+        ) { result in
+            switch result {
+            case .success:
+                self.isPresented = false
+                self.onCompletion(.createKeySet(seedName: self.seedName))
+            case let .failure(error):
+                self.errorViewModel = .alertError(message: error.localizedDescription)
+                self.isPresentingError = true
+            }
+        }
+    }
+
+    func bananaSplitRecovery(_ seedPhrase: String) {
+        bananaSplitRecoveryService.startBananaSplitRecover(seedName)
+        seedsMediator.createSeed(
+            seedName: seedName,
+            seedPhrase: seedPhrase,
+            shouldCheckForCollision: false
+        )
+        bananaSplitRecoveryService.completeBananaSplitRecovery(seedPhrase)
+        createKeyService.createDerivedKeys(
+            seedName,
+            seedPhrase,
+            networks: selectedNetworks
+        ) { result in
+            switch result {
+            case .success:
+                self.isPresented = false
+                self.onCompletion(.bananaSplitRecovery(seedName: self.seedName))
+            case let .failure(error):
+                self.errorViewModel = .alertError(message: error.localizedDescription)
+                self.isPresentingError = true
             }
         }
     }
@@ -310,8 +383,10 @@ private extension CreateKeysForNetworksView.ViewModel {
             CreateKeysForNetworksView(
                 viewModel: .init(
                     seedName: "seedName",
-                    mode: .createKeySet(seedPhrase: ""),
-                    isPresented: .constant(true)
+                    seedPhrase: "seedPhrase",
+                    mode: .createKeySet,
+                    isPresented: .constant(true),
+                    onCompletion: { _ in }
                 )
             )
         }

--- a/ios/PolkadotVault/Screens/CreateKey/NewKeySet/CreateKeySetSeedPhraseView.swift
+++ b/ios/PolkadotVault/Screens/CreateKey/NewKeySet/CreateKeySetSeedPhraseView.swift
@@ -113,16 +113,19 @@ extension CreateKeySetSeedPhraseView {
         @Published var isPresentingInfo: Bool = false
         @Published var presentableInfo: ErrorBottomModalViewModel = .bananaSplitExplanation()
         private let service: CreateKeySetService
+        private let onCompletion: (CreateKeysForNetworksView.OnCompletionAction) -> Void
 
         init(
             dataModel: MNewSeedBackup,
             isPresented: Binding<Bool>,
             service: CreateKeySetService = CreateKeySetService(),
-            seedsMediator: SeedsMediating = ServiceLocator.seedsMediator
+            seedsMediator: SeedsMediating = ServiceLocator.seedsMediator,
+            onCompletion: @escaping (CreateKeysForNetworksView.OnCompletionAction) -> Void
         ) {
             self.dataModel = dataModel
             self.service = service
             self.seedsMediator = seedsMediator
+            self.onCompletion = onCompletion
             _isPresented = isPresented
         }
 
@@ -137,8 +140,10 @@ extension CreateKeySetSeedPhraseView {
         func createDerivedKeys() -> CreateKeysForNetworksView.ViewModel {
             .init(
                 seedName: dataModel.seed,
-                mode: .createKeySet(seedPhrase: dataModel.seedPhrase),
-                isPresented: $isPresented
+                seedPhrase: dataModel.seedPhrase,
+                mode: .createKeySet,
+                isPresented: $isPresented,
+                onCompletion: onCompletion
             )
         }
     }
@@ -157,7 +162,8 @@ extension CreateKeySetSeedPhraseView {
                         """,
                         identicon: .stubIdenticon
                     ),
-                    isPresented: .constant(true)
+                    isPresented: .constant(true),
+                    onCompletion: { _ in }
                 )
             )
         }

--- a/ios/PolkadotVault/Screens/CreateKey/NewKeySet/EnterKeySetNameView.swift
+++ b/ios/PolkadotVault/Screens/CreateKey/NewKeySet/EnterKeySetNameView.swift
@@ -39,7 +39,8 @@ struct EnterKeySetNameView: View {
                     CreateKeySetSeedPhraseView(
                         viewModel: .init(
                             dataModel: viewModel.detailsContent,
-                            isPresented: $viewModel.isPresented
+                            isPresented: $viewModel.isPresented,
+                            onCompletion: viewModel.onCompletion
                         )
                     )
                     .navigationBarHidden(true),
@@ -104,6 +105,7 @@ extension EnterKeySetNameView {
         @Published var isPresentingError: Bool = false
         @Published var presentableError: ErrorBottomModalViewModel!
         @Binding var isPresented: Bool
+        let onCompletion: (CreateKeysForNetworksView.OnCompletionAction) -> Void
 
         private let seedsMediator: SeedsMediating
         private let service: CreateKeySetService
@@ -111,10 +113,12 @@ extension EnterKeySetNameView {
         init(
             seedsMediator: SeedsMediating = ServiceLocator.seedsMediator,
             service: CreateKeySetService = CreateKeySetService(),
-            isPresented: Binding<Bool>
+            isPresented: Binding<Bool>,
+            onCompletion: @escaping (CreateKeysForNetworksView.OnCompletionAction) -> Void
         ) {
             self.seedsMediator = seedsMediator
             self.service = service
+            self.onCompletion = onCompletion
             _isPresented = isPresented
         }
 
@@ -150,7 +154,10 @@ extension EnterKeySetNameView {
     struct EnterKeySetNameView_Previews: PreviewProvider {
         static var previews: some View {
             EnterKeySetNameView(
-                viewModel: .init(isPresented: .constant(true))
+                viewModel: .init(
+                    isPresented: .constant(true),
+                    onCompletion: { _ in }
+                )
             )
             .previewLayout(.sizeThatFits)
         }

--- a/ios/PolkadotVault/Screens/CreateKey/RecoverKeySet/RecoverKeySetNameView.swift
+++ b/ios/PolkadotVault/Screens/CreateKey/RecoverKeySet/RecoverKeySetNameView.swift
@@ -39,7 +39,8 @@ struct RecoverKeySetNameView: View {
                     RecoverKeySetSeedPhraseView(
                         viewModel: .init(
                             content: viewModel.detailsContent,
-                            isPresented: $viewModel.isPresented
+                            isPresented: $viewModel.isPresented,
+                            onCompletion: viewModel.onCompletion
                         )
                     )
                     .navigationBarHidden(true),
@@ -93,6 +94,7 @@ extension RecoverKeySetNameView {
         @Published var seedName: String = ""
         private let service: RecoverKeySetService
         private let seedsMediator: SeedsMediating
+        let onCompletion: (CreateKeysForNetworksView.OnCompletionAction) -> Void
         @Binding var isPresented: Bool
         @Published var isPresentingDetails: Bool = false
         @Published var detailsContent: MRecoverSeedPhrase!
@@ -100,10 +102,12 @@ extension RecoverKeySetNameView {
         init(
             service: RecoverKeySetService = RecoverKeySetService(),
             seedsMediator: SeedsMediating = ServiceLocator.seedsMediator,
-            isPresented: Binding<Bool>
+            isPresented: Binding<Bool>,
+            onCompletion: @escaping (CreateKeysForNetworksView.OnCompletionAction) -> Void
         ) {
             self.service = service
             self.seedsMediator = seedsMediator
+            self.onCompletion = onCompletion
             _isPresented = isPresented
         }
 

--- a/ios/PolkadotVault/Screens/CreateKey/RecoverKeySet/RecoverKeySetSeedPhraseView.swift
+++ b/ios/PolkadotVault/Screens/CreateKey/RecoverKeySet/RecoverKeySetSeedPhraseView.swift
@@ -189,6 +189,7 @@ extension RecoverKeySetSeedPhraseView {
         private let textInput = TextInput()
         private var shouldSkipUpdate = false
         private let service: RecoverKeySetService
+        private let onCompletion: (CreateKeysForNetworksView.OnCompletionAction) -> Void
         @Binding var isPresented: Bool
         @Published var isPresentingDetails: Bool = false
         @Published var seedPhraseGrid: [GridElement] = []
@@ -209,11 +210,13 @@ extension RecoverKeySetSeedPhraseView {
             content: MRecoverSeedPhrase,
             isPresented: Binding<Bool>,
             seedsMediator: SeedsMediating = ServiceLocator.seedsMediator,
-            service: RecoverKeySetService = RecoverKeySetService()
+            service: RecoverKeySetService = RecoverKeySetService(),
+            onCompletion: @escaping (CreateKeysForNetworksView.OnCompletionAction) -> Void
         ) {
             self.content = content
             self.seedsMediator = seedsMediator
             self.service = service
+            self.onCompletion = onCompletion
             _isPresented = isPresented
             regenerateGrid()
         }
@@ -241,23 +244,17 @@ extension RecoverKeySetSeedPhraseView {
         }
 
         func onDoneTap() {
-            let seedPhrase = content.readySeed ?? ""
-            if seedsMediator.checkSeedPhraseCollision(seedPhrase: seedPhrase) {
-                presentableError = .seedPhraseAlreadyExists()
-                isPresentingError = true
-                return
-            }
-            seedsMediator.createSeed(
-                seedName: content.seedName,
-                seedPhrase: seedPhrase,
-                shouldCheckForCollision: false
-            )
-            service.finishKeySetRecover(seedPhrase)
             isPresentingDetails = true
         }
 
         func createDerivedKeys() -> CreateKeysForNetworksView.ViewModel {
-            .init(seedName: content.seedName, mode: .recoverKeySet, isPresented: $isPresented)
+            .init(
+                seedName: content.seedName,
+                seedPhrase: content.readySeed ?? "",
+                mode: .recoverKeySet,
+                isPresented: $isPresented,
+                onCompletion: onCompletion
+            )
         }
     }
 }

--- a/ios/PolkadotVault/Screens/KeySetsList/KeySetList.swift
+++ b/ios/PolkadotVault/Screens/KeySetsList/KeySetList.swift
@@ -97,13 +97,23 @@ struct KeySetList: View {
             isPresented: $viewModel.isShowingCreateKeySet,
             onDismiss: viewModel.updateData
         ) {
-            EnterKeySetNameView(viewModel: .init(isPresented: $viewModel.isShowingCreateKeySet))
+            EnterKeySetNameView(
+                viewModel: .init(
+                    isPresented: $viewModel.isShowingCreateKeySet,
+                    onCompletion: viewModel.onKeySetAddCompletion(_:)
+                )
+            )
         }
         .fullScreenModal(
             isPresented: $viewModel.isShowingRecoverKeySet,
             onDismiss: viewModel.updateData
         ) {
-            RecoverKeySetNameView(viewModel: .init(isPresented: $viewModel.isShowingRecoverKeySet))
+            RecoverKeySetNameView(
+                viewModel: .init(
+                    isPresented: $viewModel.isShowingRecoverKeySet,
+                    onCompletion: viewModel.onKeySetAddCompletion(_:)
+                )
+            )
         }
         .fullScreenModal(
             isPresented: $viewModel.isShowingMoreMenu
@@ -339,6 +349,22 @@ extension KeySetList {
 
         func onShowMoreTap() {
             isShowingMoreMenu.toggle()
+        }
+
+        func onKeySetAddCompletion(_ completionAction: CreateKeysForNetworksView.OnCompletionAction) {
+            let message: String
+            switch completionAction {
+            case let .createKeySet(seedName):
+                message = Localizable.CreateKeysForNetwork.Snackbar.keySetCreated(seedName)
+            case let .recoveredKeySet(seedName),
+                 let .bananaSplitRecovery(seedName):
+                message = Localizable.CreateKeysForNetwork.Snackbar.keySetRecovered(seedName)
+            }
+            snackbarViewModel = .init(
+                title: message,
+                style: .info
+            )
+            isSnackbarPresented = true
         }
     }
 }

--- a/ios/PolkadotVault/StateMediators/OnboardingMediator.swift
+++ b/ios/PolkadotVault/StateMediators/OnboardingMediator.swift
@@ -36,10 +36,10 @@ final class OnboardingMediator: ObservableObject {
         databaseMediator.recreateDatabaseFile()
         navigationInitialisationService.initialiseNavigation(verifierRemoved: verifierRemoved) { [weak self] in
             guard let self = self else { return }
-            seedsMediator.refreshSeeds()
-            onboardingDone = true
-            warningStateMediator.updateWarnings()
-            initialisationService.initialiseAppSession()
+            self.seedsMediator.refreshSeeds()
+            self.onboardingDone = true
+            self.warningStateMediator.updateWarnings()
+            self.initialisationService.initialiseAppSession()
         }
     }
 }

--- a/ios/PolkadotVault/StateMediators/OnboardingMediator.swift
+++ b/ios/PolkadotVault/StateMediators/OnboardingMediator.swift
@@ -34,10 +34,12 @@ final class OnboardingMediator: ObservableObject {
     func onboard(verifierRemoved: Bool = false) {
         guard seedsMediator.removeAllSeeds() else { return }
         databaseMediator.recreateDatabaseFile()
-        navigationInitialisationService.initialiseNavigation(verifierRemoved: verifierRemoved)
-        seedsMediator.refreshSeeds()
-        onboardingDone = true
-        warningStateMediator.updateWarnings()
-        initialisationService.initialiseAppSession()
+        navigationInitialisationService.initialiseNavigation(verifierRemoved: verifierRemoved) { [weak self] in
+            guard let self = self else { return }
+            seedsMediator.refreshSeeds()
+            onboardingDone = true
+            warningStateMediator.updateWarnings()
+            initialisationService.initialiseAppSession()
+        }
     }
 }


### PR DESCRIPTION
## Purpose
This PR provides support for new flow within banana split

## Scope
- redesign Banana Split recovery
- add specific error handling when creation of derived keys fail after recovery of given key set succeeds
- add create derived keys step after banana split
- minor refactors

## Screenshots

| Example |  |
|-|-|
|<img src="https://github.com/paritytech/parity-signer/assets/1955364/da33b127-3044-4aef-b26d-95d0f54e5f56" width="320px">| |
|<img src="https://github.com/paritytech/parity-signer/assets/1955364/eb3e0e6d-712d-4b3a-8415-94911a5df3d9" width="320px">|<img src="https://github.com/paritytech/parity-signer/assets/1955364/63dcbe47-89f0-4d74-bff1-724f08367881" width="320px">|

