### PR TITLE
feat: ios: default derived key name

### DIFF
--- a/ios/PolkadotVault.xcodeproj/project.pbxproj
+++ b/ios/PolkadotVault.xcodeproj/project.pbxproj
@@ -212,6 +212,8 @@
 		6DA9DAE929E5831C009CC12C /* ManageNetworkDetailsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DA9DAE829E5831C009CC12C /* ManageNetworkDetailsService.swift */; };
 		6DAA6CB129BF482E002329A8 /* AuthenticatedStateMediator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DAA6CB029BF482E002329A8 /* AuthenticatedStateMediator.swift */; };
 		6DAA6CB329BF7155002329A8 /* OnboardingMediator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DAA6CB229BF7155002329A8 /* OnboardingMediator.swift */; };
+		6DB39AA62A45ABFB004B8FAA /* CreateDerivedKeyNameService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DB39AA52A45ABFB004B8FAA /* CreateDerivedKeyNameService.swift */; };
+		6DB39AA92A45C909004B8FAA /* TransparentHelpBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DB39AA82A45C909004B8FAA /* TransparentHelpBox.swift */; };
 		6DB99035295C1080001101DC /* ConnectivityAlertButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DB99034295C1080001101DC /* ConnectivityAlertButton.swift */; };
 		6DB99037295C160D001101DC /* ConnectivityAlertOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DB99036295C160D001101DC /* ConnectivityAlertOverlay.swift */; };
 		6DB99039295E95E9001101DC /* NetworkCapsuleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DB99038295E95E9001101DC /* NetworkCapsuleView.swift */; };
@@ -551,6 +553,8 @@
 		6DA9DAE829E5831C009CC12C /* ManageNetworkDetailsService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManageNetworkDetailsService.swift; sourceTree = "<group>"; };
 		6DAA6CB029BF482E002329A8 /* AuthenticatedStateMediator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatedStateMediator.swift; sourceTree = "<group>"; };
 		6DAA6CB229BF7155002329A8 /* OnboardingMediator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingMediator.swift; sourceTree = "<group>"; };
+		6DB39AA52A45ABFB004B8FAA /* CreateDerivedKeyNameService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateDerivedKeyNameService.swift; sourceTree = "<group>"; };
+		6DB39AA82A45C909004B8FAA /* TransparentHelpBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransparentHelpBox.swift; sourceTree = "<group>"; };
 		6DB99034295C1080001101DC /* ConnectivityAlertButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityAlertButton.swift; sourceTree = "<group>"; };
 		6DB99036295C160D001101DC /* ConnectivityAlertOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityAlertOverlay.swift; sourceTree = "<group>"; };
 		6DB99038295E95E9001101DC /* NetworkCapsuleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkCapsuleView.swift; sourceTree = "<group>"; };
@@ -924,6 +928,7 @@
 				6D10EAC6296FA6410063FB71 /* AttributedInfoBoxView.swift */,
 				6DF3CFEF29937E48002DF203 /* AttributedTintInfoBox.swift */,
 				6D0BF95129F2BBF500F5B569 /* NetworkIconCapsuleView.swift */,
+				6DB39AA82A45C909004B8FAA /* TransparentHelpBox.swift */,
 			);
 			path = Text;
 			sourceTree = "<group>";
@@ -1054,7 +1059,6 @@
 				6D476A1829FC05ED00326F74 /* AddKeySetUpNetworksStepOneView.swift */,
 				6D476A1A29FC05F500326F74 /* AddKeySetUpNetworksStepTwoView.swift */,
 				6D45065D296E94FC0065B4D4 /* DerivationMethodsInfoView.swift */,
-				6D10EAC4296F16EE0063FB71 /* DerivationPathNameView.swift */,
 				6D10EACA2970397E0063FB71 /* CreateDerivedKeyConfirmationView.swift */,
 			);
 			path = Subviews;
@@ -1310,6 +1314,8 @@
 			isa = PBXGroup;
 			children = (
 				6D77F31E296D0C5600044C7C /* CreateKeyNetworkSelectionView.swift */,
+				6D10EAC4296F16EE0063FB71 /* DerivationPathNameView.swift */,
+				6DB39AA72A45C109004B8FAA /* Services */,
 				6D45065C296E94E70065B4D4 /* Subviews */,
 			);
 			path = DerivedKey;
@@ -1508,6 +1514,14 @@
 				6DA501D6290BECBE0096DA4E /* AppState.swift */,
 			);
 			path = Data;
