### PR TITLE
chore: add try_create_imported_address

### DIFF
--- a/rust/db_handling/src/identities.rs
+++ b/rust/db_handling/src/identities.rs
@@ -1364,6 +1364,42 @@ pub fn try_create_address(
     path: &str,
     network_specs_key: &NetworkSpecsKey,
 ) -> Result<()> {
+    do_try_create_address(
+        database,
+        seed_name,
+        seed_phrase,
+        path,
+        network_specs_key,
+        false,
+    )
+}
+
+/// Create a new address in the Vault database and mark it as imported.
+pub fn try_create_imported_address(
+    database: &sled::Db,
+    seed_name: &str,
+    seed_phrase: &str,
+    path: &str,
+    network_specs_key: &NetworkSpecsKey,
+) -> Result<()> {
+    do_try_create_address(
+        database,
+        seed_name,
+        seed_phrase,
+        path,
+        network_specs_key,
+        true,
+    )
+}
+
+fn do_try_create_address(
+    database: &sled::Db,
+    seed_name: &str,
+    seed_phrase: &str,
+    path: &str,
+    network_specs_key: &NetworkSpecsKey,
+    mark_as_imported: bool,
+) -> Result<()> {
     match derivation_check(database, seed_name, path, network_specs_key)? {
         // UI should prevent user from getting into `try_create_address` if
         // derivation has a bad format
@@ -1394,7 +1430,7 @@ pub fn try_create_address(
                 Some(&network_specs.specs),
                 seed_name,
                 seed_phrase,
-                false,
+                mark_as_imported,
             )?;
             let id_batch = upd_id_batch(Batch::default(), prep_data.address_prep);
             TrDbCold::new()

--- a/rust/db_handling/tests/tests.rs
+++ b/rust/db_handling/tests/tests.rs
@@ -35,6 +35,7 @@ use definitions::{
 
 use db_handling::identities::{
     create_key_set, dynamic_derivations_response, process_dynamic_derivations_v1,
+    try_create_imported_address,
 };
 use db_handling::{
     cold_default::{
@@ -2077,6 +2078,41 @@ fn test_create_key_set_generate_default_addresses() {
     )
     .unwrap();
     assert!(identities.contains_key(test_key.key()).unwrap());
+}
+
+#[test]
+fn test_created_imported_address() {
+    let dbname = tempdir().unwrap();
+    let db = sled::open(&dbname).unwrap();
+
+    populate_cold(&db, Verifier { v: None }).unwrap();
+    let ordered_specs = default_chainspecs();
+    let spec = ordered_specs
+        .into_iter()
+        .find(|spec| spec.specs.name == "westend")
+        .unwrap()
+        .specs;
+    let network_id = NetworkSpecsKey::from_parts(&spec.genesis_hash, &spec.encryption);
+    let seed_name = "Alice";
+
+    let derivation_path = "//imported";
+    try_create_imported_address(
+        &db,
+        seed_name,
+        ALICE_SEED_PHRASE,
+        derivation_path,
+        &network_id,
+    )
+    .unwrap();
+    let identities: Vec<(MultiSigner, AddressDetails)> =
+        get_addresses_by_seed_name(&db, seed_name).unwrap();
+
+    let (_, address_details) = identities
+        .iter()
+        .find(|(_, a)| a.path == derivation_path)
+        .unwrap();
+
+    assert!(address_details.was_imported);
 }
 
 #[test]

--- a/rust/signer/src/lib.rs
+++ b/rust/signer/src/lib.rs
@@ -342,6 +342,23 @@ fn try_create_address(
         .map_err(|e| e.to_string().into())
 }
 
+fn try_create_imported_address(
+    seed_name: &str,
+    seed_phrase: &str,
+    path: &str,
+    network: &str,
+) -> anyhow::Result<(), ErrorDisplayed> {
+    let network = NetworkSpecsKey::from_hex(network).map_err(|e| format!("{e}"))?;
+    db_handling::identities::try_create_imported_address(
+        &get_db()?,
+        seed_name,
+        seed_phrase,
+        path,
+        &network,
+    )
+    .map_err(|e| e.to_string().into())
+}
+
 /// Must be called once on normal first start of the app upon accepting conditions; relies on old
 /// data being already removed
 fn history_init_history_with_cert() -> anyhow::Result<(), ErrorDisplayed> {

--- a/rust/signer/src/signer.udl
+++ b/rust/signer/src/signer.udl
@@ -611,6 +611,9 @@ namespace signer {
     void try_create_address([ByRef] string seed_name, [ByRef] string seed_phrase, [ByRef] string path, [ByRef] string network);
 
     [Throws=ErrorDisplayed]
+    void try_create_imported_address([ByRef] string seed_name, [ByRef] string seed_phrase, [ByRef] string path, [ByRef] string network);
+
+    [Throws=ErrorDisplayed]
     void history_init_history_with_cert();
 
     [Throws=ErrorDisplayed]


### PR DESCRIPTION
## Scope
<!-- What is the technical scope of the changes? i.e.:
- refactored module XYZ
- added unit tests for ABC
-->
Add `try_create_imported_address` function. It should be used to create dynamic derivations addresses.

It works just like `try_create_address`, but marks new address as `was_imported`. 

