### PR TITLE
feat: ios: remove Backup Secret Phrase option from Settings

### DIFF
--- a/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
+++ b/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
@@ -342,7 +342,6 @@
 "Settings.Label.Networks" = "Networks";
 "Settings.Label.Logs" = "Logs";
 "Settings.Label.Verifier" = "Verifier Certificate";
-"Settings.Label.Backup" = "Backup Secret Phrase";
 "Settings.Label.Policy" = "Privacy Policy";
 "Settings.Label.Terms" = "Terms of Service";
 "Settings.Label.Version" = "App version %@";

--- a/ios/PolkadotVault/Screens/Settings/SettingsItem.swift
+++ b/ios/PolkadotVault/Screens/Settings/SettingsItem.swift
@@ -11,7 +11,6 @@ enum SettingsItem: Equatable, Hashable, CaseIterable {
     case logs
     case networks
     case verifier
-    case backup
     case privacyPolicy
     case termsAndConditions
     case wipe
@@ -26,8 +25,6 @@ extension SettingsItem {
             Localizable.Settings.Label.networks.string
         case .verifier:
             Localizable.Settings.Label.verifier.string
-        case .backup:
-            Localizable.Settings.Label.backup.string
         case .privacyPolicy:
             Localizable.Settings.Label.policy.string
         case .termsAndConditions:

--- a/ios/PolkadotVault/Screens/Settings/SettingsView.swift
+++ b/ios/PolkadotVault/Screens/Settings/SettingsView.swift
@@ -74,8 +74,6 @@ struct SettingsView: View {
             NetworkSelectionSettings(viewModel: .init())
         case .verifier:
             VerifierCertificateView(viewModel: .init())
-        case .backup:
-            BackupSelectKeyView(viewModel: .init())
         case .privacyPolicy:
             PrivacyPolicyView(viewModel: .init())
         case .termsAndConditions:
@@ -119,9 +117,6 @@ extension SettingsView {
                 isDetailsPresented = true
             case .privacyPolicy:
                 detailScreen = .privacyPolicy
-                isDetailsPresented = true
-            case .backup:
-                detailScreen = .backup
                 isDetailsPresented = true
             case .networks:
                 detailScreen = .networks


### PR DESCRIPTION
## Purpose
Remove Backup Secret Phrase option from Settings

## Screenshots

| Light | Dark |
|-|-|
|<img src="https://github.com/paritytech/parity-signer/assets/1955364/5dc5080b-82ab-4abd-adc1-1900cdeb77cd" width="320px">|<img src="https://github.com/paritytech/parity-signer/assets/1955364/b315e7c1-6477-46ca-af77-3d529708f4f6" width="320px">|
