### PR TITLE
fix: fixed appearance of bottom sheets. 

### DIFF
--- a/android/src/main/java/io/parity/signer/screens/createderivation/DerivationCreateSubgraph.kt
+++ b/android/src/main/java/io/parity/signer/screens/createderivation/DerivationCreateSubgraph.kt
@@ -1,6 +1,8 @@
 package io.parity.signer.screens.createderivation
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material.MaterialTheme
@@ -87,7 +89,11 @@ fun DerivationCreateSubgraph(
 				startDestination = PathDerivationSheetsSubGraph.empty,
 			) {
 				val closeAction: Callback = { menuNavController.popBackStack() }
-				composable(PathDerivationSheetsSubGraph.empty) {}
+				composable(PathDerivationSheetsSubGraph.empty) {
+					//no menu - Spacer element so when other part shown there won't
+					// be an appearance animation from top left part despite there shouldn't be
+					Spacer(modifier = Modifier.fillMaxSize(1f))
+				}
 				composable(PathDerivationSheetsSubGraph.help) {
 					BottomSheetWrapperRoot(onClosedAction = closeAction) {
 						DerivationMethodsHelpBottomSheet(

--- a/android/src/main/java/io/parity/signer/screens/keydetails/KeyDetailsScreenSubgraph.kt
+++ b/android/src/main/java/io/parity/signer/screens/keydetails/KeyDetailsScreenSubgraph.kt
@@ -2,6 +2,8 @@ package io.parity.signer.screens.keydetails
 
 import android.widget.Toast
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -63,7 +65,11 @@ fun KeyDetailsScreenSubgraph(
 		val closeAction: Callback = {
 			menuNavController.popBackStack()
 		}
-		composable(KeyPublicDetailsMenuSubgraph.empty) {}//no menu
+		composable(KeyPublicDetailsMenuSubgraph.empty) {
+			//no menu - Spacer element so when other part shown there won't
+			// be an appearance animation from top left part despite there shouldn't be
+			Spacer(modifier = Modifier.fillMaxSize(1f))
+		}
 		composable(KeyPublicDetailsMenuSubgraph.keyMenuGeneral) {
 			BottomSheetWrapperRoot(onClosedAction = closeAction) {
 				KeyDetailsGeneralMenu(

--- a/android/src/main/java/io/parity/signer/screens/keysetdetails/KeySetDetailsScreenSubgraph.kt
+++ b/android/src/main/java/io/parity/signer/screens/keysetdetails/KeySetDetailsScreenSubgraph.kt
@@ -3,6 +3,8 @@ package io.parity.signer.screens.keysetdetails
 import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.EnterTransition
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
@@ -95,17 +97,15 @@ fun KeySetDetailsScreenSubgraph(
 	NavHost(
 		navController = menuNavController,
 		startDestination = KeySetDetailsMenuSubgraph.empty,
-		enterTransition = {
-			EnterTransition.None
-		},
-		exitTransition = {
-			slideOutOfContainer(AnimatedContentTransitionScope.SlideDirection.Down)
-		},
 	) {
 		val closeAction: Callback = {
 			menuNavController.popBackStack()
 		}
-		composable(KeySetDetailsMenuSubgraph.empty) {}//no menu
+		composable(KeySetDetailsMenuSubgraph.empty) {
+			//no menu - Spacer element so when other part shown there won't
+			// be an appearance animation from top left part despite there shouldn't be
+			Spacer(modifier = Modifier.fillMaxSize(1f))
+		}
 		composable(KeySetDetailsMenuSubgraph.keys_menu) {
 			BottomSheetWrapperRoot(onClosedAction = closeAction) {
 				KeyDetailsMenuGeneral(
@@ -116,7 +116,7 @@ fun KeySetDetailsScreenSubgraph(
 					},
 					onBackupClicked = {
 						menuNavController.navigate(KeySetDetailsMenuSubgraph.backup) {
-							popUpTo(KeySetDetailsMenuSubgraph.empty)
+//							popUpTo(KeySetDetailsMenuSubgraph.empty)
 						}
 					},
 					onCancel = {
@@ -124,12 +124,12 @@ fun KeySetDetailsScreenSubgraph(
 					},
 					onDeleteClicked = {
 						menuNavController.navigate(KeySetDetailsMenuSubgraph.keys_menu_delete_confirm) {
-							popUpTo(KeySetDetailsMenuSubgraph.empty)
+//							popUpTo(KeySetDetailsMenuSubgraph.empty)
 						}
 					},
 					exposeConfirmAction = {
 						menuNavController.navigate(KeySetDetailsMenuSubgraph.exposed_shield_alert) {
-							popUpTo(KeySetDetailsMenuSubgraph.empty)
+//							popUpTo(KeySetDetailsMenuSubgraph.empty)
 						}
 					}
 				)

--- a/android/src/main/java/io/parity/signer/screens/keysetdetails/KeySetDetailsScreenSubgraph.kt
+++ b/android/src/main/java/io/parity/signer/screens/keysetdetails/KeySetDetailsScreenSubgraph.kt
@@ -116,7 +116,7 @@ fun KeySetDetailsScreenSubgraph(
 					},
 					onBackupClicked = {
 						menuNavController.navigate(KeySetDetailsMenuSubgraph.backup) {
-//							popUpTo(KeySetDetailsMenuSubgraph.empty)
+							popUpTo(KeySetDetailsMenuSubgraph.empty)
 						}
 					},
 					onCancel = {
@@ -124,12 +124,12 @@ fun KeySetDetailsScreenSubgraph(
 					},
 					onDeleteClicked = {
 						menuNavController.navigate(KeySetDetailsMenuSubgraph.keys_menu_delete_confirm) {
-//							popUpTo(KeySetDetailsMenuSubgraph.empty)
+							popUpTo(KeySetDetailsMenuSubgraph.empty)
 						}
 					},
 					exposeConfirmAction = {
 						menuNavController.navigate(KeySetDetailsMenuSubgraph.exposed_shield_alert) {
-//							popUpTo(KeySetDetailsMenuSubgraph.empty)
+							popUpTo(KeySetDetailsMenuSubgraph.empty)
 						}
 					}
 				)

--- a/android/src/main/java/io/parity/signer/screens/keysets/KeySetsListScreenSubgraph.kt
+++ b/android/src/main/java/io/parity/signer/screens/keysets/KeySetsListScreenSubgraph.kt
@@ -1,8 +1,11 @@
 package io.parity.signer.screens.keysets
 
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
+import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
@@ -67,7 +70,11 @@ fun KeySetsListScreenSubgraph(
 		navController = menuNavController,
 		startDestination = KeySetsMenuSubgraph.empty,
 	) {
-		composable(KeySetsMenuSubgraph.empty) {}//no menu
+		composable(KeySetsMenuSubgraph.empty) {
+			//no menu - Spacer element so when other part shown there won't
+			// be an appearance animation from top left part despite there shouldn't be
+			Spacer(modifier = Modifier.fillMaxSize(1f))
+		}
 		composable(KeySetsMenuSubgraph.exposed_shield_alert) {
 			ExposedAlert(navigateBack = { menuNavController.popBackStack() })
 		}

--- a/android/src/main/java/io/parity/signer/screens/settings/general/SettingsGeneralNavSubgraph.kt
+++ b/android/src/main/java/io/parity/signer/screens/settings/general/SettingsGeneralNavSubgraph.kt
@@ -1,6 +1,8 @@
 package io.parity.signer.screens.settings.general
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -61,7 +63,11 @@ internal fun SettingsGeneralNavSubgraph(
 		val closeAction: Callback = {
 			menuNavController.popBackStack()
 		}
-		composable(SettingsGeneralMenu.empty) {}//no menu
+		composable(SettingsGeneralMenu.empty) {
+			//no menu - Spacer element so when other part shown there won't
+			// be an appearance animation from top left part despite there shouldn't be
+			Spacer(modifier = Modifier.fillMaxSize(1f))
+		}
 		composable(SettingsGeneralMenu.wipe_factory) {
 			BottomSheetWrapperRoot(onClosedAction = closeAction) {
 				ConfirmFactorySettingsBottomSheet(

--- a/android/src/main/java/io/parity/signer/screens/settings/logs/logslist/LogsScreenFull.kt
+++ b/android/src/main/java/io/parity/signer/screens/settings/logs/logslist/LogsScreenFull.kt
@@ -3,6 +3,8 @@ package io.parity.signer.screens.settings.logs.logslist
 import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -68,7 +70,11 @@ fun LogsScreenFull(
 		val closeAction: Callback = {
 			menuNavController.popBackStack()
 		}
-		composable(LogsMenuSubgraph.logs_empty) {}//no menu
+		composable(LogsMenuSubgraph.logs_empty) {
+			//no menu - Spacer element so when other part shown there won't
+			// be an appearance animation from top left part despite there shouldn't be
+			Spacer(modifier = Modifier.fillMaxSize(1f))
+		}
 		composable(LogsMenuSubgraph.logs_menu) {
 			BottomSheetWrapperRoot(onClosedAction = closeAction) {
 				LogsMenuGeneral(

--- a/android/src/main/java/io/parity/signer/screens/settings/networks/details/NetworkDetailsSubgraph.kt
+++ b/android/src/main/java/io/parity/signer/screens/settings/networks/details/NetworkDetailsSubgraph.kt
@@ -1,6 +1,8 @@
 package io.parity.signer.screens.settings.networks.details
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -69,12 +71,16 @@ fun NetworkDetailsSubgraph(
 	val closeAction: Callback = {
 		menuController.popBackStack()
 	}
-	//menus
+	//bottom sheets
 	NavHost(
 		navController = menuController,
 		startDestination = NetworkDetailsMenuSubgraph.empty,
 	) {
-		composable(NetworkDetailsMenuSubgraph.empty) {}
+		composable(NetworkDetailsMenuSubgraph.empty) {
+			//no menu - Spacer element so when other part shown there won't
+			// be an appearance animation from top left part despite there shouldn't be
+			Spacer(modifier = Modifier.fillMaxSize(1f))
+		}
 		composable(NetworkDetailsMenuSubgraph.menu) {
 			BottomSheetWrapperRoot(onClosedAction = closeAction) {
 				NetworkDetailsMenuGeneral(


### PR DESCRIPTION
There was top left to full screen animation despite animations were disabled when navigating from completely empty composable to something new.

With this changes they appear normally.