### PR TITLE
feat: android support for empty path only password derivation path

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -29,7 +29,6 @@ jobs:
 
       - name:                 Install dependencies
         run:                  |
-          brew update
           brew install swiftgen
           brew install swiftformat
           brew install xcbeautify

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -29,7 +29,6 @@ jobs:
 
       - name:                 Install dependencies
         run:                  |
-          brew update
           brew install swiftgen
           brew install swiftformat
 

--- a/android/src/main/java/io/parity/signer/screens/createderivation/DerivationPathAnalyzer.kt
+++ b/android/src/main/java/io/parity/signer/screens/createderivation/DerivationPathAnalyzer.kt
@@ -16,7 +16,7 @@ import kotlin.math.min
 
 class DerivationPathAnalyzer {
 	// stolen from rust/db_handling/src/identities.rs:99 where it was stolen from sp_core
-	private val regexCheckPath: Regex = "^((//?[^/]+)+)(///.*)?$".toRegex()
+	private val regexCheckPath: Regex = "^((//?[^/]+)*)(///.*)?$".toRegex()
 
 	fun isCorrect(path: String): Boolean {
 		return path.isEmpty() || regexCheckPath.matches(path)

--- a/android/src/test/java/io/parity/signer/screens/createderivation/DerivationPathAnalyzerTest.kt
+++ b/android/src/test/java/io/parity/signer/screens/createderivation/DerivationPathAnalyzerTest.kt
@@ -50,11 +50,13 @@ class DerivationPathAnalyzerTest {
 		assertTrue(analyzer.isCorrect("//seed///sdfsdf"))
 		assertTrue(analyzer.isCorrect("//seed//sdfsdf"))
 		assertTrue(analyzer.isCorrect("/asdd"))
+		assertTrue(analyzer.isCorrect("///sdf"))
+		assertTrue(analyzer.isCorrect("")) //root key
+		assertTrue(analyzer.isCorrect("///some///another"))  //this means password is "some///another" - correct one
+
 		assertTrue(analyzer.isCorrect("///")) // no password is another error - not correctness
 		assertTrue(analyzer.isCorrect("//seed///")) // no password is another error
-		assertTrue(analyzer.isCorrect("///sdf"))
 
 		assertFalse(analyzer.isCorrect("//"))
-		assertTrue(analyzer.isCorrect(""))//root key
 	}
 }

--- a/android/src/test/java/io/parity/signer/screens/createderivation/DerivationPathAnalyzerTest.kt
+++ b/android/src/test/java/io/parity/signer/screens/createderivation/DerivationPathAnalyzerTest.kt
@@ -50,11 +50,11 @@ class DerivationPathAnalyzerTest {
 		assertTrue(analyzer.isCorrect("//seed///sdfsdf"))
 		assertTrue(analyzer.isCorrect("//seed//sdfsdf"))
 		assertTrue(analyzer.isCorrect("/asdd"))
+		assertTrue(analyzer.isCorrect("///")) // no password is another error - not correctness
 		assertTrue(analyzer.isCorrect("//seed///")) // no password is another error
+		assertTrue(analyzer.isCorrect("///sdf"))
 
 		assertFalse(analyzer.isCorrect("//"))
-		assertFalse(analyzer.isCorrect("///"))
-		assertFalse(analyzer.isCorrect("///sdf"))
 		assertTrue(analyzer.isCorrect(""))//root key
 	}
 }


### PR DESCRIPTION
## Purpose
Fixes #1914 

## Scope
android added support for empty path only password derivation path



## Screenshots
<!--
| Left title, i.e. "Before" | Right title, i.e. "After" |
|-|-|
| ![image](https://github.com/paritytech/parity-signer/assets/11879032/4eacfef5-e97d-4be9-8770-efeb0d46c6c7) |  |