+			sourceTree = "<group>";
+		};
+		6DB39AA72A45C109004B8FAA /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				6DB39AA52A45ABFB004B8FAA /* CreateDerivedKeyNameService.swift */,
+			);
+			path = Services;
 			sourceTree = "<group>";
 		};
 		6DBA658A2A2656B400F04492 /* CreateKeysForNetworks */ = {
@@ -2327,6 +2341,7 @@
 				6DA08B8A29B614C20027CFCB /* RecoverKeySetSeedPhraseView.swift in Sources */,
 				6D932CE6292E0CE6008AD883 /* PrimaryTextField.swift in Sources */,
 				6DD9FF1628C8B85300FB6195 /* HorizontalActionsBottomModal.swift in Sources */,
+				6DB39AA92A45C909004B8FAA /* TransparentHelpBox.swift in Sources */,
 				6D4F779929CAECA500374C83 /* SignSpecsListView.swift in Sources */,
 				6D55F286292CF2F800871896 /* StrokeContainerBackground.swift in Sources */,
 				6DBF6E2728E44DD700CC959F /* ErrorBottomModal.swift in Sources */,
@@ -2347,6 +2362,7 @@
 				6D10EAC5296F16EE0063FB71 /* DerivationPathNameView.swift in Sources */,
 				6D4C0753289AC36100B2EE48 /* Fonts.swift in Sources */,
 				6D199C9F292A8D1100E79113 /* TransactionDetailsView.swift in Sources */,
+				6DB39AA62A45ABFB004B8FAA /* CreateDerivedKeyNameService.swift in Sources */,
 				6D10EAC9296FA8910063FB71 /* Localizable+Formatted.swift in Sources */,
 				6D17EF8628EEEDDA008626E9 /* CameraPreviewUIView.swift in Sources */,
 				6DA501D4290BC55A0096DA4E /* KeyDetailsService.swift in Sources */,

--- a/ios/PolkadotVault/Backend/CreateDerivedKeyService.swift
+++ b/ios/PolkadotVault/Backend/CreateDerivedKeyService.swift
@@ -130,34 +130,6 @@ final class CreateDerivedKeyService {
         }
     }
 
-    func createDerivedKeyOnAllNetworks(
-        _ seedName: String,
-        _ path: String,
-        _ completion: @escaping (Result<Void, Error>) -> Void
-    ) {
-        callQueue.async {
-            let result: Result<Void, Error>
-            let seedPhrase = self.seedsMediator.getSeed(seedName: seedName)
-            do {
-                try getAllNetworks()
-                    .forEach {
-                        try tryCreateAddress(
-                            seedName: seedName,
-                            seedPhrase: seedPhrase,
-                            path: path,
-                            network: $0.key
-                        )
-                    }
-                result = .success(())
-            } catch {
-                result = .failure(error)
-            }
-            self.callbackQueue.async {
-                completion(result)
-            }
-        }
-    }
-
     func createDerivedKeyForKeySets(
         _ seedNames: [String],
         _ networkName: String,

--- a/ios/PolkadotVault/Components/Text/TransparentHelpBox.swift
+++ b/ios/PolkadotVault/Components/Text/TransparentHelpBox.swift
@@ -1,0 +1,46 @@
+//
+//  TransparentHelpBox.swift
+//  PolkadotVault
+//
+//  Created by Krzysztof Rodak on 23/06/2023.
+//
+
+import SwiftUI
+
+struct TransparentHelpBox: View {
+    let text: String
+
+    var body: some View {
+        HStack {
+            Text(text)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .fixedSize(horizontal: false, vertical: true)
+                .foregroundColor(Asset.textAndIconsTertiary.swiftUIColor)
+            Spacer().frame(maxWidth: Spacing.medium)
+            Asset.helpOutline.swiftUIImage
+                .foregroundColor(Asset.accentPink300.swiftUIColor)
+        }
+        .padding(Spacing.medium)
+        .font(PrimaryFont.bodyM.font)
+        .background(
+            RoundedRectangle(cornerRadius: CornerRadius.small)
+                .stroke(Asset.fill12.swiftUIColor, lineWidth: 1)
+                .cornerRadius(CornerRadius.small)
+        )
+    }
+}
+
+#if DEBUG
+    struct TransparentHelpBox_Previews: PreviewProvider {
+        static var previews: some View {
+            VStack {
+                TransparentHelpBox(text: Localizable.KeysExport.KeySets.Label.info.string)
+                    .preferredColorScheme(.dark)
+            }
+            VStack {
+                TransparentHelpBox(text: Localizable.KeysExport.KeySets.Label.info.string)
+                    .preferredColorScheme(.light)
+            }
+        }
+    }
+#endif

--- a/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
+++ b/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
@@ -453,17 +453,21 @@
 "EnterBananaSplitPasswordView.Error.LocalRestoreFailed.Message" = "Given combination of seed phrase and seed name couldn't be saved.";
 "EnterBananaSplitPasswordView.Action.Next" = "Next";
 
-"CreateDerivedKey.Label.Title" = "Select Network";
-"CreateDerivedKey.Label.Footer.Network" = "Learn more about How to Set up networks";
+"CreateDerivedKey.Label.Title" = "Create Derived Key";
+"CreateDerivedKey.Label.Subtitle" = "Step 1 / 2";
+"CreateDerivedKey.Label.Header" = "Select Network";
+"CreateDerivedKey.Label.Footer.Network" = "Haven’t found a network needed?\nLearn more about how to set up networks";
 "CreateDerivedKey.Label.Network.Title" = "Choose Network";
 "CreateDerivedKey.Label.Network.OnAny" = "Allow use on any network";
 
-"CreateDerivedKey.Modal.Path.Title" = "Derivation Path Name";
+"CreateDerivedKey.Modal.Path.Title" = "Create Derived Key";
+"CreateDerivedKey.Modal.Path.Subtitle" = "Step 2 / 2";
+"CreateDerivedKey.Modal.Path.Header" = "Derivation Path Name";
 "CreateDerivedKey.Modal.Path.Action.Navigation" = "Done";
 "CreateDerivedKey.Modal.Path.Action.SoftPath" = " / ";
 "CreateDerivedKey.Modal.Path.Action.HardPath" = "//";
 "CreateDerivedKey.Modal.Path.Action.PasswordedPath" = "///Password";
-"CreateDerivedKey.Modal.Path.Footer.Path" = "Path name example //network//1";
+"CreateDerivedKey.Modal.Path.Footer.Path" = "Proceed with default or enter custom.\nPath name example: //<network>//0. ";
 "CreateDerivedKey.Modal.Path.Suggestion.Path" = "Enter path name";
 "CreateDerivedKey.Modal.Path.Header.Password" = "Confirm Password";
 "CreateDerivedKey.Modal.Path.Placeholder.Password" = "Confirm Password";

--- a/ios/PolkadotVault/Screens/DerivedKey/Services/CreateDerivedKeyNameService.swift
+++ b/ios/PolkadotVault/Screens/DerivedKey/Services/CreateDerivedKeyNameService.swift
@@ -1,0 +1,35 @@
+//
+//  CreateDerivedKeyNameService.swift
+//  PolkadotVault
+//
+//  Created by Krzysztof Rodak on 23/06/2023.
+//
+
+import Foundation
+
+final class CreateDerivedKeyNameService {
+    func defaultDerivedKeyName(_ keySet: MKeysNew, network: MmNetwork) -> String {
+        let currentPaths = keySet.set.map(\.key.address.path)
+        let isPrimaryPathPresent = currentPaths.contains { $0 == network.pathId }
+        if !isPrimaryPathPresent {
+            return network.pathId
+        }
+        let numericPaths = currentPaths.compactMap {
+            var trimmedValue = $0
+            if let range = trimmedValue.range(of: "\(network.pathId)\(DerivationPathComponent.hard.description)"),
+               range.lowerBound == trimmedValue.startIndex {
+                trimmedValue.removeSubrange(range)
+                return Int(trimmedValue)
+            }
+            return nil
+        }.sorted()
+        var lowestAvailableNumericPath = 0
+        for path in numericPaths {
+            if path != lowestAvailableNumericPath {
+                break
+            }
+            lowestAvailableNumericPath += 1
+        }
+        return "\(network.pathId)\(DerivationPathComponent.hard.description)\(lowestAvailableNumericPath)"
+    }
+}

--- a/ios/PolkadotVault/Screens/KeyDetails/Views/KeyDetails+ViewModel.swift
+++ b/ios/PolkadotVault/Screens/KeyDetails/Views/KeyDetails+ViewModel.swift
@@ -185,6 +185,16 @@ extension KeyDetailsView {
                 isSnackbarPresented = true
             }
         }
