### PR TITLE
feat: ios: update public key details right after key is exported

### DIFF
--- a/ios/PolkadotVault/Backend/Services/KeyDetailsActionService.swift
+++ b/ios/PolkadotVault/Backend/Services/KeyDetailsActionService.swift
@@ -25,7 +25,7 @@ final class KeyDetailsActionService {
         }, completion: completion)
     }
 
-    func navigateToPublicKey(
+    func publicKey(
         addressKey: String,
         networkSpecsKey: String,
         _ completion: @escaping (Result<MKeyDetails, ServiceError>) -> Void

--- a/ios/PolkadotVault/Screens/KeyDetails/Views/KeyDetails+ViewModel.swift
+++ b/ios/PolkadotVault/Screens/KeyDetails/Views/KeyDetails+ViewModel.swift
@@ -314,7 +314,7 @@ extension KeyDetailsView.ViewModel {
 
     func onDerivedKeyTap(_ deriveKey: DerivedKeyRowModel) {
         DispatchQueue.main.async {
-            self.keyDetailsActionsService.navigateToPublicKey(
+            self.keyDetailsActionsService.publicKey(
                 addressKey: deriveKey.keyData.key.addressKey,
                 networkSpecsKey: deriveKey.keyData.network.networkSpecsKey
             ) { result in

--- a/ios/PolkadotVault/Screens/PublicKey/KeyDetailsPublicKeyView.swift
+++ b/ios/PolkadotVault/Screens/PublicKey/KeyDetailsPublicKeyView.swift
@@ -225,12 +225,13 @@ extension KeyDetailsPublicKeyView {
     }
 
     final class ViewModel: ObservableObject {
-        let keyDetails: MKeyDetails
         let addressKey: String
         private let publicKeyDetailsService: PublicKeyDetailsService
         private let exportPrivateKeyService: ExportPrivateKeyService
+        private let keyDetailsService: KeyDetailsActionService
         private let warningStateMediator: WarningStateMediator
 
+        @Published var keyDetails: MKeyDetails
         @Published var exportPrivateKeyViewModel: ExportPrivateKeyViewModel!
         @Published var renderable: KeyDetailsPublicKeyViewModel
         @Published var isShowingRemoveConfirmation = false
@@ -260,13 +261,15 @@ extension KeyDetailsPublicKeyView {
             addressKey: String,
             publicKeyDetailsService: PublicKeyDetailsService = PublicKeyDetailsService(),
             exportPrivateKeyService: ExportPrivateKeyService = ExportPrivateKeyService(),
+            keyDetailsService: KeyDetailsActionService = KeyDetailsActionService(),
             warningStateMediator: WarningStateMediator = ServiceLocator.warningStateMediator,
             onCompletion: @escaping (OnCompletionAction) -> Void
         ) {
-            self.keyDetails = keyDetails
+            _keyDetails = .init(initialValue: keyDetails)
             self.addressKey = addressKey
             self.publicKeyDetailsService = publicKeyDetailsService
             self.exportPrivateKeyService = exportPrivateKeyService
+            self.keyDetailsService = keyDetailsService
             self.warningStateMediator = warningStateMediator
             self.onCompletion = onCompletion
             _renderable = .init(initialValue: KeyDetailsPublicKeyViewModel(keyDetails))
@@ -300,6 +303,19 @@ extension KeyDetailsPublicKeyView {
 
         func onExportKeysDismissal() {
             exportPrivateKeyViewModel = nil
+            keyDetailsService.publicKey(
+                addressKey: addressKey,
+                networkSpecsKey: keyDetails.networkInfo.networkSpecsKey
+            ) { result in
+                switch result {
+                case let .success(keyDetails):
+                    self.keyDetails = keyDetails
+                    self.renderable = KeyDetailsPublicKeyViewModel(keyDetails)
+                case let .failure(error):
+                    self.presentableError = .alertError(message: error.localizedDescription)
+                    self.isPresentingError = true
+                }
+            }
         }
 
         func onConnectivityErrorContinueTap() {


### PR DESCRIPTION
## Purpose
Update public key details to show "hot" indicator right after key export

## Screenshots

| Example | |
|-|-|
|<img src="https://github.com/paritytech/parity-signer/assets/1955364/ac892845-8b8b-4137-98b7-2be0adc2f217" width="320px">||


