### PR TITLE
refactor: replace `ENV[]` with `ENV.fetch`

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,16 @@
+version = 1
+
+[[analyzers]]
+name = "ruby"
+
+[[analyzers]]
+name = "docker"
+
+[[analyzers]]
+name = "shell"
+
+[[analyzers]]
+name = "rust"
+
+  [analyzers.meta]
+  msrv = "stable"

--- a/ios/fastlane/lanes/lane_build.rb
+++ b/ios/fastlane/lanes/lane_build.rb
@@ -20,7 +20,7 @@ lane :build_release do |options|
   clean_build_artifacts
 
   increment_build_number(
-    build_number: ENV["BUILD_NUMBER"], # based on commit, defined in GA
+    build_number: ENV.fetch("BUILD_NUMBER", nil), # based on commit, defined in GA
     xcodeproj: xcodeproj_path
   )
   update_code_signing_settings(
@@ -53,8 +53,8 @@ lane :prepare_code_signing do |options|
 
   cert(
     api_key: api_key,
-    keychain_path: ENV["KEYCHAIN_PATH"],
-    keychain_password: ENV["KEYCHAIN_PASSWORD"]
+    keychain_path: ENV.fetch("KEYCHAIN_PATH", nil),
+    keychain_password: ENV.fetch("KEYCHAIN_PASSWORD", nil)
   )
   sigh(
     api_key: api_key,

--- a/ios/fastlane/lanes/lane_testflight.rb
+++ b/ios/fastlane/lanes/lane_testflight.rb
@@ -9,9 +9,9 @@ end
 desc "Load ASC API Key information to use in subsequent lanes"
 lane :load_asc_api_key do
   app_store_connect_api_key(
-    key_id: ENV["ASC_KEY_ID"],
-    issuer_id: ENV["ASC_ISSUER_ID"],
-    key_content: ENV["ASC_KEY_BASE64"],
+    key_id: ENV.fetch("ASC_KEY_ID", nil),
+    issuer_id: ENV.fetch("ASC_ISSUER_ID", nil),
+    key_content: ENV.fetch("ASC_KEY_BASE64", nil),
     is_key_content_base64: true,
     in_house: false
    )


### PR DESCRIPTION
`ENV[]` silently fails and returns `nil` when the environment variable is unset, which may cause unexpected behaviors when the developer forgets to set it. On the other hand, `ENV.fetch` raises `KeyError` or returns the explicitly specified default value.