+
+        func createDerivedKeyViewModel() -> CreateKeyNetworkSelectionView.ViewModel {
+            .init(
+                seedName: keysData?.root?.address.seedName ?? "",
+                keyName: keyName,
+                // swiftlint: disable:next force_unwrapping
+                keySet: keysData!,
+                onCompletion: onAddDerivedKeyCompletion(_:)
+            )
+        }
     }
 }
 

--- a/ios/PolkadotVault/Screens/KeyDetails/Views/KeyDetailsView.swift
+++ b/ios/PolkadotVault/Screens/KeyDetails/Views/KeyDetailsView.swift
@@ -173,14 +173,9 @@ struct KeyDetailsView: View {
             onDismiss: viewModel.refreshData
         ) {
             NavigationView {
-                CreateKeyNetworkSelectionView(viewModel: .init(
-                    seedName: viewModel.keysData?.root?.address
-                        .seedName ?? "",
-                    keyName: viewModel.keyName,
-                    onCompletion: viewModel.onAddDerivedKeyCompletion(_:)
-                ))
-                .navigationViewStyle(StackNavigationViewStyle())
-                .navigationBarHidden(true)
+                CreateKeyNetworkSelectionView(viewModel: viewModel.createDerivedKeyViewModel())
+                    .navigationViewStyle(StackNavigationViewStyle())
+                    .navigationBarHidden(true)
             }
         }
         .bottomSnackbar(


### PR DESCRIPTION
## Purpose
This PR adds default derived key name strategy and removes "Allowed on any network" option when creating key


## Screenshots

| Primary derived key | "Numeric" derived key |
|-|-|
|<img src="https://github.com/paritytech/parity-signer/assets/1955364/1bec150c-d101-4193-959c-bc94e08c62ff" width="320px">|<img src="https://github.com/paritytech/parity-signer/assets/1955364/2b685711-c848-4d3b-8897-07b040ca71ff" width="320px">|

