### PR TITLE
fix: ios: fix eth blockies generation

### DIFF
--- a/ios/Packages/Blockies/Sources/Blockies/BlockiesConfiguration.swift
+++ b/ios/Packages/Blockies/Sources/Blockies/BlockiesConfiguration.swift
@@ -7,33 +7,42 @@
 
 import Foundation
 
+/// A structure that holds the configuration settings for a Blockies identicon.
+///
+/// This struct encapsulates the size and scale for the identicon. The `size` determines
+/// the number of blocks along the x and y axis of the image, while `scale` specifies
+/// the pixel size of each block.
 public struct BlockiesConfiguration {
-    public let seed: String
-    public let color: PlatformColor?
-    public let bgcolor: PlatformColor?
-    public let spotcolor: PlatformColor?
+    /// The size of the identicon.
+    ///
+    /// This value represents the number of blocks along the x and y axis of the identicon.
+    /// For example, a size of `8` will create an identicon that is `8` blocks wide and `8` blocks tall.
     public let size: Int
+
+    /// The scale of the identicon.
+    ///
+    /// This value represents the pixel size of each block in the identicon.
+    /// For example, a scale of `3` will create each block with a size of `3x3` pixels.
     public let scale: Int
 
+    /// Initializes a new instance of a Blockies configuration.
+    ///
+    /// This initializer takes a size and a scale which are used to create the identicon.
+    ///
+    /// - Parameters:
+    ///   - size: The number of blocks along the x and y axis of the identicon. Default value is `8`.
+    ///   - scale: The pixel size of each block in the identicon. Default value is `3`.
     public init(
-        seed: String?,
-        color: PlatformColor? = nil,
-        bgcolor: PlatformColor? = nil,
-        spotcolor: PlatformColor? = nil,
         size: Int = 8,
-        scale: Int = 4
+        scale: Int = 3
     ) {
-        self.seed = seed ?? String(Int64(floor(Double.random * pow(10, 16))))
-        self.color = color
-        self.bgcolor = bgcolor
-        self.spotcolor = spotcolor
         self.size = size
         self.scale = scale
     }
-}
 
-extension Double {
-    static var random: Double {
-        Double(arc4random()) / Double(UInt32.max)
-    }
+    /// A static configuration that is suitable for Ethereum addresses.
+    ///
+    /// This configuration creates an identicon that is `8` blocks wide and `8` blocks tall,
+    /// with each block having a size of `3x3` pixels.
+    public static let ethAddress = BlockiesConfiguration(size: 8, scale: 3)
 }

--- a/ios/Packages/Blockies/Sources/Blockies/BlockiesIdenticonGenerator.swift
+++ b/ios/Packages/Blockies/Sources/Blockies/BlockiesIdenticonGenerator.swift
@@ -13,12 +13,25 @@ import Foundation
     import AppKit
 #endif
 
