### PR TITLE
feat: #2065 ios: Secret recovery field is not tappable

### DIFF
--- a/ios/PolkadotVault/Screens/CreateKey/RecoverKeySet/RecoverKeySetSeedPhraseView.swift
+++ b/ios/PolkadotVault/Screens/CreateKey/RecoverKeySet/RecoverKeySetSeedPhraseView.swift
@@ -61,6 +61,11 @@ struct RecoverKeySetSeedPhraseView: View {
                     }
                     .frame(minHeight: 156)
                     .containerBackground(CornerRadius.small)
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        /// #2065 Enable to focus `recoveryTextInput` when tapping anywhere within input rectangle
+                        focus = true
+                    }
                     .padding(.horizontal, Spacing.large)
                     .padding(.bottom, Spacing.small)
                     ScrollView(.horizontal, showsIndicators: false) {


### PR DESCRIPTION
## Purpose
Resolves #2065

## Screenshots

| Example |
|-|
|<img src="https://github.com/paritytech/parity-signer/assets/1955364/6cd58e6e-01ef-43b3-a274-173707fe362d" width="320px">|
