### PR TITLE
feat: #1885: iOS: Dynamic Derivations support

### DIFF
--- a/ios/Packages/Blockies/Sources/Blockies/BlockiesIdenticonGenerator.swift
+++ b/ios/Packages/Blockies/Sources/Blockies/BlockiesIdenticonGenerator.swift
@@ -26,7 +26,7 @@ public final class BlockiesIdenticonGenerator {
     private let patternGenerator: PatternGenerator
     private let imageRenderer: BlockiesImageRenderer
     private let colorGenerator: PseudoRandomColorGenerator
-    
+
     /// Initializes a new `BlockiesIdenticonGenerator` instance.
     ///
     /// - Parameters:
@@ -42,7 +42,7 @@ public final class BlockiesIdenticonGenerator {
         imageRenderer = BlockiesImageRenderer(randomNumberGenerator: randomNumberGenerator)
         colorGenerator = PseudoRandomColorGenerator(randomNumberGenerator: randomNumberGenerator)
     }
-    
+
     /// Creates a block-style identicon image from a seed string.
     ///
     /// - Parameters:
@@ -50,7 +50,7 @@ public final class BlockiesIdenticonGenerator {
     ///   - customScale: An optional scaling factor for the size of the blocks.
     ///
     /// - Returns: The generated block-style identicon image.
-    
+
     public func createImage(seed: String, customScale: Int = 1) -> PlatformImage? {
         randomNumberGenerator.loadSeed(from: seed)
         let colors = colorGenerator.generateColors()

--- a/ios/PolkadotVault.xcodeproj/project.pbxproj
+++ b/ios/PolkadotVault.xcodeproj/project.pbxproj
@@ -214,6 +214,7 @@
 		6DA9DAE929E5831C009CC12C /* ManageNetworkDetailsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DA9DAE829E5831C009CC12C /* ManageNetworkDetailsService.swift */; };
 		6DAA6CB129BF482E002329A8 /* AuthenticatedStateMediator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DAA6CB029BF482E002329A8 /* AuthenticatedStateMediator.swift */; };
 		6DAA6CB329BF7155002329A8 /* OnboardingMediator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DAA6CB229BF7155002329A8 /* OnboardingMediator.swift */; };
+		6DB39AA42A4579E0004B8FAA /* AddDerivedKeysView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DB39AA32A4579E0004B8FAA /* AddDerivedKeysView.swift */; };
 		6DB39AA62A45ABFB004B8FAA /* CreateDerivedKeyNameService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DB39AA52A45ABFB004B8FAA /* CreateDerivedKeyNameService.swift */; };
 		6DB39AA92A45C909004B8FAA /* TransparentHelpBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DB39AA82A45C909004B8FAA /* TransparentHelpBox.swift */; };
 		6DB99035295C1080001101DC /* ConnectivityAlertButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DB99034295C1080001101DC /* ConnectivityAlertButton.swift */; };
@@ -557,6 +558,7 @@
 		6DA9DAE829E5831C009CC12C /* ManageNetworkDetailsService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManageNetworkDetailsService.swift; sourceTree = "<group>"; };
 		6DAA6CB029BF482E002329A8 /* AuthenticatedStateMediator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatedStateMediator.swift; sourceTree = "<group>"; };
 		6DAA6CB229BF7155002329A8 /* OnboardingMediator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingMediator.swift; sourceTree = "<group>"; };
+		6DB39AA32A4579E0004B8FAA /* AddDerivedKeysView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddDerivedKeysView.swift; sourceTree = "<group>"; };
 		6DB39AA52A45ABFB004B8FAA /* CreateDerivedKeyNameService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateDerivedKeyNameService.swift; sourceTree = "<group>"; };
 		6DB39AA82A45C909004B8FAA /* TransparentHelpBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransparentHelpBox.swift; sourceTree = "<group>"; };
 		6DB99034295C1080001101DC /* ConnectivityAlertButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityAlertButton.swift; sourceTree = "<group>"; };
@@ -1539,12 +1541,12 @@
 			path = DynamicDerivations;
 			sourceTree = "<group>";
 		};
-		6DB39AA72A45C109004B8FAA /* Services */ = {
+		6DB39AA22A4579CF004B8FAA /* DynamicDerivations */ = {
 			isa = PBXGroup;
 			children = (
-				6DB39AA52A45ABFB004B8FAA /* CreateDerivedKeyNameService.swift */,
+				6DB39AA32A4579E0004B8FAA /* AddDerivedKeysView.swift */,
 			);
-			path = Services;
+			path = DynamicDerivations;
 			sourceTree = "<group>";
 		};
 		6DBA658A2A2656B400F04492 /* CreateKeysForNetworks */ = {
@@ -2229,6 +2231,7 @@
 				6D52E3B12946FF5E00AD72F0 /* NetworkLogoIcon.swift in Sources */,
 				6D52E3A52946C3B400AD72F0 /* SettingsView.swift in Sources */,
 				6DA2ACA22939CB3900AAEADC /* CancelBag.swift in Sources */,
+				6DB39AA42A4579E0004B8FAA /* AddDerivedKeysView.swift in Sources */,
 				6DFE588F297A9F78002BFDBF /* ServiceError.swift in Sources */,
 				6D52E3A72946C45100AD72F0 /* SettingsItem.swift in Sources */,
 				6D4F711929F913FC00729610 /* KeyDetailsPublicKeyViewModel.swift in Sources */,

--- a/ios/PolkadotVault.xcodeproj/project.pbxproj
+++ b/ios/PolkadotVault.xcodeproj/project.pbxproj
@@ -254,6 +254,7 @@
 		6DC909F629C87C8C00AE6BAD /* LogsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DC909F529C87C8C00AE6BAD /* LogsService.swift */; };
 		6DC9C486294B7F57000E6899 /* NetworkSelectionSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DC9C485294B7F57000E6899 /* NetworkSelectionSettings.swift */; };
 		6DCC572728D8C0490014278A /* BackupModal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DCC572628D8C0490014278A /* BackupModal.swift */; };
+		6DD17CA42A77A3DD008442FD /* Error+RustDisplayError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DD17CA32A77A3DD008442FD /* Error+RustDisplayError.swift */; };
 		6DD4A6A429E9404200FA6746 /* CreateKeySetService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DD4A6A329E9404200FA6746 /* CreateKeySetService.swift */; };
 		6DD4A6A629E9480700FA6746 /* KeyListService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DD4A6A529E9480700FA6746 /* KeyListService.swift */; };
 		6DD860E8299CAD140000D81E /* OnboadingAirgapView+Components.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DD860E7299CAD140000D81E /* OnboadingAirgapView+Components.swift */; };
@@ -600,6 +601,7 @@
 		6DC909F529C87C8C00AE6BAD /* LogsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogsService.swift; sourceTree = "<group>"; };
 		6DC9C485294B7F57000E6899 /* NetworkSelectionSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkSelectionSettings.swift; sourceTree = "<group>"; };
 		6DCC572628D8C0490014278A /* BackupModal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupModal.swift; sourceTree = "<group>"; };
+		6DD17CA32A77A3DD008442FD /* Error+RustDisplayError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Error+RustDisplayError.swift"; sourceTree = "<group>"; };
 		6DD4A6A329E9404200FA6746 /* CreateKeySetService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateKeySetService.swift; sourceTree = "<group>"; };
 		6DD4A6A529E9480700FA6746 /* KeyListService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyListService.swift; sourceTree = "<group>"; };
 		6DD860E4299CAAA70000D81E /* OnboardingAirgapView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnboardingAirgapView.swift; sourceTree = "<group>"; };
@@ -1548,7 +1550,7 @@
 			path = Data;
 			sourceTree = "<group>";
 		};
-	   	6DB39AA22A4579CF004B8FAA /* DynamicDerivations */ = {
+		6DB39AA22A4579CF004B8FAA /* DynamicDerivations */ = {
 			isa = PBXGroup;
 			children = (
 				6DB39AA32A4579E0004B8FAA /* AddDerivedKeysView.swift */,
@@ -1573,6 +1575,7 @@
 				6D2D244C28CE55A000862726 /* String+Utilities.swift */,
 				6D16687C28F84953008C664A /* EnvironmentValues+SafeAreaInsets.swift */,
 				6D10EAC8296FA8910063FB71 /* Localizable+Formatted.swift */,
+				6DD17CA32A77A3DD008442FD /* Error+RustDisplayError.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -2176,6 +2179,7 @@
 				6DDD73732940471900F04CE7 /* Event+AdditionalValue.swift in Sources */,
 				6D10EACB2970397E0063FB71 /* CreateDerivedKeyConfirmationView.swift in Sources */,
 				6D850BE2292F85F200BA9017 /* SecuredTextField.swift in Sources */,
+				6DD17CA42A77A3DD008442FD /* Error+RustDisplayError.swift in Sources */,
 				2DA5F87627566D7C00D8DD29 /* TransactionPreview.swift in Sources */,
 				6D7129252952C3D50048558C /* VerticalRoundedBackgroundContainer.swift in Sources */,
 				6DF5543629E952270078B8DC /* RecoverKeySetService.swift in Sources */,

--- a/ios/PolkadotVault.xcodeproj/project.pbxproj
+++ b/ios/PolkadotVault.xcodeproj/project.pbxproj
@@ -88,6 +88,8 @@
 		6D31E7C42A404C4A00BF9D9B /* UnknownNetworkIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D31E7C32A404C4A00BF9D9B /* UnknownNetworkIcon.swift */; };
 		6D3423352994F0D200F3BA27 /* ErrorBottomModalViewModel+TransactionErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D3423342994F0D200F3BA27 /* ErrorBottomModalViewModel+TransactionErrors.swift */; };
 		6D34233A299615FD00F3BA27 /* MVerifier+Type.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D342339299615FD00F3BA27 /* MVerifier+Type.swift */; };