+/// `BlockiesIdenticonGenerator` is a class that generates block-style identicons.
+///
+/// The class allows you to create images by providing a seed string. You can also customize the image generation by
+/// changing the size, scale, colors, and patterns used.
+///
+/// The class uses a pseudo-random number generator, a pattern generator, an image renderer, and a color generator
+/// to create the identicon image.
 public final class BlockiesIdenticonGenerator {
     private let configuration: BlockiesConfiguration
     private let randomNumberGenerator: PseudoRandomNumberGenerator
     private let patternGenerator: PatternGenerator
     private let imageRenderer: BlockiesImageRenderer
-
+    private let colorGenerator: PseudoRandomColorGenerator
+    
+    /// Initializes a new `BlockiesIdenticonGenerator` instance.
+    ///
+    /// - Parameters:
+    ///   - configuration: The configuration to be used for the blockies identicon generation.
+    ///   - randomNumberGenerator: A pseudo random number generator used for creating the pattern.
     public init(
         configuration: BlockiesConfiguration,
         randomNumberGenerator: PseudoRandomNumberGenerator = PseudoRandomNumberGenerator()
@@ -27,11 +40,26 @@ public final class BlockiesIdenticonGenerator {
         self.randomNumberGenerator = randomNumberGenerator
         patternGenerator = PatternGenerator(randomNumberGenerator: randomNumberGenerator)
         imageRenderer = BlockiesImageRenderer(randomNumberGenerator: randomNumberGenerator)
+        colorGenerator = PseudoRandomColorGenerator(randomNumberGenerator: randomNumberGenerator)
     }
-
-    public func createImage(customScale: Int = 1) -> PlatformImage? {
-        randomNumberGenerator.loadSeed(from: configuration.seed)
+    
+    /// Creates a block-style identicon image from a seed string.
+    ///
+    /// - Parameters:
+    ///   - seed: The seed string to be used for generating the identicon.
+    ///   - customScale: An optional scaling factor for the size of the blocks.
+    ///
+    /// - Returns: The generated block-style identicon image.
+    
+    public func createImage(seed: String, customScale: Int = 1) -> PlatformImage? {
+        randomNumberGenerator.loadSeed(from: seed)
+        let colors = colorGenerator.generateColors()
         let imageData = patternGenerator.generatePattern(blockSize: configuration.size)
-        return imageRenderer.renderImage(from: imageData, configuration: configuration, scalingFactor: customScale)
+        return imageRenderer.renderImage(
+            from: imageData,
+            configuration: configuration,
+            colors: colors,
+            scalingFactor: customScale
+        )
     }
 }

--- a/ios/Packages/Blockies/Sources/Blockies/BlockiesImageRenderer.swift
+++ b/ios/Packages/Blockies/Sources/Blockies/BlockiesImageRenderer.swift
@@ -24,29 +24,31 @@ public class BlockiesImageRenderer {
     /// - Parameters:
     ///   - randomNumberGenerator: A pseudo random number generator used for generating fallback color values.
     public init(
-        randomNumberGenerator: PseudoRandomNumberGenerator = PseudoRandomNumberGenerator()
+        randomNumberGenerator: PseudoRandomNumberGenerator
     ) {
         self.randomNumberGenerator = randomNumberGenerator
     }
 
     /// Renders an image based on the given data and colors.
     ///
-    /// - parameter data: The data that describes the blocks in the blockies.
-    /// - parameter primaryColor: The primary color for the blockies.
-    /// - parameter backgroundColor: The background color for the blockies.
-    /// - parameter spotColor: The spot color for the blockies.
-    /// - parameter scalingFactor: The scaling factor for the size of the blocks.
+    /// - Parameters:
+    ///   - data: The data that describes the blocks in the blockies.
+    ///   - configuration: The Blockies configuration containing size and scale for the image.
+    ///   - colors: The `ColorsConfiguration` object containing the primary, background, and spot color for the
+    /// blockies.
+    ///   - scalingFactor: The scaling factor for the size of the blocks.
     ///
     /// - returns: The rendered image, or `nil` if the image could not be created.
     public func renderImage(
         from data: [Double],
         configuration: BlockiesConfiguration,
+        colors: ColorsConfiguration,
         scalingFactor: Int
     ) -> PlatformImage? {
         let finalSize = configuration.size * configuration.scale * scalingFactor
-        let primaryColor = configuration.color ?? createColor()
-        let backgroundColor = configuration.bgcolor ?? createColor()
-        let spotColor = configuration.spotcolor ?? createColor()
+        let primaryColor = colors.color
+        let backgroundColor = colors.bgcolor
+        let spotColor = colors.spotcolor
 
         #if os(iOS) || os(tvOS) || os(watchOS)
             let renderer = UIGraphicsImageRenderer(size: CGSize(width: finalSize, height: finalSize))
@@ -139,16 +141,5 @@ public class BlockiesImageRenderer {
                 height: CGFloat(scale * scalingFactor)
             ))
         }
-    }
-
-    private func createColor() -> PlatformColor {
-        let h = randomNumberGenerator.nextValue() * 360
-        let s = ((randomNumberGenerator.nextValue() * 60) + 40) / 100
-        let l = (
-            randomNumberGenerator.nextValue() + randomNumberGenerator.nextValue() + randomNumberGenerator
-                .nextValue() + randomNumberGenerator.nextValue()
-        ) * 25 / 100
-
-        return PlatformColor(hue: h, saturation: s, lightness: l) ?? PlatformColor.black
     }
 }

