### PR TITLE
fix: ios: update to newest simulator in order to fix CI / CD workflows

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -63,10 +63,4 @@ jobs:
         shell:                bash
         run:                  |
           cd ios
-          xcodebuild \
-          -project PolkadotVault.xcodeproj \
-          -scheme PolkadotVault \
-          -sdk iphonesimulator \
-          -destination 'platform=iOS Simulator,name=iPhone 14' \
-          test \
-          | xcbeautify
+          bundle exec fastlane run_unit_tests

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -24,6 +24,12 @@ jobs:
           fetch-depth:        50
           submodules:         'recursive'
 
+      - name:                 Setup Ruby
+        uses:                 ruby/setup-ruby@v1
+        with:
+          ruby-version:       '2.7'
+          bundler-cache:      true
+
       - name:                 Setup - Xcode
         run:                  sudo xcode-select -switch '/Applications/Xcode_15.0.app/Contents/Developer' && /usr/bin/xcodebuild -version
 
@@ -31,7 +37,6 @@ jobs:
         run:                  |
           brew install swiftgen
           brew install swiftformat
-          brew install xcbeautify
 
       - name: Get cached Swift Packages managed by Xcode
         uses: actions/cache@v3

--- a/ios/fastlane/lanes/lane_tests.rb
+++ b/ios/fastlane/lanes/lane_tests.rb
@@ -9,7 +9,7 @@ lane :test_build do |options|
   scan(
     clean: true,
     scheme: scheme,
-    device: "iPhone 13",
+    device: "iPhone 15",
     output_directory: "./fastlane/test_output/"
   )
 end


### PR DESCRIPTION
## Purpose
CI / CD fails as iPhone 13 was removed, this PR fixes that by running Github Actions workflows on newest sim