+		6D36CBB72A557E660001BB31 /* AddDerivedKeysData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D36CBB62A557E660001BB31 /* AddDerivedKeysData.swift */; };
+		6D36CBBA2A55834B0001BB31 /* CreateDerivedKeyNameService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D36CBB92A55834B0001BB31 /* CreateDerivedKeyNameService.swift */; };
 		6D3A538729968D920004DDDD /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6D3A538629968D920004DDDD /* LaunchScreen.storyboard */; };
 		6D3A538E299B162F0004DDDD /* OnboardingScreenshotsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D3A538D299B162F0004DDDD /* OnboardingScreenshotsView.swift */; };
 		6D3DF92829920AA800B8A430 /* UnknownNetworkColorsGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D3DF92729920AA800B8A430 /* UnknownNetworkColorsGenerator.swift */; };
@@ -215,7 +217,6 @@
 		6DAA6CB129BF482E002329A8 /* AuthenticatedStateMediator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DAA6CB029BF482E002329A8 /* AuthenticatedStateMediator.swift */; };
 		6DAA6CB329BF7155002329A8 /* OnboardingMediator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DAA6CB229BF7155002329A8 /* OnboardingMediator.swift */; };
 		6DB39AA42A4579E0004B8FAA /* AddDerivedKeysView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DB39AA32A4579E0004B8FAA /* AddDerivedKeysView.swift */; };
-		6DB39AA62A45ABFB004B8FAA /* CreateDerivedKeyNameService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DB39AA52A45ABFB004B8FAA /* CreateDerivedKeyNameService.swift */; };
 		6DB39AA92A45C909004B8FAA /* TransparentHelpBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DB39AA82A45C909004B8FAA /* TransparentHelpBox.swift */; };
 		6DB99035295C1080001101DC /* ConnectivityAlertButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DB99034295C1080001101DC /* ConnectivityAlertButton.swift */; };
 		6DB99037295C160D001101DC /* ConnectivityAlertOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DB99036295C160D001101DC /* ConnectivityAlertOverlay.swift */; };
@@ -302,6 +303,7 @@
 		6DF5E7A02922DDAD00F2B5B4 /* MTransaction+TransactionCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DF5E79F2922DDAD00F2B5B4 /* MTransaction+TransactionCards.swift */; };
 		6DF5E7A22923A08A00F2B5B4 /* AttributedString+Markdown.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DF5E7A12923A08A00F2B5B4 /* AttributedString+Markdown.swift */; };
 		6DF5E7A42923DD4400F2B5B4 /* Text+Markdown.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DF5E7A32923DD4400F2B5B4 /* Text+Markdown.swift */; };
+		6DF714712A55652900F6A527 /* DynamicDerivationsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DF714702A55652900F6A527 /* DynamicDerivationsService.swift */; };
 		6DF7257828BE0E08007CD9B6 /* DerivedKeyRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DF7257728BE0E08007CD9B6 /* DerivedKeyRow.swift */; };
 		6DF7751B28B399AC0040012E /* CornerRadius.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DF7751A28B399AC0040012E /* CornerRadius.swift */; };
 		6DF7751E28B39F630040012E /* KeySetRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DF7751D28B39F630040012E /* KeySetRow.swift */; };
@@ -435,6 +437,8 @@
 		6D31E7C32A404C4A00BF9D9B /* UnknownNetworkIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnknownNetworkIcon.swift; sourceTree = "<group>"; };
 		6D3423342994F0D200F3BA27 /* ErrorBottomModalViewModel+TransactionErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ErrorBottomModalViewModel+TransactionErrors.swift"; sourceTree = "<group>"; };
 		6D342339299615FD00F3BA27 /* MVerifier+Type.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MVerifier+Type.swift"; sourceTree = "<group>"; };
+		6D36CBB62A557E660001BB31 /* AddDerivedKeysData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddDerivedKeysData.swift; sourceTree = "<group>"; };
+		6D36CBB92A55834B0001BB31 /* CreateDerivedKeyNameService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CreateDerivedKeyNameService.swift; sourceTree = "<group>"; };
 		6D3A538629968D920004DDDD /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		6D3A538D299B162F0004DDDD /* OnboardingScreenshotsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingScreenshotsView.swift; sourceTree = "<group>"; };
 		6D3DF92729920AA800B8A430 /* UnknownNetworkColorsGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnknownNetworkColorsGenerator.swift; sourceTree = "<group>"; };
@@ -559,7 +563,6 @@
 		6DAA6CB029BF482E002329A8 /* AuthenticatedStateMediator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatedStateMediator.swift; sourceTree = "<group>"; };
 		6DAA6CB229BF7155002329A8 /* OnboardingMediator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingMediator.swift; sourceTree = "<group>"; };
 		6DB39AA32A4579E0004B8FAA /* AddDerivedKeysView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddDerivedKeysView.swift; sourceTree = "<group>"; };
-		6DB39AA52A45ABFB004B8FAA /* CreateDerivedKeyNameService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateDerivedKeyNameService.swift; sourceTree = "<group>"; };
 		6DB39AA82A45C909004B8FAA /* TransparentHelpBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransparentHelpBox.swift; sourceTree = "<group>"; };
 		6DB99034295C1080001101DC /* ConnectivityAlertButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityAlertButton.swift; sourceTree = "<group>"; };
 		6DB99036295C160D001101DC /* ConnectivityAlertOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityAlertOverlay.swift; sourceTree = "<group>"; };
@@ -650,6 +653,7 @@
 		6DF5E79F2922DDAD00F2B5B4 /* MTransaction+TransactionCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MTransaction+TransactionCards.swift"; sourceTree = "<group>"; };
 		6DF5E7A12923A08A00F2B5B4 /* AttributedString+Markdown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AttributedString+Markdown.swift"; sourceTree = "<group>"; };
 		6DF5E7A32923DD4400F2B5B4 /* Text+Markdown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Text+Markdown.swift"; sourceTree = "<group>"; };
+		6DF714702A55652900F6A527 /* DynamicDerivationsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicDerivationsService.swift; sourceTree = "<group>"; };
 		6DF7257728BE0E08007CD9B6 /* DerivedKeyRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DerivedKeyRow.swift; sourceTree = "<group>"; };
 		6DF7751A28B399AC0040012E /* CornerRadius.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CornerRadius.swift; sourceTree = "<group>"; };
 		6DF7751D28B39F630040012E /* KeySetRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeySetRow.swift; sourceTree = "<group>"; };
@@ -815,6 +819,7 @@
 				2DE72BD226A588C9002BB752 /* PolkadotVaultTests */,
 				2DE72BBF26A588C7002BB752 /* Products */,
 				2DE72C0B26A992D9002BB752 /* Frameworks */,
+				6DF7146C2A555CB300F6A527 /* Recovered References */,
 			);
 			sourceTree = "<group>";
 		};
@@ -1032,6 +1037,7 @@
 				6D8973A62A08E6550046A2F3 /* GeneralVerifierService.swift */,
 				6D8973A82A08E6A90046A2F3 /* SettingsTabService.swift */,
 				6D8973AA2A08EE1E0046A2F3 /* SignSpecService.swift */,
+				6DF714702A55652900F6A527 /* DynamicDerivationsService.swift */,
 			);
 			path = Backend;
 			sourceTree = "<group>";
@@ -1069,6 +1075,14 @@
 				6D17D2A02A2E7DF70023B3A7 /* ErrorDisplayed+LocalizedDescription.swift */,
 			);
 			path = Errors;
+			sourceTree = "<group>";
+		};
+		6D36CBB82A55834B0001BB31 /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				6D36CBB92A55834B0001BB31 /* CreateDerivedKeyNameService.swift */,
+			);
+			path = Services;
 			sourceTree = "<group>";
 		};
 		6D45065C296E94E70065B4D4 /* Subviews */ = {
@@ -1333,7 +1347,7 @@
 			children = (
 				6D77F31E296D0C5600044C7C /* CreateKeyNetworkSelectionView.swift */,
 				6D10EAC4296F16EE0063FB71 /* DerivationPathNameView.swift */,
-				6DB39AA72A45C109004B8FAA /* Services */,
+				6D36CBB82A55834B0001BB31 /* Services */,
 				6D45065C296E94E70065B4D4 /* Subviews */,
 			);
 			path = DerivedKey;
@@ -1534,17 +1548,11 @@
 			path = Data;
 			sourceTree = "<group>";
 		};
