### PR TITLE
fix: do not use deprecated actions-rs/toolchain

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -44,9 +44,7 @@ jobs:
       - name:                 Install Rust targets
         uses:                 dtolnay/rust-toolchain@stable
         with:
-          targets:
-            - x86_64-apple-ios
-            - aarch64-apple-ios
+          targets:            x86_64-apple-ios,aarch64-apple-ios
           components:         rust-std
 
       - name:                 Install uniffi_bindgen

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -41,23 +41,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-spm-
 
-      - name:                 Install Rust aarch64-apple-ios target
-        uses:                 actions-rs/toolchain@v1.0.7
+      - name:                 Install Rust targets
+        uses:                 dtolnay/rust-toolchain@stable
         with:
-          profile:            minimal
-          toolchain:          stable
-          target:             aarch64-apple-ios
+          targets:
+            - x86_64-apple-ios
+            - aarch64-apple-ios
           components:         rust-std
-          override:           true
-
-      - name:                 Install Rust x86_64-apple-ios target
-        uses:                 actions-rs/toolchain@v1.0.7
-        with:
-          profile:            minimal
-          toolchain:          stable
-          target:             x86_64-apple-ios
-          components:         rust-std
-          override:           true
 
       - name:                 Install uniffi_bindgen
         uses:                 actions-rs/install@v0.1

--- a/.github/workflows/android-app.yml
+++ b/.github/workflows/android-app.yml
@@ -29,11 +29,7 @@ jobs:
           sudo apt-get install -y clang libclang-dev libopencv-dev
 
       - name:           Install Rust stable toolchain
-        uses:           actions-rs/toolchain@v1
-        with:
-          profile:      minimal
-          toolchain:    stable
-          override:     true
+        uses:           dtolnay/rust-toolchain@stable
 
       - name:                 Install uniffi_bindgen
         uses:                 actions-rs/install@v0.1
@@ -96,11 +92,7 @@ jobs:
           sudo apt-get install -y clang libclang-dev libopencv-dev
 
       - name:           Install Rust stable toolchain
-        uses:           actions-rs/toolchain@v1
-        with:
-          profile:      minimal
-          toolchain:    stable
-          override:     true
+        uses:           dtolnay/rust-toolchain@stable
 
       - name:                 Install uniffi_bindgen
         uses:                 actions-rs/install@v0.1

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -25,11 +25,7 @@ jobs:
           sudo apt-get install -y clang libclang-dev libopencv-dev
 
       - name:           Install Rust stable toolchain
-        uses:           actions-rs/toolchain@v1
-        with:
-          profile:      minimal
-          toolchain:    stable
-          override:     true
+        uses:           dtolnay/rust-toolchain@stable
 
       - name:                 Install uniffi_bindgen
         uses:                 actions-rs/install@v0.1
@@ -91,11 +87,7 @@ jobs:
           sudo apt-get install -y clang libclang-dev libopencv-dev
 
       - name:           Install Rust stable toolchain
-        uses:           actions-rs/toolchain@v1
-        with:
-          profile:      minimal
-          toolchain:    stable
-          override:     true
+        uses:           dtolnay/rust-toolchain@stable
 
       - name:                 Install uniffi_bindgen
         uses:                 actions-rs/install@v0.1

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -29,11 +29,7 @@ jobs:
           sudo apt install -y clang libclang-dev libopencv-dev
 
       - name:                 Install Rust stable toolchain
-        uses:                 actions-rs/toolchain@v1.0.7
-        with:
-          profile:            minimal
-          toolchain:          stable
-          override:           true
+        uses:                 dtolnay/rust-toolchain@stable
 
       - name:                 Install uniffi_bindgen
         uses:                 actions-rs/install@v0.1

--- a/.github/workflows/rust-fmt.yml
+++ b/.github/workflows/rust-fmt.yml
@@ -24,11 +24,7 @@ jobs:
           submodules:         'recursive'
 
       - name:                 Install Rust stable toolchain
-        uses:                 actions-rs/toolchain@v1.0.7
-        with:
-          profile:            minimal
-          toolchain:          stable
-          override:           true
+        uses:                 dtolnay/rust-toolchain@stable
 
       - name:                 cargo fmt
         run:                  |

--- a/.github/workflows/rust-test-android.yml
+++ b/.github/workflows/rust-test-android.yml
@@ -29,11 +29,7 @@ jobs:
           sudo apt install -y clang libclang-dev libopencv-dev
 
       - name:                 Install Rust stable toolchain
-        uses:                 actions-rs/toolchain@v1.0.7
-        with:
-          profile:            minimal
-          toolchain:          stable
-          override:           true
+        uses:                 dtolnay/rust-toolchain@stable
 
       - name:                 Install cargo-nextest
         uses:                 baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941 # v2.2.0

--- a/.github/workflows/rust-test-ios.yml
+++ b/.github/workflows/rust-test-ios.yml
@@ -28,11 +28,7 @@ jobs:
           brew install opencv
 
       - name:                 Install Rust stable toolchain
-        uses:                 actions-rs/toolchain@v1.0.7
-        with:
-          profile:            minimal
-          toolchain:          stable
-          override:           true
+        uses:                 dtolnay/rust-toolchain@stable
 
       - name:                 Install cargo-nextest
         uses:                 baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941 # v2.2.0

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   distribute_testflight:
-    if: contains('["krodak","prybalko", "montekki"]', github.actor)
+    if: contains('["krodak","prybalko"]', github.actor)
     runs-on:                  macos-13
     name:                     Distribute TestFlight Build
 
@@ -40,23 +40,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-spm-
 
-      - name:                 Install Rust aarch64-apple-ios target
-        uses:                 actions-rs/toolchain@v1.0.7
+      - name: Install Rust targets
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile:            minimal
-          toolchain:          stable
-          target:             aarch64-apple-ios
-          components:         rust-std
-          override:           true
-
-      - name:                 Install Rust x86_64-apple-ios target
-        uses:                 actions-rs/toolchain@v1.0.7
-        with:
-          profile:            minimal
-          toolchain:          stable
-          target:             x86_64-apple-ios
-          components:         rust-std
-          override:           true
+          targets:
+            - x86_64-apple-ios
+            - aarch64-apple-ios
+          components: rust-std
 
       - name:                 Install uniffi_bindgen
         uses:                 actions-rs/install@v0.1

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -40,13 +40,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-spm-
 
-      - name: Install Rust targets
-        uses: dtolnay/rust-toolchain@stable
+      - name:                 Install Rust targets
+        uses:                 dtolnay/rust-toolchain@stable
         with:
-          targets:
-            - x86_64-apple-ios
-            - aarch64-apple-ios
-          components: rust-std
+          targets:            x86_64-apple-ios,aarch64-apple-ios
+          components:         rust-std
 
       - name:                 Install uniffi_bindgen
         uses:                 actions-rs/install@v0.1


### PR DESCRIPTION
do not use deprecated `actions-rs/toolchain`
https://github.com/actions-rs/toolchain

Use `dtolnay/rust-toolchain` instead