### PR TITLE
fix: ios: fix testflight deployment on macos 13

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -82,7 +82,7 @@ jobs:
           KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
 
           # import certificate and provisioning profile from secrets
-          echo -n "$IOS_CERT_BASE64" | base64 --decode --output $CERTIFICATE_PATH
+          echo -n "$IOS_CERT_BASE64" | base64 --decode -o $CERTIFICATE_PATH
 
           # create temporary keychain
           security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH


### PR DESCRIPTION
## Purpose
Syntax for `base64` has changed slightly for macOS 13 so this aims to fix that