-		6DB39AA22A4579CF004B8FAA /* DynamicDerivations */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = DynamicDerivations;
-			sourceTree = "<group>";
-		};
-		6DB39AA22A4579CF004B8FAA /* DynamicDerivations */ = {
+	   	6DB39AA22A4579CF004B8FAA /* DynamicDerivations */ = {
 			isa = PBXGroup;
 			children = (
 				6DB39AA32A4579E0004B8FAA /* AddDerivedKeysView.swift */,
+				6D36CBB62A557E660001BB31 /* AddDerivedKeysData.swift */,
 			);
 			path = DynamicDerivations;
 			sourceTree = "<group>";
@@ -1859,6 +1867,13 @@
 			path = CreateKey;
 			sourceTree = "<group>";
 		};
+		6DF7146C2A555CB300F6A527 /* Recovered References */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = "Recovered References";
+			sourceTree = "<group>";
+		};
 		6DF7751C28B39F590040012E /* KeySetsList */ = {
 			isa = PBXGroup;
 			children = (
@@ -2104,6 +2119,7 @@
 		};
 		6DDEF13528AE65D7004CA2FD /* Build libsigner.a */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 12;
 			files = (
 			);
@@ -2267,6 +2283,7 @@
 				6DF07AE429C1141000C01DE8 /* SetUpNetworksStepTwoView.swift in Sources */,
 				6D7DF6542987ADEF00A8438E /* OnboardingState.swift in Sources */,
 				6D16685D28F5C15C008C664A /* CameraVideoOutputDelegate.swift in Sources */,
+				6D36CBB72A557E660001BB31 /* AddDerivedKeysData.swift in Sources */,
 				6D57DC4B289D614F00005C63 /* BackendNavigationAdapter.swift in Sources */,
 				6DC5643528B69355003D540B /* AccessControlProvidingAssembler.swift in Sources */,
 				2DE72BC426A588C7002BB752 /* MainScreenContainer.swift in Sources */,
@@ -2317,6 +2334,7 @@
 				6D2E66FD29DFFC1E000CE788 /* RootPresentationMode.swift in Sources */,
 				6DED2AB52A405DD300EF1C49 /* SelectKeySetsForNetworkKeyView.swift in Sources */,
 				6D14F978293480A900F8EF44 /* InfoBoxView.swift in Sources */,
+				6DF714712A55652900F6A527 /* DynamicDerivationsService.swift in Sources */,
 				6D7B44FC2979263200111D0E /* TermsOfServiceView.swift in Sources */,
 				6D52E3A32946C1B500AD72F0 /* SettingsRowView.swift in Sources */,
 				6D16687F28F86DE0008C664A /* CameraButton.swift in Sources */,
@@ -2390,7 +2408,6 @@
 				6D10EAC5296F16EE0063FB71 /* DerivationPathNameView.swift in Sources */,
 				6D4C0753289AC36100B2EE48 /* Fonts.swift in Sources */,
 				6D199C9F292A8D1100E79113 /* TransactionDetailsView.swift in Sources */,
-				6DB39AA62A45ABFB004B8FAA /* CreateDerivedKeyNameService.swift in Sources */,
 				6D10EAC9296FA8910063FB71 /* Localizable+Formatted.swift in Sources */,
 				6D17EF8628EEEDDA008626E9 /* CameraPreviewUIView.swift in Sources */,
 				6DA501D4290BC55A0096DA4E /* KeyDetailsService.swift in Sources */,
@@ -2401,6 +2418,7 @@
 				6DEB18EA2A0B8EEC0013995E /* Stubs+Signer.swift in Sources */,
 				6D17EF8328EDC951008626E9 /* Encryption+RawRepresentable.swift in Sources */,
 				6DBF6E4328EACB7B00CC959F /* ConnectivityMediator.swift in Sources */,
+				6D36CBBA2A55834B0001BB31 /* CreateDerivedKeyNameService.swift in Sources */,
 				6D7B44FE2979298700111D0E /* PrivacyPolicyView.swift in Sources */,
 				6DC5643928B7DED8003D540B /* KeychainQueryProvider.swift in Sources */,
 				6D52E3AF2946FF5400AD72F0 /* NetworkSelectionModal.swift in Sources */,

--- a/ios/PolkadotVault/Backend/CreateDerivedKeyService.swift
+++ b/ios/PolkadotVault/Backend/CreateDerivedKeyService.swift
@@ -200,7 +200,7 @@ final class CreateDerivedKeyService {
             let result: Result<Void, ImportDerivedKeyError>
             keysToImport.forEach {
                 do {
-                    try tryCreateAddress(
+                    try tryCreateImportedAddress(
                         seedName: seedName,
                         seedPhrase: seedPhrase,
                         path: $0.path,

--- a/ios/PolkadotVault/Backend/CreateDerivedKeyService.swift
+++ b/ios/PolkadotVault/Backend/CreateDerivedKeyService.swift
@@ -206,10 +206,8 @@ final class CreateDerivedKeyService {
                         path: $0.path,
                         network: $0.networkSpecsKey
                     )
-                } catch let displayedError as ErrorDisplayed {
-                    occuredErrors.append((key: $0.path, error: displayedError.localizedDescription))
                 } catch {
-                    occuredErrors.append((key: $0.path, error: error.localizedDescription))
+                    occuredErrors.append((key: $0.path, error: error.backendDisplayError))
                 }
             }
             if occuredErrors.isEmpty {
@@ -233,7 +231,7 @@ final class CreateDerivedKeyService {
         do {
             return try .success(substratePathCheck(seedName: seedName, path: path, network: network))
         } catch {
-            return .failure(.init(message: error.localizedDescription))
+            return .failure(.init(message: error.backendDisplayError))
         }
     }
 

--- a/ios/PolkadotVault/Backend/CreateDerivedKeyService.swift
+++ b/ios/PolkadotVault/Backend/CreateDerivedKeyService.swift
@@ -45,6 +45,25 @@ enum CreateDerivedKeyForKeySetsError: Error {
     }
 }
 
+enum ImportDerivedKeyError: Error {
+    case noKeysImported(errors: [String])
+    case keyNotImported([(key: String, error: String)])
+
+    var localizedDescription: String {
+        switch self {
+        case let .keyNotImported(errorInfo):
+            return errorInfo.reduce(into: "") {
+                $0 += (
+                    Localizable.AddDerivedKeys.Error
+                        .derivedKeyForNetwork($1.key, $1.error) + "\n"
+                )
+            }
+        case let .noKeysImported(errors):
+            return errors.reduce(into: "") { $0 += ($1 + "\n") }
+        }
+    }
+}
+
 final class CreateDerivedKeyService {
     private let databaseMediator: DatabaseMediating
     private let callQueue: Dispatching
@@ -163,6 +182,42 @@ final class CreateDerivedKeyService {
                 result = .success(())
             } else {
                 result = .failure(.keysNotCreated(occuredErrors))
+            }
+            self.callbackQueue.async {
+                completion(result)
+            }
+        }
+    }
+
+    func createDerivedKeys(
+        _ seedName: String,
+        _ seedPhrase: String,
+        keysToImport: [DdDetail],
+        completion: @escaping (Result<Void, ImportDerivedKeyError>) -> Void
+    ) {
+        var occuredErrors: [(key: String, error: String)] = []
+        callQueue.async {
+            let result: Result<Void, ImportDerivedKeyError>
+            keysToImport.forEach {
+                do {
+                    try tryCreateAddress(
+                        seedName: seedName,
+                        seedPhrase: seedPhrase,
+                        path: $0.path,
+                        network: $0.networkSpecsKey
+                    )
+                } catch let displayedError as ErrorDisplayed {
+                    occuredErrors.append((key: $0.path, error: displayedError.localizedDescription))
+                } catch {
+                    occuredErrors.append((key: $0.path, error: error.localizedDescription))
+                }
+            }
+            if occuredErrors.isEmpty {
+                result = .success(())
+            } else if occuredErrors.count == keysToImport.count {
+                result = .failure(.noKeysImported(errors: occuredErrors.map(\.error)))
+            } else {
+                result = .failure(.keyNotImported(occuredErrors))
             }
             self.callbackQueue.async {
                 completion(result)

--- a/ios/PolkadotVault/Backend/CreateDerivedKeyService.swift
+++ b/ios/PolkadotVault/Backend/CreateDerivedKeyService.swift
@@ -55,7 +55,7 @@ enum ImportDerivedKeyError: Error {
             return errorInfo.reduce(into: "") {
                 $0 += (
                     Localizable.AddDerivedKeys.Error
-                        .derivedKeyForNetwork($1.key, $1.error) + "\n"
+                        .DerivedKeyForNetwork.content($1.key, $1.error) + "\n"
                 )
             }
         case let .noKeysImported(errors):

--- a/ios/PolkadotVault/Backend/DynamicDerivationsService.swift
+++ b/ios/PolkadotVault/Backend/DynamicDerivationsService.swift
@@ -33,7 +33,7 @@ final class DynamicDerivationsService {
                 let preview: DdPreview = try previewDynamicDerivations(seeds: seedPhrases, payload: payload)
                 result = .success(preview)
             } catch {
-                result = .failure(.init(message: error.localizedDescription))
+                result = .failure(.init(message: error.backendDisplayError))
             }
             self.callbackQueue.async {
                 completion(result)

--- a/ios/PolkadotVault/Backend/DynamicDerivationsService.swift
+++ b/ios/PolkadotVault/Backend/DynamicDerivationsService.swift
@@ -1,0 +1,43 @@
+//
+//  DynamicDerivationsService.swift
+//  PolkadotVault
+//
+//  Created by Krzysztof Rodak on 05/07/2023.
+//
+
+import Foundation
+
+final class DynamicDerivationsService {
+    private let databaseMediator: DatabaseMediating
+    private let callQueue: Dispatching
+    private let callbackQueue: Dispatching
+
+    init(
+        databaseMediator: DatabaseMediating = DatabaseMediator(),
+        callQueue: Dispatching = DispatchQueue(label: "DynamicDerivationsService", qos: .userInitiated),
+        callbackQueue: Dispatching = DispatchQueue.main
+    ) {
+        self.databaseMediator = databaseMediator
+        self.callQueue = callQueue
+        self.callbackQueue = callbackQueue
+    }
+
+    func getDynamicDerivationsPreview(
+        for seedPhrases: [String: String],
+        payload: String,
+        completion: @escaping (Result<DdPreview, ServiceError>) -> Void
+    ) {
+        callQueue.async {
+            let result: Result<DdPreview, ServiceError>
+            do {
+                let preview: DdPreview = try importDynamicDerivations(seeds: seedPhrases, payload: payload)
+                result = .success(preview)
+            } catch {
+                result = .failure(.init(message: error.localizedDescription))
+            }
+            self.callbackQueue.async {
+                completion(result)
+            }
+        }
+    }
+}

--- a/ios/PolkadotVault/Backend/DynamicDerivationsService.swift
+++ b/ios/PolkadotVault/Backend/DynamicDerivationsService.swift
@@ -30,7 +30,7 @@ final class DynamicDerivationsService {
         callQueue.async {
             let result: Result<DdPreview, ServiceError>
             do {
-                let preview: DdPreview = try importDynamicDerivations(seeds: seedPhrases, payload: payload)
+                let preview: DdPreview = try previewDynamicDerivations(seeds: seedPhrases, payload: payload)
                 result = .success(preview)
             } catch {
                 result = .failure(.init(message: error.localizedDescription))

--- a/ios/PolkadotVault/Backend/ExportMultipleKeysService.swift
+++ b/ios/PolkadotVault/Backend/ExportMultipleKeysService.swift
@@ -56,7 +56,7 @@ final class ExportMultipleKeysService {
                 ).frames
                 result = .success(AnimatedQRCodeViewModel(qrCodes: qrCodes.map(\.payload)))
             } catch {
-                result = .failure(.init(message: error.localizedDescription))
+                result = .failure(.init(message: error.backendDisplayError))
             }
             self.callbackQueue.async {
                 completion(result)

--- a/ios/PolkadotVault/Backend/GetAllNetworksService.swift
+++ b/ios/PolkadotVault/Backend/GetAllNetworksService.swift
@@ -31,7 +31,7 @@ final class GetAllNetworksService {
                 let networks: [MmNetwork] = try getAllNetworks()
                 result = .success(networks)
             } catch {
-                result = .failure(.init(message: error.localizedDescription))
+                result = .failure(.init(message: error.backendDisplayError))
             }
             self.callbackQueue.async {
                 completion(result)

--- a/ios/PolkadotVault/Backend/ImportDerivedKeysService.swift
+++ b/ios/PolkadotVault/Backend/ImportDerivedKeysService.swift
@@ -40,7 +40,7 @@ final class ImportDerivedKeysService {
                 try importDerivations(seedDerivedKeys: seedPreviewsToImport)
                 result = .success(())
             } catch {
-                result = .failure(.init(message: error.localizedDescription))
+                result = .failure(.init(message: error.backendDisplayError))
             }
             self.callbackQueue.async {
                 completion(result)
@@ -61,7 +61,7 @@ final class ImportDerivedKeysService {
             )
             result = .success(filledInSeedPreviews)
         } catch {
-            result = .failure(.init(message: error.localizedDescription))
+            result = .failure(.init(message: error.backendDisplayError))
         }
         callbackQueue.async {
             completion(result)

--- a/ios/PolkadotVault/Backend/KeyDetailsService.swift
+++ b/ios/PolkadotVault/Backend/KeyDetailsService.swift
@@ -32,7 +32,7 @@ final class KeyDetailsService {
                 let keys: MKeysNew = try keysBySeedName(seedName: seedName)
                 result = .success(keys)
             } catch {
-                result = .failure(.init(message: error.localizedDescription))
+                result = .failure(.init(message: error.backendDisplayError))
             }
             self.callbackQueue.async {
                 completion(result)

--- a/ios/PolkadotVault/Backend/KeyListService.swift
+++ b/ios/PolkadotVault/Backend/KeyListService.swift
@@ -16,7 +16,7 @@ final class KeyListService {
         self.navigation = navigation
     }
 
-    func getKeyList() -> MSeeds! {
+    func getKeyList() -> MSeeds? {
         navigation.performFake(navigation: .init(action: .start))
         guard case let .seedSelector(value) = navigation
             .performFake(navigation: .init(action: .navbarKeys))?.screenData else { return nil }

--- a/ios/PolkadotVault/Backend/LogsService.swift
+++ b/ios/PolkadotVault/Backend/LogsService.swift
@@ -47,7 +47,7 @@ final class LogsService {
                 let logDetails: MLogDetails = try PolkadotVault.getLogDetails(order: logIndex)
                 result = .success(logDetails)
             } catch {
-                result = .failure(.init(message: error.localizedDescription))
+                result = .failure(.init(message: error.backendDisplayError))
             }
             self.callbackQueue.async {
                 completion(result)
@@ -64,7 +64,7 @@ final class LogsService {
                 try PolkadotVault.clearLogHistory()
                 result = .success(())
             } catch {
-                result = .failure(.init(message: error.localizedDescription))
+                result = .failure(.init(message: error.backendDisplayError))
             }
             self.callbackQueue.async {
                 completion(result)
@@ -79,10 +79,10 @@ final class LogsService {
         callQueue.async {
             let result: Result<Void, ServiceError>
             do {
-                try PolkadotVault.handleLogComment(userInput: userComment)
+                try handleLogComment(userInput: userComment)
                 result = .success(())
             } catch {
-                result = .failure(.init(message: error.localizedDescription))
+                result = .failure(.init(message: error.backendDisplayError))
             }
             self.callbackQueue.async {
                 completion(result)

--- a/ios/PolkadotVault/Backend/ServiceError.swift
+++ b/ios/PolkadotVault/Backend/ServiceError.swift
@@ -14,4 +14,8 @@ struct ServiceError: Error, CustomStringConvertible {
         [Localizable.Error.Service.Label.prefix.string, message, Localizable.Error.Service.Label.suffix.string]
             .joined(separator: "\n")
     }
+
+    var localizedDescription: String {
+        description
+    }
 }

--- a/ios/PolkadotVault/Design/Heights.swift
+++ b/ios/PolkadotVault/Design/Heights.swift
@@ -31,6 +31,7 @@ enum Heights {
     static let identiconInCell: CGFloat = 36
     /// Height for `Identicon` when used as inline icon
     static let identiconSmall: CGFloat = 16
+    static let identiconInAddDerivedKey: CGFloat = 40
     static let tabbarHeight: CGFloat = 49
     static let textFieldHeight: CGFloat = 48
     static let seedPhraseCapsuleHeight: CGFloat = 32

--- a/ios/PolkadotVault/Design/PrimaryFont.swift
+++ b/ios/PolkadotVault/Design/PrimaryFont.swift
@@ -25,6 +25,8 @@ enum PrimaryFont {
     case labelS
     /// Medium, 13pt
     case labelXS
+    /// Semibold, 12pt
+    case labelXXS
     /// Regular, 16pt
     case bodyL
     /// Regular, 14pt
@@ -54,6 +56,8 @@ extension PrimaryFont {
             return FontFamily.Inter.semiBold.swiftUIFont(size: 14)
         case .labelXS:
             return FontFamily.Inter.medium.swiftUIFont(size: 13)
+        case .labelXXS:
+            return FontFamily.Inter.semiBold.swiftUIFont(size: 12)
         case .bodyL:
             return FontFamily.Inter.regular.swiftUIFont(size: 16)
         case .bodyM:

--- a/ios/PolkadotVault/Extensions/Error+RustDisplayError.swift
+++ b/ios/PolkadotVault/Extensions/Error+RustDisplayError.swift
@@ -1,0 +1,14 @@
+//
+//  Error+RustDisplayError.swift
+//  PolkadotVault
+//
+//  Created by Krzysztof Rodak on 31/07/2023.
+//
+
+import Foundation
+
+extension Error {
+    var backendDisplayError: String {
+        (self as? ErrorDisplayed)?.localizedDescription ?? localizedDescription
+    }
+}

--- a/ios/PolkadotVault/Modals/Errors/ErrorBottomModalViewModel.swift
+++ b/ios/PolkadotVault/Modals/Errors/ErrorBottomModalViewModel.swift
@@ -77,6 +77,18 @@ struct ErrorBottomModalViewModel {
         )
     }
 
+    static func importDynamicDerivedKeys(content: String, _ action: @escaping @autoclosure () -> Void = {}())
+        -> ErrorBottomModalViewModel {
+        ErrorBottomModalViewModel(
+            title: Localizable.AddDerivedKeys.Error.DerivedKeyForNetwork.title.string,
+            content: content,
+            secondaryAction: .init(
+                label: Localizable.ImportKeys.ErrorModal.MissingKeySets.Action.ok.key,
+                action: action
+            )
+        )
+    }
+
     static func importDerivedKeysBadFormat(_ action: @escaping @autoclosure () -> Void = {}())
         -> ErrorBottomModalViewModel {
         ErrorBottomModalViewModel(

--- a/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
+++ b/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
@@ -618,4 +618,6 @@
 "AddDerivedKeys.Label.Header" = "Сheck the keys and scan QR code into Omni Wallet app";
 "AddDerivedKeys.Label.Footer" = "Scan QR code to add the keys";
 "AddDerivedKeys.Action.Done" = "Done";
-
+"AddDerivedKeys.Error.KeySetMissing" = "Some keys can not be imported until their key sets are recovered. Please recover the missing Key Sets.";
+"AddDerivedKeys.Error.NetworkMissing" = "Some keys can not be imported until their networks are added. Please add missing networks and their metadata. ";
+"AddDerivedKeys.Error.AlreadyImported" = "Some are hidden from the list because they have already been imported.";

--- a/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
+++ b/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
@@ -622,3 +622,4 @@
 "AddDerivedKeys.Action.Done" = "Done";
 "AddDerivedKeys.Error.NetworkMissing" = "Some keys can not be imported until their networks are added. Please add missing networks and their metadata. ";
 "AddDerivedKeys.Error.AlreadyImported" = "Some are hidden from the list because they have already been imported.";
+"AddDerivedKeys.Error.DerivedKeyForNetwork" = "Derived key %@ could not be created: %@";

--- a/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
+++ b/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
@@ -125,6 +125,7 @@
 "AddKeySet.Button.Recover" = "Recover Key Set";
 
 "KeyDetails.Label.Derived" = "Derived keys";
+"KeyDetails.Label.ImportedKey" = "Imported from Omni Wallet";
 "KeyDetails.Label.EmptyState.Header" = "Key Set Has No Derived Keys";
 "KeyDetails.Label.EmptyState.Action" = "Create Derived Key";
 
@@ -142,6 +143,7 @@
 
 "PublicKeyDetails.Label.Title" = "Public Key";
 "PublicKeyDetails.Label.Subtitle" = "Derived Key";
+"PublicKeyDetails.Label.ImportedKey" = "Imported from Omni Wallet";
 "PublicKeyDetails.Label.Keys" = "%@ Keys";
 "PublicKeyDetails.Label.KeySetName" = "Key Set Name";
 "PublicKeyDetails.Label.Network" = "Network";

--- a/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
+++ b/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
@@ -613,3 +613,9 @@
 
 "ErrorDisplayed.DbNotInitialized" = "Database not initialized";
 "ErrorDisplayed.MutexPoisoned" = "Mutex poisoned";
+
+"AddDerivedKeys.Label.Title" = "Add Derived Keys";
+"AddDerivedKeys.Label.Header" = "Сheck the keys and scan QR code into Omni Wallet app";
+"AddDerivedKeys.Label.Footer" = "Scan QR code to add the keys";
+"AddDerivedKeys.Action.Done" = "Done";
+

--- a/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
+++ b/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
@@ -622,4 +622,5 @@
 "AddDerivedKeys.Action.Done" = "Done";
 "AddDerivedKeys.Error.NetworkMissing" = "Some keys can not be imported until their networks are added. Please add missing networks and their metadata. ";
 "AddDerivedKeys.Error.AlreadyImported" = "Some are hidden from the list because they have already been imported.";
-"AddDerivedKeys.Error.DerivedKeyForNetwork" = "Derived key %@ could not be created: %@";
+"AddDerivedKeys.Error.DerivedKeyForNetwork.Content" = "Derived key %@ could not be created: %@";
+"AddDerivedKeys.Error.DerivedKeyForNetwork.Title" = "There was an issue importing keys.";

--- a/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
+++ b/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
@@ -620,6 +620,5 @@
 "AddDerivedKeys.Label.Header" = "Сheck the keys and scan QR code into Omni Wallet app";
 "AddDerivedKeys.Label.Footer" = "Scan QR code to add the keys";
 "AddDerivedKeys.Action.Done" = "Done";
-"AddDerivedKeys.Error.KeySetMissing" = "Some keys can not be imported until their key sets are recovered. Please recover the missing Key Sets.";
 "AddDerivedKeys.Error.NetworkMissing" = "Some keys can not be imported until their networks are added. Please add missing networks and their metadata. ";
 "AddDerivedKeys.Error.AlreadyImported" = "Some are hidden from the list because they have already been imported.";

--- a/ios/PolkadotVault/Screens/DerivedKey/DerivationPathNameView.swift
+++ b/ios/PolkadotVault/Screens/DerivedKey/DerivationPathNameView.swift
@@ -357,7 +357,7 @@ private extension DerivationPathNameView.ViewModel {
                 derivationPathError = nil
             }
         case let .failure(error):
-            presentableInfoModal = .alertError(message: error.localizedDescription)
+            presentableInfoModal = .alertError(message: error.backendDisplayError)
             isPresentingInfoModal = true
         }
     }

--- a/ios/PolkadotVault/Screens/KeyDetails/Models/DerivedKeyRowModel.swift
+++ b/ios/PolkadotVault/Screens/KeyDetails/Models/DerivedKeyRowModel.swift
@@ -26,6 +26,7 @@ struct DerivedKeyRowViewModel: Equatable {
     let path: String
     let hasPassword: Bool
     let base58: String
+    let isImported: Bool
     // for Keys Export
     let rootKeyName: String
 
@@ -36,6 +37,7 @@ struct DerivedKeyRowViewModel: Equatable {
         network = key.network.networkLogo
         hasPassword = key.key.address.hasPwd
         base58 = key.key.base58
+        isImported = key.key.wasImported
         rootKeyName = key.key.address.seedName
     }
 }
@@ -48,6 +50,7 @@ extension DerivedKeyRowViewModel {
         path: String,
         hasPassword: Bool,
         base58: String,
+        isImported: Bool,
         rootKeyName: String = ""
     ) {
         self.addressKey = addressKey
@@ -56,6 +59,7 @@ extension DerivedKeyRowViewModel {
         self.path = path
         self.hasPassword = hasPassword
         self.base58 = base58
+        self.isImported = isImported
         self.rootKeyName = rootKeyName
     }
 }

--- a/ios/PolkadotVault/Screens/KeyDetails/Views/DerivedKeyRow.swift
+++ b/ios/PolkadotVault/Screens/KeyDetails/Views/DerivedKeyRow.swift
@@ -26,12 +26,16 @@ struct DerivedKeyRow: View {
             )
             .padding(.top, Spacing.extraExtraSmall)
             .padding(.leading, Spacing.medium)
-            VStack(alignment: .leading) {
+            VStack(alignment: .leading, spacing: Spacing.extraExtraSmall) {
+                if viewModel.isImported {
+                    Localizable.KeyDetails.Label.importedKey.text
+                        .foregroundColor(Asset.textAndIconsTertiary.swiftUIColor)
+                        .font(PrimaryFont.labelXXS.font)
+                }
                 if !isRoot {
                     fullPath
                         .foregroundColor(Asset.textAndIconsTertiary.swiftUIColor)
                         .font(PrimaryFont.captionM.font)
-                    Spacer().frame(height: Spacing.extraExtraSmall)
                 }
                 HStack(spacing: Spacing.extraExtraSmall) {
                     Text(viewModel.base58.truncateMiddle())
@@ -87,6 +91,7 @@ struct DerivedKeyRow: View {
                         path: "//polkadot",
                         hasPassword: false,
                         base58: "15Gsc678654FDSG0HA04H0A",
+                        isImported: true,
                         rootKeyName: ""
                     ),
                     selectedKeys: Binding<[DerivedKeyRowModel]>.constant([]),
@@ -98,7 +103,8 @@ struct DerivedKeyRow: View {
                         network: "kusama",
                         path: "",
                         hasPassword: false,
-                        base58: "15Gsc678654FDSG0HA04H0A"
+                        base58: "15Gsc678654FDSG0HA04H0A",
+                        isImported: false
                     ),
                     selectedKeys: Binding<[DerivedKeyRowModel]>.constant([]),
                     isPresentingSelectionOverlay: Binding<Bool>.constant(true)
@@ -109,7 +115,8 @@ struct DerivedKeyRow: View {
                         network: "astar",
                         path: "//astar",
                         hasPassword: false,
-                        base58: "15Gsc678654FDSG0HA04H0A"
+                        base58: "15Gsc678654FDSG0HA04H0A",
+                        isImported: false
                     ),
                     selectedKeys: Binding<[DerivedKeyRowModel]>.constant([]),
                     isPresentingSelectionOverlay: Binding<Bool>.constant(true)
@@ -120,7 +127,8 @@ struct DerivedKeyRow: View {
                         network: "kusama",
                         path: "//kusama",
                         hasPassword: true,
-                        base58: "15Gsc678654FDSG0HA04H0A"
+                        base58: "15Gsc678654FDSG0HA04H0A",
+                        isImported: true
                     ),
                     selectedKeys: Binding<[DerivedKeyRowModel]>.constant([]),
                     isPresentingSelectionOverlay: Binding<Bool>.constant(false)
@@ -131,7 +139,8 @@ struct DerivedKeyRow: View {
                         network: "kusama",
                         path: "//kusama//verylongpathsolongitrequirestwolinesoftextormaybeevenmoremaybethree",
                         hasPassword: true,
-                        base58: "15Gsc678654FDSG0HA04H0A"
+                        base58: "15Gsc678654FDSG0HA04H0A",
+                        isImported: false
                     ),
                     selectedKeys: Binding<[DerivedKeyRowModel]>.constant([]),
                     isPresentingSelectionOverlay: Binding<Bool>.constant(false)

--- a/ios/PolkadotVault/Screens/KeySetsList/KeySetList.swift
+++ b/ios/PolkadotVault/Screens/KeySetsList/KeySetList.swift
@@ -258,7 +258,9 @@ extension KeySetList {
         }
 
         func updateData() {
-            dataModel = keyListService.getKeyList()
+            if let keyList = keyListService.getKeyList() {
+                dataModel = keyList
+            }
             updateView(dataModel)
         }
 

--- a/ios/PolkadotVault/Screens/PublicKey/KeyDetailsPublicKeyView.swift
+++ b/ios/PolkadotVault/Screens/PublicKey/KeyDetailsPublicKeyView.swift
@@ -54,6 +54,18 @@ struct KeyDetailsPublicKeyView: View {
                                 viewModel: viewModel.renderable.footer,
                                 backgroundColor: Asset.fill6Solid.swiftUIColor
                             )
+                            if viewModel.keyDetails.wasImported {
+                                Divider()
+                                    .padding(.horizontal, Spacing.medium)
+                                HStack(spacing: 0) {
+                                    Spacer()
+                                    Localizable.PublicKeyDetails.Label.importedKey.text
+                                        .font(PrimaryFont.captionM.font)
+                                        .foregroundColor(Asset.textAndIconsTertiary.swiftUIColor)
+                                        .padding(.vertical, Spacing.small)
+                                    Spacer()
+                                }
+                            }
                         }
                         .strokeContainerBackground()
                         // Key data
@@ -212,7 +224,7 @@ extension KeyDetailsPublicKeyView {
     }
 
     final class ViewModel: ObservableObject {
-        private let keyDetails: MKeyDetails
+        let keyDetails: MKeyDetails
         private let publicKeyDetails: String
         private let publicKeyDetailsService: PublicKeyDetailsService
         private let exportPrivateKeyService: ExportPrivateKeyService

--- a/ios/PolkadotVault/Screens/Scan/CameraView.swift
+++ b/ios/PolkadotVault/Screens/Scan/CameraView.swift
@@ -254,7 +254,7 @@ struct CameraView: View {
 
     func addDerivedKeysView() -> AddDerivedKeysView.ViewModel {
         .init(
-            dataModel: .stub,
+            dataModel: .init(viewModel.dynamicDerivationsPreview),
             isPresented: $viewModel.isPresentingAddDerivedKeys,
             onCompletion: viewModel.onAddDerivedKeyCompletion(_:)
         )

--- a/ios/PolkadotVault/Screens/Scan/CameraView.swift
+++ b/ios/PolkadotVault/Screens/Scan/CameraView.swift
@@ -255,6 +255,7 @@ struct CameraView: View {
     func addDerivedKeysView() -> AddDerivedKeysView.ViewModel {
         .init(
             dataModel: .init(viewModel.dynamicDerivationsPreview),
+            dynamicDerivationsPreview: viewModel.dynamicDerivationsPreview,
             isPresented: $viewModel.isPresentingAddDerivedKeys,
             onCompletion: viewModel.onAddDerivedKeyCompletion(_:)
         )

--- a/ios/PolkadotVault/Screens/Scan/CameraView.swift
+++ b/ios/PolkadotVault/Screens/Scan/CameraView.swift
@@ -485,6 +485,7 @@ extension CameraView {
             case .onDone:
                 ()
             }
+            resumeCamera()
         }
     }
 }

--- a/ios/PolkadotVault/Screens/Scan/CameraView.swift
+++ b/ios/PolkadotVault/Screens/Scan/CameraView.swift
@@ -198,6 +198,14 @@ struct CameraView: View {
             )
             .clearModalBackground()
         }
+        .fullScreenModal(
+            isPresented: $viewModel.isPresentingAddDerivedKeys
+        ) {
+            AddDerivedKeysView(
+                viewModel: addDerivedKeysView()
+            )
+            .clearModalBackground()
+        }
         .bottomSnackbar(
             viewModel.snackbarViewModel,
             isPresented: $viewModel.isSnackbarPresented
@@ -242,6 +250,14 @@ struct CameraView: View {
             onCompletion: viewModel.onSelectKeySetsForNetworkCompletion(_:)
         )
     }
+
+    func addDerivedKeysView() -> AddDerivedKeysView.ViewModel {
+        .init(
+            dataModel: .stub,
+            isPresented: $viewModel.isPresentingAddDerivedKeys,
+            onCompletion: viewModel.onAddDerivedKeyCompletion(_:)
+        )
+    }
 }
 
 extension CameraView {
@@ -267,6 +283,9 @@ extension CameraView {
         @Published var shouldPresentKeySetSelection: Bool = false
         @Published var isPresentingKeySetSelection: Bool = false
         var networkName: String!
+
+        // Dynamic Derived Keys
+        @Published var isPresentingAddDerivedKeys: Bool = false
 
         // Data models for modals
         @Published var transactions: [MTransaction] = []
@@ -477,6 +496,15 @@ extension CameraView {
             cameraModel?.multipleTransactions = []
             cameraModel?.start()
             clearTransactionState()
+        }
+
+        func onAddDerivedKeyCompletion(_ onComplete: AddDerivedKeysView.OnCompletionAction) {
+            switch onComplete {
+            case .onCancel:
+                ()
+            case .onDone:
+                ()
+            }
         }
     }
 }

--- a/ios/PolkadotVault/Screens/Scan/CameraView.swift
+++ b/ios/PolkadotVault/Screens/Scan/CameraView.swift
@@ -292,6 +292,7 @@ extension CameraView {
         @Published var transactions: [MTransaction] = []
         @Published var signature: MSignatureReady?
         @Published var enterPassword: MEnterPassword!
+        @Published var dynamicDerivationsPreview: DdPreview!
         @Published var presentableError: ErrorBottomModalViewModel = .signingForgotPassword()
         var snackbarViewModel: SnackbarViewModel = .init(title: "")
         @Published var isSnackbarPresented: Bool = false
@@ -574,6 +575,8 @@ private extension CameraView.ViewModel {
         dynamicDerivationsService.getDynamicDerivationsPreview(for: seedPhrases, payload: payload) { result in
             switch result {
             case let .success(preview):
+                self.dynamicDerivationsPreview = preview
+                self.isPresentingAddDerivedKeys = true
                 ()
             case let .failure(error):
                 self.presentableError = .alertError(message: error.localizedDescription)

--- a/ios/PolkadotVault/Screens/Scan/CameraView.swift
+++ b/ios/PolkadotVault/Screens/Scan/CameraView.swift
@@ -19,8 +19,9 @@ struct CameraView: View {
             // Full screen camera preview
             CameraPreview(session: model.session)
                 .onReceive(model.$payload) { payload in
+                    guard let payload else { return }
                     DispatchQueue.main.async {
-                        viewModel.checkForTransactionNavigation(payload)
+                        viewModel.didUpdatePayload(payload)
                     }
                 }
                 .onChange(of: model.total) { total in
@@ -297,6 +298,7 @@ extension CameraView {
 
         @Binding var isPresented: Bool
         private let scanService: ScanTabService
+        private let dynamicDerivationsService: DynamicDerivationsService
         private let seedsMediator: SeedsMediating
 
         private weak var cameraModel: CameraService?
@@ -304,11 +306,13 @@ extension CameraView {
         init(
             isPresented: Binding<Bool>,
             seedsMediator: SeedsMediating = ServiceLocator.seedsMediator,
-            scanService: ScanTabService = ScanTabService()
+            scanService: ScanTabService = ScanTabService(),
+            dynamicDerivationsService: DynamicDerivationsService = DynamicDerivationsService()
         ) {
             _isPresented = isPresented
             self.seedsMediator = seedsMediator
             self.scanService = scanService
+            self.dynamicDerivationsService = dynamicDerivationsService
         }
 
         func onAppear() {
@@ -319,39 +323,14 @@ extension CameraView {
             self.cameraModel = cameraModel
         }
 
-        func checkForTransactionNavigation(_ payload: String?) {
-            guard let payload = payload, !isInTransactionProgress else { return }
+        func didUpdatePayload(_ payload: DecodedPayload) {
+            guard !isInTransactionProgress else { return }
             isInTransactionProgress = true
-            switch scanService.performTransaction(with: payload) {
-            case let .success(actionResult):
-                // Handle transactions with just error payload
-                guard case let .transaction(transactions) = actionResult.screenData else { return }
-                if transactions.allSatisfy(\.isDisplayingErrorOnly) {
-                    presentableError = .transactionSigningError(
-                        message: transactions
-                            .reduce("") { $0 + $1.transactionIssues() + ($1 == transactions.last ? "\n" : "") }
-                    )
-                    isPresentingError = true
-                    scanService.resetNavigationState()
-                    return
-                }
-                // Handle rest of transactions with optional error payload
-                // Type is assumed based on first error
-                let firstTransaction = transactions.first
-                switch firstTransaction?.ttype {
-                case .sign:
-                    continueTransactionSignature(transactions)
-                case .importDerivations:
-                    continueImportDerivedKeys(transactions)
-                default:
-                    // Transaction with error
-                    // Transaction that does not require signing (i.e. adding network or metadata)
-                    self.transactions = transactions
-                    isPresentingTransactionPreview = true
-                }
-            case let .failure(error):
-                presentableError = ErrorBottomModalViewModel.transactionError(for: error)
-                isPresentingError = true
+            switch payload.type {
+            case .dynamicDerivations:
+                startDynamicDerivationsFlow(payload.payload)
+            case .transaction:
+                startTransactionSigningFlow(payload.payload)
             }
         }
 
@@ -511,7 +490,41 @@ extension CameraView {
 
 // MARK: - Transaction Signature
 
-extension CameraView.ViewModel {
+private extension CameraView.ViewModel {
+    func startTransactionSigningFlow(_ payload: String) {
+        switch scanService.performTransaction(with: payload) {
+        case let .success(actionResult):
+            // Handle transactions with just error payload
+            guard case let .transaction(transactions) = actionResult.screenData else { return }
+            if transactions.allSatisfy(\.isDisplayingErrorOnly) {
+                presentableError = .transactionSigningError(
+                    message: transactions
+                        .reduce("") { $0 + $1.transactionIssues() + ($1 == transactions.last ? "\n" : "") }
+                )
+                isPresentingError = true
+                scanService.resetNavigationState()
+                return
+            }
+            // Handle rest of transactions with optional error payload
+            // Type is assumed based on first error
+            let firstTransaction = transactions.first
+            switch firstTransaction?.ttype {
+            case .sign:
+                continueTransactionSignature(transactions)
+            case .importDerivations:
+                continueImportDerivedKeys(transactions)
+            default:
+                // Transaction with error
+                // Transaction that does not require signing (i.e. adding network or metadata)
+                self.transactions = transactions
+                isPresentingTransactionPreview = true
+            }
+        case let .failure(error):
+            presentableError = ErrorBottomModalViewModel.transactionError(for: error)
+            isPresentingError = true
+        }
+    }
+
     func continueTransactionSignature(_ transactions: [MTransaction]) {
         let actionResult = sign(transactions: transactions)
         self.transactions = transactions
@@ -549,6 +562,23 @@ extension CameraView.ViewModel {
         } else {
             self.transactions = transactions
             isPresentingTransactionPreview = true
+        }
+    }
+}
+
+// MARK: - Dynamic Derivations
+
+private extension CameraView.ViewModel {
+    func startDynamicDerivationsFlow(_ payload: String) {
+        let seedPhrases = seedsMediator.getAllSeeds()
+        dynamicDerivationsService.getDynamicDerivationsPreview(for: seedPhrases, payload: payload) { result in
+            switch result {
+            case let .success(preview):
+                ()
+            case let .failure(error):
+                self.presentableError = .alertError(message: error.localizedDescription)
+                self.isPresentingError = true
+            }
         }
     }
 }

--- a/ios/PolkadotVault/Screens/Scan/DynamicDerivations/AddDerivedKeysData.swift
+++ b/ios/PolkadotVault/Screens/Scan/DynamicDerivations/AddDerivedKeysData.swift
@@ -1,0 +1,65 @@
+//
+//  AddDerivedKeysData.swift
+//  PolkadotVault
+//
+//  Created by Krzysztof Rodak on 05/07/2023.
+//
+
+import Foundation
+
+extension AddDerivedKeysData {
+    init(_ preview: DdPreview) {
+        keySets = preview.keySets.map(AddDerivedKeyKeySetData.init)
+        qrPayload = preview.qr.map(\.payload)
+        var errors = [AddDerivedKeysError]()
+        if preview.isSomeKeysetMissing {
+            errors.append(.init(errorMessage: Localizable.AddDerivedKeys.Error.keySetMissing.string))
+        }
+        if preview.isSomeNetworkMissing {
+            errors.append(.init(errorMessage: Localizable.AddDerivedKeys.Error.networkMissing.string))
+        }
+        if preview.isSomeAlreadyImported {
+            errors.append(.init(errorMessage: Localizable.AddDerivedKeys.Error.alreadyImported.string))
+        }
+        self.errors = errors
+    }
+}
+
+extension AddDerivedKeyKeySetData {
+    init(_ keySet: DdKeySet) {
+        keySetName = keySet.seedName
+        derivedKeys = keySet.derivations.map(AddDerivedKeyDerivedKeyData.init)
+    }
+}
+
+struct AddDerivedKeyDerivedKeyData: Equatable {
+    let path: String
+    let base58: String
+    let identicon: SignerImage
+    let network: String
+}
+
+extension AddDerivedKeyDerivedKeyData {
+    init(_ detail: DdDetail) {
+        path = detail.path
+        base58 = detail.base58
+        identicon = detail.identicon
+        network = detail.networkLogo
+    }
+}
+
+struct AddDerivedKeyKeySetData: Equatable {
+    let keySetName: String
+    let derivedKeys: [AddDerivedKeyDerivedKeyData]
+}
+
+struct AddDerivedKeysError: Equatable, Identifiable, Hashable {
+    let id = UUID()
+    let errorMessage: String
+}
+
+struct AddDerivedKeysData: Equatable {
+    let errors: [AddDerivedKeysError]
+    let keySets: [AddDerivedKeyKeySetData]
+    let qrPayload: [[UInt8]]
+}

--- a/ios/PolkadotVault/Screens/Scan/DynamicDerivations/AddDerivedKeysData.swift
+++ b/ios/PolkadotVault/Screens/Scan/DynamicDerivations/AddDerivedKeysData.swift
@@ -9,12 +9,9 @@ import Foundation
 
 extension AddDerivedKeysData {
     init(_ preview: DdPreview) {
-        keySets = preview.keySets.map(AddDerivedKeyKeySetData.init)
+        keySets = [AddDerivedKeyKeySetData(preview.keySet)]
         qrPayload = preview.qr.map(\.payload)
         var errors = [AddDerivedKeysError]()
-        if preview.isSomeKeysetMissing {
-            errors.append(.init(errorMessage: Localizable.AddDerivedKeys.Error.keySetMissing.string))
-        }
         if preview.isSomeNetworkMissing {
             errors.append(.init(errorMessage: Localizable.AddDerivedKeys.Error.networkMissing.string))
         }

--- a/ios/PolkadotVault/Screens/Scan/DynamicDerivations/AddDerivedKeysView.swift
+++ b/ios/PolkadotVault/Screens/Scan/DynamicDerivations/AddDerivedKeysView.swift
@@ -205,10 +205,10 @@ extension AddDerivedKeysView {
 
         func onDoneTap() {
             let success = { [weak self] in
-                    self?.isPresented = false
-                    self?.onCompletion(.onDone)
+                self?.isPresented = false
+                self?.onCompletion(.onDone)
             }
-            if dynamicDerivationsPreview.keySet.derivations.count > 0 {
+            if !dynamicDerivationsPreview.keySet.derivations.isEmpty {
                 derivedKeysService.createDerivedKeys(
                     dynamicDerivationsPreview.keySet.seedName,
                     seedsMediator.getSeed(seedName: dynamicDerivationsPreview.keySet.seedName),

--- a/ios/PolkadotVault/Screens/Scan/DynamicDerivations/AddDerivedKeysView.swift
+++ b/ios/PolkadotVault/Screens/Scan/DynamicDerivations/AddDerivedKeysView.swift
@@ -1,0 +1,236 @@
+//
+//  AddDerivedKeysView.swift
+//  PolkadotVault
+//
+//  Created by Krzysztof Rodak on 24/06/2023.
+//
+
+import Combine
+import SwiftUI
+
+struct AddDerivedKeyDerivedKeyData: Equatable {
+    let base58: String
+    let identicon: SignerImage
+    let network: String
+}
+
+struct AddDerivedKeyKeySetData: Equatable {
+    let keySetName: String
+    let derivedKeys: [AddDerivedKeyDerivedKeyData]
+}
+
+struct AddDerivedKeysData: Equatable {
+    let keySets: [AddDerivedKeyKeySetData]
+    let qrPayload: [[UInt8]]
+}
+
+struct AddDerivedKeysView: View {
+    @StateObject var viewModel: ViewModel
+    @Environment(\.safeAreaInsets) private var safeAreaInsets
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Navigation Bar
+            NavigationBarView(
+                viewModel: NavigationBarViewModel(
+                    leftButtons: [.init(type: .arrow, action: viewModel.onBackTap)],
+                    backgroundColor: Asset.backgroundPrimary.swiftUIColor
+                )
+            )
+            GeometryReader { geo in
+                ScrollView(showsIndicators: false) {
+                    VStack(alignment: .leading, spacing: 0) {
+                        mainContent()
+                        keySets()
+                        qrCodeFooter()
+                        Spacer()
+                        SecondaryButton(
+                            action: viewModel.onDoneTap(),
+                            text: Localizable.AddDerivedKeys.Action.done.key,
+                            style: .secondary()
+                        )
+                        .padding(Spacing.large)
+                    }
+                    .frame(
+                        minWidth: geo.size.width,
+                        minHeight: geo.size.height
+                    )
+                }
+            }
+            .background(Asset.backgroundPrimary.swiftUIColor)
+        }
+    }
+
+    @ViewBuilder
+    func mainContent() -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Localizable.AddDerivedKeys.Label.title.text
+                .foregroundColor(Asset.textAndIconsPrimary.swiftUIColor)
+                .font(PrimaryFont.titleL.font)
+                .padding(.top, Spacing.extraSmall)
+            Localizable.AddDerivedKeys.Label.header.text
+                .foregroundColor(Asset.textAndIconsPrimary.swiftUIColor)
+                .font(PrimaryFont.bodyL.font)
+                .padding(.vertical, Spacing.extraSmall)
+        }
+        .padding(.horizontal, Spacing.large)
+        .padding(.bottom, Spacing.medium)
+    }
+
+    @ViewBuilder
+    func keySets() -> some View {
+        LazyVStack(spacing: 0) {
+            ForEach(
+                viewModel.dataModel.keySets,
+                id: \.keySetName
+            ) { keySet in
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    Text(keySet.keySetName)
+                        .font(PrimaryFont.titleS.font)
+                        .foregroundColor(Asset.textAndIconsPrimary.swiftUIColor)
+                        .multilineTextAlignment(.leading)
+                        .padding(Spacing.medium)
+                    Divider()
+                        .padding(.horizontal, Spacing.medium)
+                    ForEach(
+                        keySet.derivedKeys,
+                        id: \.base58
+                    ) { key in
+                        derivedKey(for: key)
+                        if key != keySet.derivedKeys.last {
+                            Divider()
+                                .padding(.horizontal, Spacing.medium)
+                        }
+                    }
+                }
+                .containerBackground()
+                .padding(.bottom, Spacing.extraSmall)
+            }
+        }
+        .padding(.horizontal, Spacing.medium)
+    }
+
+    @ViewBuilder
+    func derivedKey(for key: AddDerivedKeyDerivedKeyData) -> some View {
+        HStack(alignment: .center, spacing: 0) {
+            NetworkIdenticon(
+                identicon: key.identicon,
+                network: key.network,
+                background: Asset.fill6.swiftUIColor,
+                size: Heights.identiconInAddDerivedKey
+            )
+            .padding(.vertical, Spacing.medium)
+            .padding(.trailing, Spacing.extraSmall)
+            Text(key.base58.truncateMiddle())
+                .foregroundColor(Asset.textAndIconsPrimary.swiftUIColor)
+                .font(PrimaryFont.bodyL.font)
+            Spacer()
+        }
+        .padding(.horizontal, Spacing.medium)
+    }
+
+    @ViewBuilder
+    func qrCodeFooter() -> some View {
+        VStack(alignment: .leading, spacing: Spacing.medium) {
+            // Header
+            Localizable.AddDerivedKeys.Label.footer.text
+                .font(PrimaryFont.bodyL.font)
+                .foregroundColor(Asset.textAndIconsPrimary.swiftUIColor)
+            // QR Code container
+            VStack(alignment: .leading, spacing: 0) {
+                AnimatedQRCodeView(
+                    viewModel: Binding<AnimatedQRCodeViewModel>.constant(
+                        .init(
+                            qrCodes: viewModel.dataModel.qrPayload
+                        )
+                    )
+                )
+            }
+            .containerBackground()
+        }
+        .padding(.horizontal, Spacing.large)
+        .padding(.top, Spacing.large)
+    }
+}
+
+extension AddDerivedKeysView {
+    enum OnCompletionAction: Equatable {}
+
+    final class ViewModel: ObservableObject {
+        var dataModel: AddDerivedKeysData! = .stub
+        private let onCompletion: (OnCompletionAction) -> Void
+        var onErrorDismiss: (() -> Void)?
+
+        @Binding var isPresented: Bool
+        @Published var isPresentingDerivationPath: Bool = false
+        @Published var keySets: [MmNetwork] = []
+
+        init(
+            isPresented: Binding<Bool>,
+            onCompletion: @escaping (OnCompletionAction) -> Void
+        ) {
+            _isPresented = isPresented
+            self.onCompletion = onCompletion
+        }
+
+        func onDoneTap() {}
+
+        func onBackTap() {
+            isPresented = false
+        }
+    }
+}
+
+#if DEBUG
+    struct AddDerivedKeysView_Previews: PreviewProvider {
+        static var previews: some View {
+            AddDerivedKeysView(
+                viewModel: .init(
+                    isPresented: .constant(true),
+                    onCompletion: { _ in }
+                )
+            )
+        }
+    }
+#endif
+
+extension AddDerivedKeysData {
+    static let stub: AddDerivedKeysData = .init(
+        keySets: [
+            .init(
+                keySetName: "My Key Set",
+                derivedKeys: [
+                    .init(
+                        base58: "1B2lb765432457SkT",
+                        identicon: .stubIdenticon,
+                        network: "polkadot"
+                    ),
+                    .init(
+                        base58: "1iKLh365474566754ZTDE",
+                        identicon: .stubIdenticon,
+                        network: "polkadot"
+                    ),
+                    .init(
+                        base58: "1jkCfy543654765675DOKg",
+                        identicon: .stubIdenticon,
+                        network: "polkadot"
+                    )
+                ]
+            ),
+            .init(
+                keySetName: "Other Key Set",
+                derivedKeys: [
+                    .init(
+                        base58: "1B2lb7653464235453SkT",
+                        identicon: .stubIdenticon,
+                        network: "polkadot"
+                    )
+                ]
+            )
+        ],
+        qrPayload:
+        [
+            Stubs.stubQRCode
+        ]
+    )
+}

--- a/ios/PolkadotVault/Screens/Scan/DynamicDerivations/AddDerivedKeysView.swift
+++ b/ios/PolkadotVault/Screens/Scan/DynamicDerivations/AddDerivedKeysView.swift
@@ -204,19 +204,26 @@ extension AddDerivedKeysView {
         }
 
         func onDoneTap() {
-            derivedKeysService.createDerivedKeys(
-                dynamicDerivationsPreview.keySet.seedName,
-                seedsMediator.getSeed(seedName: dynamicDerivationsPreview.keySet.seedName),
-                keysToImport: dynamicDerivationsPreview.keySet.derivations
-            ) { [weak self] result in
-                switch result {
-                case .success:
+            let success = { [weak self] in
                     self?.isPresented = false
                     self?.onCompletion(.onDone)
-                case let .failure(error):
-                    self?.presentableError = .importDynamicDerivedKeys(content: error.localizedDescription)
-                    self?.isPresentingError = true
+            }
+            if dynamicDerivationsPreview.keySet.derivations.count > 0 {
+                derivedKeysService.createDerivedKeys(
+                    dynamicDerivationsPreview.keySet.seedName,
+                    seedsMediator.getSeed(seedName: dynamicDerivationsPreview.keySet.seedName),
+                    keysToImport: dynamicDerivationsPreview.keySet.derivations
+                ) { [weak self] result in
+                    switch result {
+                    case .success:
+                        success()
+                    case let .failure(error):
+                        self?.presentableError = .importDynamicDerivedKeys(content: error.localizedDescription)
+                        self?.isPresentingError = true
+                    }
                 }
+            } else {
+                success()
             }
         }
 

--- a/ios/PolkadotVault/Screens/Scan/DynamicDerivations/AddDerivedKeysView.swift
+++ b/ios/PolkadotVault/Screens/Scan/DynamicDerivations/AddDerivedKeysView.swift
@@ -8,28 +8,6 @@
 import Combine
 import SwiftUI
 
-struct AddDerivedKeyDerivedKeyData: Equatable {
-    let base58: String
-    let identicon: SignerImage
-    let network: String
-}
-
-struct AddDerivedKeyKeySetData: Equatable {
-    let keySetName: String
-    let derivedKeys: [AddDerivedKeyDerivedKeyData]
-}
-
-struct AddDerivedKeysError: Equatable, Identifiable, Hashable {
-    let id = UUID()
-    let errorMessage: String
-}
-
-struct AddDerivedKeysData: Equatable {
-    let errors: [AddDerivedKeysError]
-    let keySets: [AddDerivedKeyKeySetData]
-    let qrPayload: [[UInt8]]
-}
-
 struct AddDerivedKeysView: View {
     @StateObject var viewModel: ViewModel
     @Environment(\.safeAreaInsets) private var safeAreaInsets
@@ -142,9 +120,18 @@ struct AddDerivedKeysView: View {
             )
             .padding(.vertical, Spacing.medium)
             .padding(.trailing, Spacing.extraSmall)
-            Text(key.base58.truncateMiddle())
-                .foregroundColor(Asset.textAndIconsPrimary.swiftUIColor)
-                .font(PrimaryFont.bodyL.font)
+            VStack(alignment: .leading, spacing: 0) {
+                Text(key.path)
+                    .foregroundColor(Asset.textAndIconsTertiary.swiftUIColor)
+                    .font(PrimaryFont.captionM.font)
+                Spacer().frame(height: Spacing.extraExtraSmall)
+                HStack(spacing: Spacing.extraExtraSmall) {
+                    Text(key.base58.truncateMiddle())
+                        .foregroundColor(Asset.textAndIconsPrimary.swiftUIColor)
+                        .font(PrimaryFont.bodyL.font)
+                        .lineLimit(1)
+                }
+            }
             Spacer()
         }
         .padding(.horizontal, Spacing.medium)
@@ -240,16 +227,19 @@ extension AddDerivedKeysData {
                 keySetName: "My Key Set",
                 derivedKeys: [
                     .init(
+                        path: "//polkadot//1",
                         base58: "1B2lb765432457SkT",
                         identicon: .stubIdenticon,
                         network: "polkadot"
                     ),
                     .init(
+                        path: "//polkadot//2",
                         base58: "1iKLh365474566754ZTDE",
                         identicon: .stubIdenticon,
                         network: "polkadot"
                     ),
                     .init(
+                        path: "//polkadot//3",
                         base58: "1jkCfy543654765675DOKg",
                         identicon: .stubIdenticon,
                         network: "polkadot"
@@ -260,6 +250,7 @@ extension AddDerivedKeysData {
                 keySetName: "Other Key Set",
                 derivedKeys: [
                     .init(
+                        path: "//polkadot//1",
                         base58: "1B2lb7653464235453SkT",
                         identicon: .stubIdenticon,
                         network: "polkadot"
@@ -298,16 +289,19 @@ extension AddDerivedKeysData {
                 keySetName: "My Key Set",
                 derivedKeys: [
                     .init(
+                        path: "//polkadot//1",
                         base58: "1B2lb765432457SkT",
                         identicon: .stubIdenticon,
                         network: "polkadot"
                     ),
                     .init(
+                        path: "//polkadot//2",
                         base58: "1iKLh365474566754ZTDE",
                         identicon: .stubIdenticon,
                         network: "polkadot"
                     ),
                     .init(
+                        path: "//polkadot//3",
                         base58: "1jkCfy543654765675DOKg",
                         identicon: .stubIdenticon,
                         network: "polkadot"
@@ -318,6 +312,7 @@ extension AddDerivedKeysData {
                 keySetName: "Other Key Set",
                 derivedKeys: [
                     .init(
+                        path: "//polkadot//1",
                         base58: "1B2lb7653464235453SkT",
                         identicon: .stubIdenticon,
                         network: "polkadot"

--- a/ios/PolkadotVault/Screens/Scan/DynamicDerivations/AddDerivedKeysView.swift
+++ b/ios/PolkadotVault/Screens/Scan/DynamicDerivations/AddDerivedKeysView.swift
@@ -168,20 +168,23 @@ extension AddDerivedKeysView {
     }
 
     final class ViewModel: ObservableObject {
-        let dataModel: AddDerivedKeysData
         private let onCompletion: (OnCompletionAction) -> Void
-        var onErrorDismiss: (() -> Void)?
-
+        private let dynamicDerivationsPreview: DdPreview
+        private let derivedKeysService: CreateDerivedKeyService
+        let dataModel: AddDerivedKeysData
         @Binding var isPresented: Bool
         @Published var isPresentingDerivationPath: Bool = false
-        @Published var keySets: [MmNetwork] = []
 
         init(
             dataModel: AddDerivedKeysData,
+            dynamicDerivationsPreview: DdPreview,
+            derivedKeysService: CreateDerivedKeyService = CreateDerivedKeyService(),
             isPresented: Binding<Bool>,
             onCompletion: @escaping (OnCompletionAction) -> Void
         ) {
             self.dataModel = dataModel
+            self.dynamicDerivationsPreview = dynamicDerivationsPreview
+            self.derivedKeysService = derivedKeysService
             _isPresented = isPresented
             self.onCompletion = onCompletion
         }
@@ -204,6 +207,7 @@ extension AddDerivedKeysView {
             AddDerivedKeysView(
                 viewModel: .init(
                     dataModel: .stub,
+                    dynamicDerivationsPreview: .stub,
                     isPresented: .constant(true),
                     onCompletion: { _ in }
                 )
@@ -211,6 +215,7 @@ extension AddDerivedKeysView {
             AddDerivedKeysView(
                 viewModel: .init(
                     dataModel: .stubWithErrors,
+                    dynamicDerivationsPreview: .stub,
                     isPresented: .constant(true),
                     onCompletion: { _ in }
                 )
@@ -266,12 +271,6 @@ extension AddDerivedKeysData {
 
     static let stubWithErrors: AddDerivedKeysData = .init(
         errors: [
-            .init(
-                errorMessage: """
-                Some keys can not be imported until their key sets are recovered. \
-                Please recover the missing Key Sets.
-                """
-            ),
             .init(
                 errorMessage: """
                 Some keys can not be imported until their networks are added. \

--- a/ios/PolkadotVault/Screens/Scan/Services/CameraService.swift
+++ b/ios/PolkadotVault/Screens/Scan/Services/CameraService.swift
@@ -176,7 +176,9 @@ private extension CameraService {
                     self.shutdown()
                 }
             }
-        } catch {}
+        } catch {
+            print(error.localizedDescription)
+        }
     }
 }
 

--- a/ios/PolkadotVault/Stubs/Stubs+Signer.swift
+++ b/ios/PolkadotVault/Stubs/Stubs+Signer.swift
@@ -416,6 +416,7 @@ extension DdDetail {
         base58: "5FeSzkpTHV9N86kj61QLVaYU7pndHuCD7Cjj3zyzUhxxKZ5i",
         path: "//polkadot",
         networkLogo: "polkadot",
+        networkSpecsKey: "5DCmwXp8XLzSMUyE4uhJMKV4vwvsWqqBYFKJq38CW53VHEVq",
         identicon: .stubIdenticon
     )
 }

--- a/ios/PolkadotVault/Stubs/Stubs+Signer.swift
+++ b/ios/PolkadotVault/Stubs/Stubs+Signer.swift
@@ -410,3 +410,25 @@ extension MscTxSpecPlain {
         txVersion: "tx9230"
     )
 }
+
+extension DdDetail {
+    static let stub: DdDetail = .init(
+        base58: "5FeSzkpTHV9N86kj61QLVaYU7pndHuCD7Cjj3zyzUhxxKZ5i",
+        path: "//polkadot",
+        networkLogo: "polkadot",
+        identicon: .stubIdenticon
+    )
+}
+
+extension DdKeySet {
+    static let stub: DdKeySet = .init(seedName: "seed name", derivations: [.stub])
+}
+
+extension DdPreview {
+    static let stub: DdPreview = .init(
+        qr: [.stubRegular],
+        keySet: .stub,
+        isSomeAlreadyImported: true,
+        isSomeNetworkMissing: true
+    )
+}


### PR DESCRIPTION
## Purpose
Support dynamically derived account address for operating in the Nova Spektr application

## TODOs

### UI
- [x] Add UI for "Derivations Preview screen" with QR code 
- [x] Add "import" label to Key Set Details screen
- [x] Add "import" section to Public Key Details screen

### Rust integration
- [x] Support new `qrparser_try_decode_qr_sequence` response
- [x] Support `import_dynamic_derivations` Rust call
- [x] Support any API changes to display "import" indicators in existing screens

### UX flow
- [x] Present "Derivations Preview screen" with QR code
- [x] Integrate "import" indicators into existing screens
