### PR TITLE
chore: store and check db schema version

### DIFF
--- a/android/src/main/java/io/parity/signer/screens/scan/errors/TransactionErrorsModels.kt
+++ b/android/src/main/java/io/parity/signer/screens/scan/errors/TransactionErrorsModels.kt
@@ -39,7 +39,7 @@ tailrec fun Throwable.findErrorDisplayed(): ErrorDisplayed? {
 
 fun ErrorDisplayed.toTransactionError(): TransactionError {
 	return when (this) {
-		is ErrorDisplayed.DbNotInitialized -> TransactionError.Generic("")
+		is ErrorDisplayed.DbNotInitialized -> TransactionError.Generic("Db Not Initialized. Unreachable state here.")
 		is ErrorDisplayed.LoadMetaUnknownNetwork -> TransactionError.MetadataForUnknownNetwork(
 			name
 		)
@@ -52,7 +52,7 @@ fun ErrorDisplayed.toTransactionError(): TransactionError {
 			currentVersion = have,
 			expectedVersion = want
 		)
-		is ErrorDisplayed.MutexPoisoned -> TransactionError.Generic("")
+		is ErrorDisplayed.MutexPoisoned -> TransactionError.Generic("Mutex Poisoned. Unreachable state.")
 		is ErrorDisplayed.NoMetadata -> TransactionError.NoMetadataForNetwork(name)
 		is ErrorDisplayed.SpecsKnown -> TransactionError.NetworkAlreadyAdded(
 			name,
@@ -64,6 +64,7 @@ fun ErrorDisplayed.toTransactionError(): TransactionError {
 			encryption = encryption.name
 		)
 		is ErrorDisplayed.WrongPassword -> TransactionError.Generic("Wrong Password")
+		is ErrorDisplayed.DbSchemaMismatch -> TransactionError.Generic("DB inconsistent state. Updated old app and got that far? DB flush required.")
 	}
 }
 

--- a/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
+++ b/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
@@ -610,6 +610,7 @@
 "SelectKeySetsForNetworkKey.Snackbar.KeysCreated" = "Derived Keys have been created";
 
 "ErrorDisplayed.DbNotInitialized" = "Database not initialized";
+"ErrorDisplayed.DbSchemaMismatch" = "Database scheme has been updated. Please do a fresh app install";
 "ErrorDisplayed.MutexPoisoned" = "Mutex poisoned";
 "ErrorDisplayed.InvalidType" = "Unexpected backend response type";
 "ErrorDisplayed.WrongPassword" = "Wrong Password";

--- a/ios/PolkadotVault/Screens/Scan/Errors/ErrorDisplayed+LocalizedDescription.swift
+++ b/ios/PolkadotVault/Screens/Scan/Errors/ErrorDisplayed+LocalizedDescription.swift
@@ -30,6 +30,8 @@ extension ErrorDisplayed {
             return errorMessage
         case .WrongPassword:
             return Localizable.ErrorDisplayed.wrongPassword.string
+        case .DbSchemaMismatch:
+            return Localizable.ErrorDisplayed.dbSchemaMismatch.string
         }
     }
 }

