### PR TITLE
feat: ios: Move Settings to Key Details

### DIFF
--- a/ios/PolkadotVault/Components/NavigationBarView.swift
+++ b/ios/PolkadotVault/Components/NavigationBarView.swift
@@ -13,6 +13,7 @@ enum NavigationButton {
     case xmark
     case more
     case plus
+    case settings
     case action(LocalizedStringKey)
     case activeAction(LocalizedStringKey, Binding<Bool>)
     case questionmark
@@ -110,6 +111,11 @@ struct NavigationBarView: View {
             NavbarButton(
                 action: button.action,
                 icon: Asset.moreDots.swiftUIImage
+            )
+        case .settings:
+            NavbarButton(
+                action: button.action,
+                icon: Asset.tabbarSettings.swiftUIImage
             )
         case .plus:
             NavbarButton(

--- a/ios/PolkadotVault/Components/TabBar/Builders/TabViewModelBuilder.swift
+++ b/ios/PolkadotVault/Components/TabBar/Builders/TabViewModelBuilder.swift
@@ -30,14 +30,12 @@ final class TabViewModelBuilder {
 }
 
 private extension TabViewModelBuilder {
-    func icon(for tab: Tab, isSelected: Bool) -> Image {
+    func icon(for tab: Tab, isSelected _: Bool) -> Image {
         switch tab {
         case .keys:
             return Asset.tabbarKeys.swiftUIImage
         case .scanner:
             return Asset.tabbarScanner.swiftUIImage
-        case .settings:
-            return isSelected ? Asset.tabbarSettingsSelected.swiftUIImage : Asset.tabbarSettings.swiftUIImage
         }
     }
 
@@ -47,8 +45,6 @@ private extension TabViewModelBuilder {
             return Localizable.TabBar.keys.text
         case .scanner:
             return Localizable.TabBar.scanner.text
-        case .settings:
-            return Localizable.TabBar.settings.text
         }
     }
 }

--- a/ios/PolkadotVault/Components/TabBar/TabBarView.swift
+++ b/ios/PolkadotVault/Components/TabBar/TabBarView.swift
@@ -24,10 +24,6 @@ struct TabBarView: View {
                 viewModel: viewModel.scannerTab,
                 onQRCodeTap: viewModel.onQRCodeTap
             )
-            TabBarButton(
-                viewModel: viewModel.settingsTab,
-                onTap: viewModel.onSettingsTap
-            )
         }
         .frame(height: Heights.tabbarHeight)
         .background(Asset.backgroundSecondary.swiftUIColor)
@@ -43,28 +39,23 @@ extension TabBarView {
     final class ViewModel: ObservableObject {
         let onQRCodeTap: () -> Void
         let onKeysTap: () -> Void
-        let onSettingsTap: () -> Void
         @Binding var selectedTab: Tab
         @Published var keysTab: TabViewModel!
         @Published var scannerTab: TabViewModel = TabViewModelBuilder().build(for: .scanner, isSelected: false)
-        @Published var settingsTab: TabViewModel!
 
         init(
             selectedTab: Binding<Tab>,
             onQRCodeTap: @escaping () -> Void,
-            onKeysTap: @escaping () -> Void,
-            onSettingsTap: @escaping () -> Void
+            onKeysTap: @escaping () -> Void
         ) {
             _selectedTab = selectedTab
             self.onQRCodeTap = onQRCodeTap
             self.onKeysTap = onKeysTap
-            self.onSettingsTap = onSettingsTap
             onTabChange(selectedTab.wrappedValue)
         }
 
         func onTabChange(_ tab: Tab) {
             keysTab = TabViewModelBuilder().build(for: .keys, isSelected: tab == .keys)
-            settingsTab = TabViewModelBuilder().build(for: .settings, isSelected: tab == .settings)
         }
     }
 }
@@ -149,7 +140,6 @@ extension TabBarView.ViewModel {
     static let mock = TabBarView.ViewModel(
         selectedTab: .constant(.keys),
         onQRCodeTap: {},
-        onKeysTap: {},
-        onSettingsTap: {}
+        onKeysTap: {}
     )
 }

--- a/ios/PolkadotVault/Components/TabBar/ViewModels/Tab.swift
+++ b/ios/PolkadotVault/Components/TabBar/ViewModels/Tab.swift
@@ -11,7 +11,6 @@ import Foundation
 enum Tab: Equatable, Hashable {
     case keys
     case scanner
-    case settings
 }
 
 extension Tab {
@@ -21,8 +20,6 @@ extension Tab {
             return .navbarKeys
         case .scanner:
             return nil
-        case .settings:
-            return .navbarSettings
         }
     }
 }

--- a/ios/PolkadotVault/Screens/Containers/AuthenticatedScreenContainer.swift
+++ b/ios/PolkadotVault/Screens/Containers/AuthenticatedScreenContainer.swift
@@ -16,12 +16,7 @@ struct AuthenticatedScreenContainer: View {
 
     var body: some View {
         ZStack {
-            if viewModel.selectedTab == .keys {
-                KeySetList(viewModel: .init(tabBarViewModel: tabBarViewModel()))
-            }
-            if viewModel.selectedTab == .settings {
-                SettingsView(viewModel: .init(tabBarViewModel: tabBarViewModel()))
-            }
+            KeySetList(viewModel: .init(tabBarViewModel: tabBarViewModel()))
         }
         .animation(.default, value: AnimationDuration.standard)
         .fullScreenModal(
@@ -52,8 +47,7 @@ struct AuthenticatedScreenContainer: View {
         .init(
             selectedTab: $viewModel.selectedTab,
             onQRCodeTap: viewModel.onQRCodeTap,
-            onKeysTap: viewModel.onKeysTap,
-            onSettingsTap: viewModel.onSettingsTap
+            onKeysTap: viewModel.onKeysTap
         )
     }
 }
@@ -75,10 +69,6 @@ extension AuthenticatedScreenContainer {
 
         func onKeysTap() {
             selectedTab = .keys
-        }
-
-        func onSettingsTap() {
-            selectedTab = .settings
         }
 
         func onQRScannerDismiss() {

--- a/ios/PolkadotVault/Screens/KeyDetails/Views/KeyDetails+ViewModel.swift
+++ b/ios/PolkadotVault/Screens/KeyDetails/Views/KeyDetails+ViewModel.swift
@@ -48,11 +48,11 @@ extension KeyDetailsView {
         @Published var presentedPublicKeyDetails: String!
 
         @Published var isShowingKeysExportModal = false
-        // Network selection
         @Published var isPresentingNetworkSelection = false
         @Published var isPresentingKeySetSelection = false
         @Published var isShowingRecoverKeySet = false
         @Published var isShowingCreateKeySet = false
+        @Published var isPresentingSettings = false
 
         @Published var keySummary: KeySummaryViewModel?
         @Published var derivedKeys: [DerivedKeyRowModel] = []
@@ -282,6 +282,14 @@ extension KeyDetailsView.ViewModel {
 
     func onRootKeyTap() {
         isPresentingRootDetails = true
+    }
+
+    func onSettingsTap() {
+        isPresentingSettings = true
+    }
+
+    func onMoreTap() {
+        isShowingActionSheet = true
     }
 
     func onKeySetSelectionTap() {

--- a/ios/PolkadotVault/Screens/KeyDetails/Views/KeyDetailsView.swift
+++ b/ios/PolkadotVault/Screens/KeyDetails/Views/KeyDetailsView.swift
@@ -18,10 +18,13 @@ struct KeyDetailsView: View {
                 // Navigation bar
                 NavigationBarView(
                     viewModel: .init(
-                        leftButtons: [.init(type: .arrow, action: { presentationMode.wrappedValue.dismiss() })],
+                        leftButtons: [
+                            .init(type: .arrow, action: { presentationMode.wrappedValue.dismiss() }),
+                            .init(type: .settings, action: viewModel.onSettingsTap)
+                        ],
                         rightButtons: [
                             .init(type: .plus, action: viewModel.onCreateDerivedKeyTap),
-                            .init(type: .more, action: { viewModel.isShowingActionSheet.toggle() })
+                            .init(type: .more, action: viewModel.onMoreTap)
                         ]
                     )
                 )
@@ -193,6 +196,11 @@ struct KeyDetailsView: View {
                     .navigationViewStyle(StackNavigationViewStyle())
                     .navigationBarHidden(true)
             }
+        }
+        .fullScreenModal(
+            isPresented: $viewModel.isPresentingSettings
+        ) {
+            SettingsView(viewModel: .init())
         }
         .bottomSnackbar(
             viewModel.snackbarViewModel,

--- a/ios/PolkadotVault/Screens/Settings/SettingsView.swift
+++ b/ios/PolkadotVault/Screens/Settings/SettingsView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct SettingsView: View {
     @StateObject var viewModel: ViewModel
-    @EnvironmentObject private var appState: AppState
+    @Environment(\.presentationMode) var presentationMode
 
     var body: some View {
         NavigationView {
@@ -18,7 +18,7 @@ struct SettingsView: View {
                     NavigationBarView(
                         viewModel: NavigationBarViewModel(
                             title: .title(Localizable.Settings.Label.title.string),
-                            leftButtons: [.init(type: .empty)],
+                            leftButtons: [.init(type: .xmark, action: { presentationMode.wrappedValue.dismiss() })],
                             rightButtons: [.init(type: .empty)],
                             backgroundColor: Asset.backgroundPrimary.swiftUIColor
                         )
@@ -47,9 +47,6 @@ struct SettingsView: View {
                 .navigationBarHidden(true)
                 VStack(spacing: 0) {
                     ConnectivityAlertOverlay(viewModel: .init())
-                    TabBarView(
-                        viewModel: viewModel.tabBarViewModel
-                    )
                 }
                 NavigationLink(
                     destination: detailView(viewModel.detailScreen)
@@ -60,7 +57,6 @@ struct SettingsView: View {
             .background(Asset.backgroundPrimary.swiftUIColor)
         }
         .onAppear {
-            viewModel.use(appState: appState)
             viewModel.loadData()
         }
         .fullScreenModal(isPresented: $viewModel.isPresentingWipeConfirmation) {
@@ -104,20 +100,12 @@ extension SettingsView {
         @Published var isPresentingWipeConfirmation = false
         @Published var isDetailsPresented = false
         @Published var detailScreen: SettingsItem?
-        private weak var appState: AppState!
         private let onboardingMediator: OnboardingMediator
-        let tabBarViewModel: TabBarView.ViewModel
 
         init(
-            onboardingMediator: OnboardingMediator = ServiceLocator.onboardingMediator,
-            tabBarViewModel: TabBarView.ViewModel
+            onboardingMediator: OnboardingMediator = ServiceLocator.onboardingMediator
         ) {
             self.onboardingMediator = onboardingMediator
-            self.tabBarViewModel = tabBarViewModel
-        }
-
-        func use(appState: AppState) {
-            self.appState = appState
         }
 
         func loadData() {
@@ -172,7 +160,7 @@ struct SettingsViewRenderable: Equatable {
 #if DEBUG
     struct SettingsView_Previews: PreviewProvider {
         static var previews: some View {
-            SettingsView(viewModel: .init(tabBarViewModel: .mock))
+            SettingsView(viewModel: .init())
         }
     }
 #endif

--- a/ios/PolkadotVaultTests/Components/TabBar/TabViewModelBuilderTests.swift
+++ b/ios/PolkadotVaultTests/Components/TabBar/TabViewModelBuilderTests.swift
@@ -53,42 +53,4 @@ final class TabViewModelBuilderTests: XCTestCase {
         // Then
         XCTAssertEqual(result, expectedResult)
     }
-
-    func test_build_settings_selected_returnsExpectedModel() {
-        // Given
-        let tab: Tab = .settings
-        let isSelected = false
-        let expectedResult = TabViewModel(
-            action: .navbarSettings,
-            isActive: isSelected,
-            icon: Asset.tabbarSettings.swiftUIImage,
-            label: Localizable.TabBar.settings.text,
-            tab: tab
-        )
-
-        // When
-        let result = subject.build(for: tab, isSelected: isSelected)
-
-        // Then
-        XCTAssertEqual(result, expectedResult)
-    }
-
-    func test_build_settings_notSelected_returnsExpectedModel() {
-        // Given
-        let tab: Tab = .settings
-        let isSelected = true
-        let expectedResult = TabViewModel(
-            action: .navbarSettings,
-            isActive: isSelected,
-            icon: Asset.tabbarSettingsSelected.swiftUIImage,
-            label: Localizable.TabBar.settings.text,
-            tab: tab
-        )
-
-        // When
-        let result = subject.build(for: tab, isSelected: isSelected)
-
-        // Then
-        XCTAssertEqual(result, expectedResult)
-    }
 }


### PR DESCRIPTION
## Purpose
Another mid-point of updated design to be Key-Details driven.
Next PR will remove tab bar all together

## Screenshots

| Example |
|-|
|<img src="https://github.com/paritytech/parity-signer/assets/1955364/18ac972c-0a59-4738-a230-64552d6a6b13" width="320px">|
