### PR TITLE
feat: ios: db check fixes and keyset recovery screen copy update

### DIFF
--- a/ios/PolkadotVault/PolkadotVaultApp.swift
+++ b/ios/PolkadotVault/PolkadotVaultApp.swift
@@ -14,10 +14,6 @@ struct PolkadotVaultApp: App {
     @StateObject var jailbreakDetectionPublisher = JailbreakDetectionPublisher()
     @StateObject var applicationStatePublisher = ApplicationStatePublisher()
 
-    init() {
-        AppLaunchMediator().finaliseInitialisation()
-    }
-
     var body: some Scene {
         WindowGroup {
             if jailbreakDetectionPublisher.isJailbroken {

--- a/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
+++ b/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
@@ -79,7 +79,7 @@
 "SEED PHRASE" = "Secret Recovery Phrase";
 "RecoverSeedPhrase.Action.Next" = "Next";
 "RecoverSeedPhrase.Label.Title" = "Enter a Secret Recovery Phrase";
-"RecoverSeedPhrase.Label.Header" = "Enter a 24-word phrase you were given when you created your key set";
+"RecoverSeedPhrase.Label.Header" = "Enter a phrase you were given when you created your key set";
 "RecoverSeedPhrase.Error.IncorrectPhrase.Title" = "Please enter the correct Secret Recovery phrase";
 "RecoverSeedPhrase.Error.IncorrectPhrase.Message" = "Please edit your secret recovery phrase and try again.";
 

--- a/ios/PolkadotVault/Screens/Containers/MainScreenContainer.swift
+++ b/ios/PolkadotVault/Screens/Containers/MainScreenContainer.swift
@@ -67,10 +67,10 @@ extension MainScreenContainer {
                     switch error {
                     case .invalidVersion:
                         self.viewState = .updateRequired
-                    case let .error(serviceError):
-                        // todo what we should really do here?
+                    case .error:
+                        /// If DB version check was unavailable, assume user needs to update
+                        /// If that's not the case (i.e. there is no newer version), app restart will fix it so should be ok
                         self.viewState = .updateRequired
-                        print(serviceError)
                     }
                 }
             }

--- a/ios/PolkadotVault/Screens/Containers/MainScreenContainer.swift
+++ b/ios/PolkadotVault/Screens/Containers/MainScreenContainer.swift
@@ -13,17 +13,28 @@ struct MainScreenContainer: View {
     @StateObject var onboarding: OnboardingStateMachine
 
     var body: some View {
-        switch viewModel.viewState {
-        case .authenticated:
-            AuthenticatedScreenContainer(viewModel: .init())
-        case .deviceLocked:
-            UnlockDeviceView(viewModel: .init())
-        case .onboarding:
-            onboarding.currentView()
-        case .updateRequired:
-            ApplicationUpdateRequiredView(viewModel: .init())
-        case .noPincode:
-            DevicePincodeRequired(viewModel: .init())
+        Group {
+            switch viewModel.viewState {
+            case .authenticated:
+                AuthenticatedScreenContainer(viewModel: .init())
+            case .deviceLocked:
+                UnlockDeviceView(viewModel: .init())
+            case .onboarding:
+                onboarding.currentView()
+            case .updateRequired:
+                ApplicationUpdateRequiredView(viewModel: .init())
+            case .noPincode:
+                DevicePincodeRequired(viewModel: .init())
+            }
+        }
+        .fullScreenModal(
+            isPresented: $viewModel.isPresentingError
+        ) {
+            ErrorBottomModal(
+                viewModel: viewModel.presentableError,
+                isShowingBottomAlert: $viewModel.isPresentingError
+            )
+            .clearModalBackground()
         }
     }
 }
@@ -42,20 +53,37 @@ extension MainScreenContainer {
         private let onboardingMediator: OnboardingMediator
         private let passwordProtectionStatePublisher: PasswordProtectionStatePublisher
         private let databaseVersionMediator: DatabaseVersionMediator
+        private let appLaunchMediator: AppLaunchMediating
         private let cancelBag = CancelBag()
         @Published var viewState: ViewState = .deviceLocked
+        @Published var isPresentingError: Bool = false
+        @Published var presentableError: ErrorBottomModalViewModel = .alertError(message: "")
 
         init(
             authenticationStateMediator: AuthenticatedStateMediator = ServiceLocator.authenticationStateMediator,
             onboardingMediator: OnboardingMediator = ServiceLocator.onboardingMediator,
             passwordProtectionStatePublisher: PasswordProtectionStatePublisher = PasswordProtectionStatePublisher(),
-            databaseVersionMediator: DatabaseVersionMediator = DatabaseVersionMediator()
+            databaseVersionMediator: DatabaseVersionMediator = DatabaseVersionMediator(),
+            appLaunchMediator: AppLaunchMediating = AppLaunchMediator()
         ) {
             self.authenticationStateMediator = authenticationStateMediator
             self.onboardingMediator = onboardingMediator
             self.passwordProtectionStatePublisher = passwordProtectionStatePublisher
             self.databaseVersionMediator = databaseVersionMediator
-            checkInitialState()
+            self.appLaunchMediator = appLaunchMediator
+            initialiseAppRun()
+        }
+
+        private func initialiseAppRun() {
+            appLaunchMediator.finaliseInitialisation { result in
+                switch result {
+                case .success:
+                    self.checkInitialState()
+                case let .failure(error):
+                    self.presentableError = .alertError(message: error.localizedDescription)
+                    self.isPresentingError = true
+                }
+            }
         }
 
         private func checkInitialState() {
@@ -67,11 +95,13 @@ extension MainScreenContainer {
                     switch error {
                     case .invalidVersion:
                         self.viewState = .updateRequired
-                    case .error:
+                    case let .error(serviceError):
                         /// If DB version check was unavailable, assume user needs to update
                         /// If that's not the case (i.e. there is no newer version), app restart will fix it so should
                         /// be ok
                         self.viewState = .updateRequired
+                        self.presentableError = .alertError(message: serviceError.localizedDescription)
+                        self.isPresentingError = true
                     }
                 }
             }

--- a/ios/PolkadotVault/Screens/Containers/MainScreenContainer.swift
+++ b/ios/PolkadotVault/Screens/Containers/MainScreenContainer.swift
@@ -69,7 +69,8 @@ extension MainScreenContainer {
                         self.viewState = .updateRequired
                     case .error:
                         /// If DB version check was unavailable, assume user needs to update
-                        /// If that's not the case (i.e. there is no newer version), app restart will fix it so should be ok
+                        /// If that's not the case (i.e. there is no newer version), app restart will fix it so should
+                        /// be ok
                         self.viewState = .updateRequired
                     }
                 }

--- a/ios/PolkadotVault/StateMediators/AppLaunchMediator.swift
+++ b/ios/PolkadotVault/StateMediators/AppLaunchMediator.swift
@@ -8,41 +8,42 @@
 import Foundation
 
 protocol AppLaunchMediating: AnyObject {
-    func finaliseInitialisation()
+    func finaliseInitialisation(_ completion: @escaping (Result<Void, ServiceError>) -> Void)
 }
 
 final class AppLaunchMediator: ObservableObject, AppLaunchMediating {
     private let seedsMediator: SeedsMediating
     private let databaseMediator: DatabaseMediating
-    private let onboardingMediator: OnboardingMediator
+    private let backendService: BackendService
 
     init(
         seedsMediator: SeedsMediating = ServiceLocator.seedsMediator,
         databaseMediator: DatabaseMediating = DatabaseMediator(),
-        onboardingMediator: OnboardingMediator = ServiceLocator.onboardingMediator
+        backendService: BackendService = BackendService()
     ) {
         self.seedsMediator = seedsMediator
         self.databaseMediator = databaseMediator
-        self.onboardingMediator = onboardingMediator
+        self.backendService = backendService
     }
 
-    func finaliseInitialisation() {
-        if onboardingMediator.onboardingDone {
-            initialiseOnboardedUserRun()
+    func finaliseInitialisation(_ completion: @escaping (Result<Void, ServiceError>) -> Void) {
+        if databaseMediator.isDatabaseAvailable() {
+            initialiseOnboardedUserRun(completion)
         } else {
-            initialiseFirstRun()
+            initialiseFirstRun(completion)
         }
     }
 
-    private func initialiseFirstRun() {
+    private func initialiseFirstRun(_ completion: @escaping (Result<Void, ServiceError>) -> Void) {
         seedsMediator.removeStalledSeeds()
         databaseMediator.wipeDatabase()
+        completion(.success(()))
     }
 
-    private func initialiseOnboardedUserRun() {
+    private func initialiseOnboardedUserRun(_ completion: @escaping (Result<Void, ServiceError>) -> Void) {
         seedsMediator.initialRefreshSeeds()
-        do {
-            try initNavigation(dbname: databaseMediator.databaseName, seedNames: seedsMediator.seedNames)
-        } catch {}
+        backendService.performCall({
+            try initNavigation(dbname: self.databaseMediator.databaseName, seedNames: self.seedsMediator.seedNames)
+        }, completion: completion)
     }
 }

--- a/ios/PolkadotVault/StateMediators/DatabaseVersionMediator.swift
+++ b/ios/PolkadotVault/StateMediators/DatabaseVersionMediator.swift
@@ -15,16 +15,22 @@ enum DatabaseCheckError: Error {
 
 final class DatabaseVersionMediator {
     private let backendService: BackendService
+    private let databaseMediator: DatabaseMediating
 
     init(
-        backendService: BackendService = BackendService()
+        backendService: BackendService = BackendService(),
+        databaseMediator: DatabaseMediating = DatabaseMediator()
     ) {
         self.backendService = backendService
+        self.databaseMediator = databaseMediator
     }
 
     func checkDatabaseScheme(
         _ completion: @escaping (Result<Void, DatabaseCheckError>) -> Void
     ) {
+        guard databaseMediator.isDatabaseAvailable() else { completion(.success(()))
+            return
+        }
         backendService.performCall({
             try checkDbVersion()
         }, completion: { (result: Result<Void, ErrorDisplayed>) in


### PR DESCRIPTION
## Purpose
- Update secret recovery copy
- clean up DB scheme check fallback as discussed in previous PR #2114 
- fixes case where DB scheme check is triggered on fresh install before DB is created 🤦🏻‍♂️ #2114 
- fixes issue with `init_navigation` not being called before DB scheme check for following app runs

## Screenshots
<img width="320" alt="gif" src="https://github.com/paritytech/parity-signer/assets/1955364/10a279d2-096c-4482-9657-c21f6421bf85">