--- a/ios/PolkadotVault/Screens/Scan/Errors/ErrorDisplayed+TransactionSigning.swift
+++ b/ios/PolkadotVault/Screens/Scan/Errors/ErrorDisplayed+TransactionSigning.swift
@@ -30,6 +30,8 @@ extension ErrorDisplayed {
             return .generic(errorMessage)
         case .WrongPassword:
             return .generic(Localizable.ErrorDisplayed.wrongPassword.string)
+        case .DbSchemaMismatch:
+            return .generic("")
         }
     }
 }

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -852,6 +852,7 @@ dependencies = [
 name = "definitions"
 version = "0.1.0"
 dependencies = [
+ "constants",
  "frame-metadata 16.0.0",
  "hex",
  "libsecp256k1",

--- a/rust/constants/src/lib.rs
+++ b/rust/constants/src/lib.rs
@@ -105,6 +105,9 @@ pub const GENERALVERIFIER: &[u8] = b"general_verifier";
 /// Key in settings tree [`SETTREE`] for Vault danger status
 pub const DANGER: &[u8] = b"dangerous_encounter";
 
+/// Key in settings tree [`SETTREE`] for Vault database schema version
+pub const SCHEMA_VERSION: &[u8] = b"schema_version";
+
 /// Key in transactions tree [`TRANSACTION`] for updates data
 pub const STUB: &[u8] = b"stub";
 
@@ -188,3 +191,6 @@ pub const FPS_DEN: u16 = 15;
 
 /// Width of the QR code border, in QR code dots
 pub const BORDER: i32 = 4;
+
+/// Current database schema version
+pub const LIVE_SCHEMA_VERSION: u32 = 1;

--- a/rust/db_handling/src/cold_default.rs
+++ b/rust/db_handling/src/cold_default.rs
@@ -43,6 +43,7 @@ use parity_scale_codec::Encode;
 #[cfg(feature = "active")]
 use sled::Batch;
 
+use constants::SCHEMA_VERSION;
 #[cfg(feature = "active")]
 use constants::{DANGER, TYPES};
 #[cfg(feature = "active")]
@@ -60,6 +61,7 @@ use defaults::default_general_verifier;
 #[cfg(feature = "active")]
 use defaults::{default_chainspecs, default_types_content, default_verifiers, release_metadata};
 use defaults::{nav_test_metadata, test_metadata};
+use definitions::schema_version::SchemaVersion;
 
 use crate::identities::generate_test_identities;
 #[cfg(feature = "active")]
@@ -142,6 +144,7 @@ fn default_cold_settings_init_later() -> Result<Batch> {
     let types_prep = default_types_content()?;
     batch.insert(TYPES, types_prep.store());
     batch.insert(DANGER, DangerRecord::safe().store());
+    batch.insert(SCHEMA_VERSION, SchemaVersion::store_current());
     Ok(batch)
 }
 

--- a/rust/db_handling/src/error.rs
+++ b/rust/db_handling/src/error.rs
@@ -39,6 +39,9 @@ pub enum Error {
     #[error("Database error. Internal error. {0}")]
     DbError(#[from] sled::Error),
 
+    #[error("Database schema version mismatch. Expected v{expected}, found v{found}.")]
+    DbSchemaMismatch { expected: u32, found: u32 },
+
     /// Temporary database entry in `TRANSACTION` tree of the Vault database
     /// under the key `STUB`, used to store the update data awaiting for the
     /// user approval.

--- a/rust/db_handling/src/helpers.rs
+++ b/rust/db_handling/src/helpers.rs
@@ -6,10 +6,13 @@ use parity_scale_codec::Encode;
 use sled::{Batch, Db, Tree};
 use sp_core::H256;
 
-use constants::{ADDRTREE, DANGER, GENERALVERIFIER, VERIFIERS};
+use constants::{
+    ADDRTREE, DANGER, GENERALVERIFIER, SCHEMA_VERSION, VERIFIERS,
+};
 use constants::{METATREE, SETTREE, SPECSTREE, TYPES};
 
 use definitions::network_specs::NetworkSpecs;
+use definitions::schema_version::SchemaVersion;
 use definitions::{
     danger::DangerRecord,
     helpers::multisigner_to_public,
@@ -39,6 +42,21 @@ use crate::manage_history::events_to_batch;
 /// Input is `&[u8]` tree identifier.
 pub fn open_tree(database: &Db, tree_name: &[u8]) -> Result<Tree> {
     Ok(database.open_tree(tree_name)?)
+}
+
+/// Check database schema version.
+/// Prevents app stash when user upgrades the app without re-install.
+pub fn assert_db_version(database: &Db) -> Result<()> {
+    let expected = *SchemaVersion::current();
+    let settings = open_tree(database, SETTREE)?;
+    let ivec = settings
+        .get(SCHEMA_VERSION)?
+        .ok_or(Error::DbSchemaMismatch { expected, found: 0 })?;
+    let found = *SchemaVersion::from_ivec(&ivec)?;
+    if expected != found {
+        return Err(Error::DbSchemaMismatch { expected, found });
+    }
+    Ok(())
 }
 
 /// Assemble a [`Batch`] that removes all elements from a tree.

--- a/rust/db_handling/src/helpers.rs
+++ b/rust/db_handling/src/helpers.rs
@@ -6,9 +6,7 @@ use parity_scale_codec::Encode;
 use sled::{Batch, Db, Tree};
 use sp_core::H256;
 
-use constants::{
-    ADDRTREE, DANGER, GENERALVERIFIER, SCHEMA_VERSION, VERIFIERS,
-};
+use constants::{ADDRTREE, DANGER, GENERALVERIFIER, SCHEMA_VERSION, VERIFIERS};
 use constants::{METATREE, SETTREE, SPECSTREE, TYPES};
 
 use definitions::network_specs::NetworkSpecs;

--- a/rust/db_handling/tests/tests.rs
+++ b/rust/db_handling/tests/tests.rs
@@ -6,7 +6,10 @@ use sp_runtime::MultiSigner;
 use std::collections::HashMap;
 use std::{convert::TryInto, str::FromStr};
 
-use constants::{test_values::{alice_sr_alice, empty_png, types_known, westend_9000, westend_9010}, ADDRTREE, ALICE_SEED_PHRASE, METATREE, SPECSTREE, SCHEMA_VERSION};
+use constants::{
+    test_values::{alice_sr_alice, empty_png, types_known, westend_9000, westend_9010},
+    ADDRTREE, ALICE_SEED_PHRASE, METATREE, SCHEMA_VERSION, SPECSTREE,
+};
 use db_handling::Error;
 use defaults::default_chainspecs;
 use definitions::{
@@ -63,9 +66,8 @@ use definitions::dynamic_derivations::{
 use definitions::helpers::multisigner_to_public;
 use definitions::navigation::MAddressCard;
 
-use tempfile::tempdir;
 use db_handling::helpers::assert_db_version;
-
+use tempfile::tempdir;
 
 fn westend_genesis() -> H256 {
     H256::from_str("e143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e").unwrap()
@@ -2161,7 +2163,7 @@ fn test_dynamic_derivations() {
 }
 
 #[test]
-fn test_assert_db_version(){
+fn test_assert_db_version() {
     let dbname = tempdir().unwrap();
     let db = sled::open(&dbname).unwrap();
     populate_cold(&db, Verifier { v: None }).unwrap();
@@ -2169,18 +2171,27 @@ fn test_assert_db_version(){
 }
 
 #[test]
-fn test_assert_empty_db_version(){
+fn test_assert_empty_db_version() {
     let dbname = tempdir().unwrap();
     let db = sled::open(&dbname).unwrap();
-    assert!(matches!(assert_db_version(&db), Err(Error::DbSchemaMismatch {found:0, .. })));
+    assert!(matches!(
+        assert_db_version(&db),
+        Err(Error::DbSchemaMismatch { found: 0, .. })
+    ));
 }
 
 #[test]
-fn test_assert_wrong_db_version(){
+fn test_assert_wrong_db_version() {
     let dbname = tempdir().unwrap();
     let db = sled::open(&dbname).unwrap();
     let mut batch = Batch::default();
     batch.insert(SCHEMA_VERSION, u32::MAX.to_be_bytes().to_vec());
     TrDbCold::new().set_settings(batch).apply(&db).unwrap();
-    assert!(matches!(assert_db_version(&db), Err(Error::DbSchemaMismatch {found:u32::MAX, .. })));
+    assert!(matches!(
+        assert_db_version(&db),
+        Err(Error::DbSchemaMismatch {
+            found: u32::MAX,
+            ..
+        })
+    ));
 }

--- a/rust/db_handling/tests/tests.rs
+++ b/rust/db_handling/tests/tests.rs
@@ -6,10 +6,7 @@ use sp_runtime::MultiSigner;
 use std::collections::HashMap;
 use std::{convert::TryInto, str::FromStr};
 
-use constants::{
-    test_values::{alice_sr_alice, empty_png, types_known, westend_9000, westend_9010},
-    ADDRTREE, ALICE_SEED_PHRASE, METATREE, SPECSTREE,
-};
+use constants::{test_values::{alice_sr_alice, empty_png, types_known, westend_9000, westend_9010}, ADDRTREE, ALICE_SEED_PHRASE, METATREE, SPECSTREE, SCHEMA_VERSION};
 use db_handling::Error;
 use defaults::default_chainspecs;
 use definitions::{
@@ -67,6 +64,8 @@ use definitions::helpers::multisigner_to_public;
 use definitions::navigation::MAddressCard;
 
 use tempfile::tempdir;
+use db_handling::helpers::assert_db_version;
+
 
 fn westend_genesis() -> H256 {
     H256::from_str("e143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e").unwrap()
@@ -2159,4 +2158,29 @@ fn test_dynamic_derivations() {
             );
         }
     }
+}
+
+#[test]
+fn test_assert_db_version(){
+    let dbname = tempdir().unwrap();
+    let db = sled::open(&dbname).unwrap();
+    populate_cold(&db, Verifier { v: None }).unwrap();
+    assert!(assert_db_version(&db).is_ok());
+}
+
+#[test]
+fn test_assert_empty_db_version(){
+    let dbname = tempdir().unwrap();
+    let db = sled::open(&dbname).unwrap();
+    assert!(matches!(assert_db_version(&db), Err(Error::DbSchemaMismatch {found:0, .. })));
+}
+
+#[test]
+fn test_assert_wrong_db_version(){
+    let dbname = tempdir().unwrap();
+    let db = sled::open(&dbname).unwrap();
+    let mut batch = Batch::default();
+    batch.insert(SCHEMA_VERSION, u32::MAX.to_be_bytes().to_vec());
+    TrDbCold::new().set_settings(batch).apply(&db).unwrap();
+    assert!(matches!(assert_db_version(&db), Err(Error::DbSchemaMismatch {found:u32::MAX, .. })));
 }

--- a/rust/definitions/Cargo.toml
+++ b/rust/definitions/Cargo.toml
@@ -19,6 +19,7 @@ sp-runtime = {git = "https://github.com/paritytech/substrate", default-features 
 sp-version = {git = "https://github.com/paritytech/substrate"}
 sp-wasm-interface = {git = "https://github.com/paritytech/substrate", optional = true}
 thiserror = "1.0.49"
+constants = {path = "../constants"}
 
 [features]
 default = []

--- a/rust/definitions/src/lib.rs
+++ b/rust/definitions/src/lib.rs
@@ -45,3 +45,4 @@ pub mod navigation;
 pub mod derivations;
 
 pub mod dynamic_derivations;
+pub mod schema_version;

--- a/rust/definitions/src/schema_version.rs
+++ b/rust/definitions/src/schema_version.rs
@@ -1,0 +1,35 @@
+//! Record of the Vault database schema version
+use constants::LIVE_SCHEMA_VERSION;
+use parity_scale_codec::{Decode, Encode};
+use sled::IVec;
+use std::ops::Deref;
+
+use crate::error::Result;
+
+type SchemaVersionType = u32;
+#[derive(Decode, Encode)]
+pub struct SchemaVersion(SchemaVersionType);
+
+impl SchemaVersion {
+    /// Get the current schema version
+    pub fn current() -> Self {
+        Self(LIVE_SCHEMA_VERSION)
+    }
+
+    /// Get `SchemaVersion` with content from the encoded value,
+    /// as it is stored in the database.
+    pub fn from_ivec(ivec: &IVec) -> Result<Self> {
+        Ok(Self(SchemaVersionType::decode(&mut &ivec[..])?))
+    }
+
+    pub fn store_current() -> Vec<u8> {
+        Self::current().encode()
+    }
+}
+
+impl Deref for SchemaVersion {
+    type Target = SchemaVersionType;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/rust/signer/src/signer.udl
+++ b/rust/signer/src/signer.udl
@@ -10,6 +10,7 @@ interface ErrorDisplayed {
     UnknownNetwork(H256 genesis_hash, Encryption encryption);
     NoMetadata(string name);
     WrongPassword();
+    DbSchemaMismatch();
 };
 
 [Error]
@@ -695,6 +696,9 @@ namespace signer {
 
     [Throws=ErrorDisplayed]
     MNewSeedBackup print_new_seed([ByRef] string new_seed_name);
+
+    [Throws=ErrorDisplayed]
+    void check_db_version();
 
     [Throws=ErrorDisplayed]
     void create_key_set([ByRef] string seed_name, [ByRef] string seed_phrase, sequence<string> networks);


### PR DESCRIPTION
## Purpose
Detect db schema change, prevent app from crashing

## Scope
- store db version
- expose `check_db_version` to check if app has been upgraded without the re-install.
- added `DbSchemaMismatch` error to catch

Scheme version should be bumped manually every time there is a breaking change on the backend.