--- a/ios/Packages/Blockies/Sources/Blockies/PatternGenerator.swift
+++ b/ios/Packages/Blockies/Sources/Blockies/PatternGenerator.swift
@@ -19,7 +19,7 @@ public class PatternGenerator {
     /// - Parameters:
     ///   - randomNumberGenerator: A pseudo random number generator used for creating the pattern.
     public init(
-        randomNumberGenerator: PseudoRandomNumberGenerator = PseudoRandomNumberGenerator()
+        randomNumberGenerator: PseudoRandomNumberGenerator
     ) {
         self.randomNumberGenerator = randomNumberGenerator
     }

--- a/ios/Packages/Blockies/Sources/Blockies/PseudoRandomColorGenerator.swift
+++ b/ios/Packages/Blockies/Sources/Blockies/PseudoRandomColorGenerator.swift
@@ -1,0 +1,75 @@
+//
+//  PseudoRandomColorGenerator.swift
+//
+//
+//  Created by Krzysztof Rodak on 27/07/2023.
+//
+
+import Foundation
+
+/// A structure that holds the color configuration for Blockies identicon.
+///
+/// This struct encapsulates the primary color, background color, and spot color for the identicon.
+/// Each color is represented by a `PlatformColor` object.
+public struct ColorsConfiguration {
+    /// The primary color for the identicon.
+    /// This color is used to paint the main pattern of the identicon.
+    public let color: PlatformColor
+
+    /// The background color for the identicon.
+    /// This color is used as the background of the identicon.
+    public let bgcolor: PlatformColor
+
+    /// The spot color for the identicon.
+    public let spotcolor: PlatformColor
+}
+
+/// A class that generates pseudo-random colors for a Blockies identicon.
+///
+/// This class uses a pseudo-random number generator to create the colors needed for an identicon.
+/// It produces a deterministic sequence of colors based on the seed used for the number generator.
+public final class PseudoRandomColorGenerator {
+    /// The pseudo-random number generator used to create the color sequence.
+    private let randomNumberGenerator: PseudoRandomNumberGenerator
+
+    /// Initializes a new instance of a pseudo-random color generator.
+    ///
+    /// This initializer takes a pseudo-random number generator which is used to create the sequence of colors.
+    ///
+    /// - Parameters:
+    ///   - randomNumberGenerator: A pseudo-random number generator used to create the color sequence.
+    public init(randomNumberGenerator: PseudoRandomNumberGenerator) {
+        self.randomNumberGenerator = randomNumberGenerator
+    }
+
+    /// Generates a color configuration for an identicon.
+    ///
+    /// This method creates a `ColorsConfiguration` object that contains a primary color, a background color,
+    /// and a spot color for the identicon. Each color is created using the pseudo-random number generator.
+    ///
+    /// - Returns: A `ColorsConfiguration` object that represents the color configuration for an identicon.
+    public func generateColors() -> ColorsConfiguration {
+        .init(
+            color: createColor(),
+            bgcolor: createColor(),
+            spotcolor: createColor()
+        )
+    }
+
+    /// Creates a pseudo random color.
+    ///
+    /// This method generates a color using the pseudo-random number generator. It calculates the hue, saturation,
+    /// and lightness of the color to ensure a wide range of colors.
+    ///
+    /// - Returns: A `PlatformColor` object that represents a pseudo randomly generated color.
+    private func createColor() -> PlatformColor {
+        let h = randomNumberGenerator.nextValue() * 360
+        let s = ((randomNumberGenerator.nextValue() * 60) + 40) / 100
+        let l = (
+            randomNumberGenerator.nextValue() + randomNumberGenerator.nextValue() +
+                randomNumberGenerator.nextValue() + randomNumberGenerator.nextValue()
+        ) * 25 / 100
+
+        return PlatformColor(hue: h, saturation: s, lightness: l) ?? PlatformColor.black
+    }
+}

--- a/ios/Packages/Blockies/Sources/Blockies/UI/BlockiesIdenticonView.swift
+++ b/ios/Packages/Blockies/Sources/Blockies/UI/BlockiesIdenticonView.swift
@@ -7,13 +7,26 @@
 
 import SwiftUI
 
+/// `BlockiesIdenticonView` is a SwiftUI view that displays a block-style identicon.
+///
+/// The view uses a `BlockiesIdenticonGenerator` to create an identicon image based on a seed string.
+/// The generated image is then displayed in the SwiftUI view.
 public struct BlockiesIdenticonView: View {
     let configuration: BlockiesConfiguration
+    let seed: String
     let width: CGFloat
     let height: CGFloat
 
-    public init(configuration: BlockiesConfiguration, width: CGFloat, height: CGFloat) {
+    /// Initializes a new `BlockiesIdenticonView` instance.
+    ///
+    /// - Parameters:
+    ///   - configuration: The configuration to be used for the blockies identicon generation.
+    ///   - seed: The seed string to be used for generating the identicon.
+    ///   - width: The desired width of the view.
+    ///   - height: The desired height of the view.
+    public init(configuration: BlockiesConfiguration = .ethAddress, seed: String, width: CGFloat, height: CGFloat) {
         self.configuration = configuration
+        self.seed = seed
         self.width = width
         self.height = height
     }
@@ -32,6 +45,6 @@ public struct BlockiesIdenticonView: View {
     private func createIdenticonImage() -> UIImage? {
         let customScale = max(Int(width / CGFloat(configuration.size)), 1)
         let generator = BlockiesIdenticonGenerator(configuration: configuration)
-        return generator.createImage(customScale: customScale)
+        return generator.createImage(seed: seed, customScale: customScale)
     }
 }

--- a/ios/PolkadotVault/Components/BlockiesIdenticonViewPreviews.swift
+++ b/ios/PolkadotVault/Components/BlockiesIdenticonViewPreviews.swift
@@ -12,36 +12,14 @@ struct BlockiesIdenticonView_Previews: PreviewProvider {
     static var previews: some View {
         VStack {
             BlockiesIdenticonView(
-                configuration: .init(seed: "0xc0ffee254729296a45a3885639AC7E10F9d54979"),
-                width: 96,
-                height: 96
+                seed: "0xb00adb8980766d75518dfa8efa139fe0d7bb5e4e",
+                width: 240,
+                height: 240
             )
             BlockiesIdenticonView(
-                configuration: .init(
-                    seed: "0x999999cf1046e68e36E1aA2E0E07105eDDD1f08E",
-                    size: 5,
-                    scale: 8
-                ),
-                width: 48,
-                height: 48
-            )
-            BlockiesIdenticonView(
-                configuration: .init(
-                    seed: "0xD2AAD5732c980AaddDe38CEAD950dBa91Cd2C726",
-                    size: 10,
-                    scale: 8
-                ),
-                width: 128,
-                height: 128
-            )
-            BlockiesIdenticonView(
-                configuration: .init(
-                    seed: "0x1524d026FCAa9F1ceeE3540dEeeE3359BAD6bfF9",
-                    size: 10,
-                    scale: 8
-                ),
-                width: 32,
-                height: 32
+                seed: "0x7204ddf9dc5f672b64ca6692da7b8f13b4d408e7",
+                width: 240,
+                height: 240
             )
         }
     }


### PR DESCRIPTION
Fix order of pseudo random generated numbers usage, to generate colors first, image data later on

## Screenshots
| Eth blockies rust library | iOS |
|-|-|
|<img src="https://github.com/paritytech/parity-signer/assets/1955364/cbe6131e-a6c3-4b88-b65a-c73fd83f9209" width="450px">|<img src="https://github.com/paritytech/parity-signer/assets/1955364/d424217f-e080-4b22-890b-fd526911be91" width="450px">|
|<img src="https://github.com/paritytech/parity-signer/assets/1955364/acd816b6-15a6-4da1-a4a2-eb6f97153918" width="450px">| |
