### PR TITLE
chore: ios: abstract Keychain Service and add unit tests

### DIFF
--- a/ios/PolkadotVault.xcodeproj/project.pbxproj
+++ b/ios/PolkadotVault.xcodeproj/project.pbxproj
@@ -240,6 +240,7 @@
 		6DBF6E4328EACB7B00CC959F /* ConnectivityMediator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DBF6E4228EACB7B00CC959F /* ConnectivityMediator.swift */; };
 		6DBF6E4B28EC51D600CC959F /* GenericError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DBF6E4A28EC51D600CC959F /* GenericError.swift */; };
 		6DC0FC98296695D000A45883 /* SeedKeysPreview+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DC0FC97296695D000A45883 /* SeedKeysPreview+Helpers.swift */; };
+		6DC2EDFE2B1198FC00298F00 /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DC2EDFD2B1198FC00298F00 /* KeychainService.swift */; };
 		6DC33717295559EA0067284B /* NetworkSettingsDetailsActionModal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DC33716295559EA0067284B /* NetworkSettingsDetailsActionModal.swift */; };
 		6DC33723295ACF2D0067284B /* CornerRadiusModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DC33722295ACF2D0067284B /* CornerRadiusModifier.swift */; };
 		6DC33725295BFA4D0067284B /* RootKeyDetailsModal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DC33724295BFA4D0067284B /* RootKeyDetailsModal.swift */; };
@@ -261,6 +262,7 @@
 		6DD860EA299CED3F0000D81E /* AirgapMediator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DD860E9299CED3F0000D81E /* AirgapMediator.swift */; };
 		6DD9FF1628C8B85300FB6195 /* HorizontalActionsBottomModal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DD9FF1528C8B85300FB6195 /* HorizontalActionsBottomModal.swift */; };
 		6DD9FF1928C8C9B000FB6195 /* Animations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DD9FF1828C8C9AF00FB6195 /* Animations.swift */; };
+		6DDD38B22B11C3C2000D2B62 /* SeedsMediatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DDD38B12B11C3C2000D2B62 /* SeedsMediatorTests.swift */; };
 		6DDD73732940471900F04CE7 /* Event+AdditionalValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DDD73722940471900F04CE7 /* Event+AdditionalValue.swift */; };
 		6DDD73752940496800F04CE7 /* LogEntryRenderable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DDD73742940496800F04CE7 /* LogEntryRenderable.swift */; };
 		6DDD73782940498000F04CE7 /* LogEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DDD73772940498000F04CE7 /* LogEntryView.swift */; };
@@ -584,6 +586,7 @@
 		6DBF6E4228EACB7B00CC959F /* ConnectivityMediator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityMediator.swift; sourceTree = "<group>"; };
 		6DBF6E4A28EC51D600CC959F /* GenericError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericError.swift; sourceTree = "<group>"; };
 		6DC0FC97296695D000A45883 /* SeedKeysPreview+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SeedKeysPreview+Helpers.swift"; sourceTree = "<group>"; };
+		6DC2EDFD2B1198FC00298F00 /* KeychainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainService.swift; sourceTree = "<group>"; };
 		6DC33716295559EA0067284B /* NetworkSettingsDetailsActionModal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkSettingsDetailsActionModal.swift; sourceTree = "<group>"; };
 		6DC33722295ACF2D0067284B /* CornerRadiusModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CornerRadiusModifier.swift; sourceTree = "<group>"; };
 		6DC33724295BFA4D0067284B /* RootKeyDetailsModal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootKeyDetailsModal.swift; sourceTree = "<group>"; };
@@ -606,6 +609,7 @@
 		6DD860E9299CED3F0000D81E /* AirgapMediator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AirgapMediator.swift; sourceTree = "<group>"; };
 		6DD9FF1528C8B85300FB6195 /* HorizontalActionsBottomModal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalActionsBottomModal.swift; sourceTree = "<group>"; };
 		6DD9FF1828C8C9AF00FB6195 /* Animations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Animations.swift; sourceTree = "<group>"; };
+		6DDD38B12B11C3C2000D2B62 /* SeedsMediatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeedsMediatorTests.swift; sourceTree = "<group>"; };
 		6DDD73722940471900F04CE7 /* Event+AdditionalValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Event+AdditionalValue.swift"; sourceTree = "<group>"; };
 		6DDD73742940496800F04CE7 /* LogEntryRenderable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogEntryRenderable.swift; sourceTree = "<group>"; };
 		6DDD73772940498000F04CE7 /* LogEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogEntryView.swift; sourceTree = "<group>"; };
@@ -1437,6 +1441,7 @@
 				6D8AF88128BCC4D100CF0AB2 /* AccessControlProvidingAssemblerTests.swift */,
 				6D8AF88928BCC60600CF0AB2 /* KeychainQueryProviderTests.swift */,
 				6DAFCAF92B0AE5C000DDD165 /* KeychainAccessAdapterTests.swift */,
+				6DDD38B12B11C3C2000D2B62 /* SeedsMediatorTests.swift */,
 			);
 			path = Keychain;
 			sourceTree = "<group>";
@@ -1665,6 +1670,7 @@
 				6DC5643628B79EC6003D540B /* SeedsMediator.swift */,
 				6DC5643828B7DED8003D540B /* KeychainQueryProvider.swift */,
 				6DC5643A28B8D189003D540B /* KeychainAccessAdapter.swift */,
+				6DC2EDFD2B1198FC00298F00 /* KeychainService.swift */,
 			);
 			path = Keychain;
 			sourceTree = "<group>";
@@ -2213,6 +2219,7 @@
 				6D67F94329825D280017C278 /* JailbreakDetectedView.swift in Sources */,
 				6DA08B8829ACFC230027CFCB /* InlineTextField.swift in Sources */,
 				6DDD73782940498000F04CE7 /* LogEntryView.swift in Sources */,
+				6DC2EDFE2B1198FC00298F00 /* KeychainService.swift in Sources */,
 				6D67F94529837BB00017C278 /* UnlockDeviceView.swift in Sources */,
 				6DBD21F4289A77DE005D539B /* BundleProtocol.swift in Sources */,
 				6D2779C828B3D33100570055 /* NavigationBarView.swift in Sources */,
@@ -2383,6 +2390,7 @@
 				6D57DC54289D6CE900005C63 /* NavigationTests.swift in Sources */,
 				6DAFCB022B0AEE4900DDD165 /* ApplicationStatePublisherTests.swift in Sources */,
 				6D8AF88A28BCC60600CF0AB2 /* KeychainQueryProviderTests.swift in Sources */,
+				6DDD38B22B11C3C2000D2B62 /* SeedsMediatorTests.swift in Sources */,
 				6D57DC52289D68B800005C63 /* ActionResult+Generate.swift in Sources */,
 				6DAFCAFD2B0AE87300DDD165 /* RuntimePropertiesProviderTests.swift in Sources */,
 				6DBD2202289A8E1F005D539B /* ErrorMock.swift in Sources */,

--- a/ios/PolkadotVault/Core/Keychain/KeychainService.swift
+++ b/ios/PolkadotVault/Core/Keychain/KeychainService.swift
@@ -1,0 +1,49 @@
+//
+//  KeychainService.swift
+//  PolkadotVault
+//
+//  Created by Krzysztof Rodak on 25/11/2023.
+//
+
+import Foundation
+
+/// A protocol that abstracts the keychain operations used by KeychainMediator.
+protocol KeychainServicing {
+    /// Adds a keychain item that matches a query.
+    /// - Parameters:
+    ///   - query: A dictionary that contains an item class key and attribute keys and values.
+    ///   - result: On return, contains the item data from the keychain.
+    /// - Returns: A result code. See "Security Result Codes"
+    /// (https://developer.apple.com/documentation/security/1542001-security_framework_result_codes).
+    func add(_ query: CFDictionary, _ result: UnsafeMutablePointer<CFTypeRef?>?) -> OSStatus
+
+    /// Returns one or more keychain items that match a search query.
+    /// - Parameters:
+    ///   - query: A dictionary that contains an item class key and attribute keys and values.
+    ///   - result: On return, contains the item data from the keychain.
+    /// - Returns: A result code. See "Security Result Codes"
+    /// (https://developer.apple.com/documentation/security/1542001-security_framework_result_codes).
+    func copyMatching(_ query: CFDictionary, _ result: UnsafeMutablePointer<CFTypeRef?>?) -> OSStatus
+
+    /// Deletes keychain items that match a search query.
+    /// - Parameter query: A dictionary that contains an item class key and attribute keys and values.
+    /// - Returns: A result code. See "Security Result Codes"
+    /// (https://developer.apple.com/documentation/security/1542001-security_framework_result_codes).
+    func delete(_ query: CFDictionary) -> OSStatus
+}
+
+/// A class that implements `KeychainService` by calling the actual `Keychain API`.
+final class KeychainService: KeychainServicing {
+    init() {}
+    func add(_ query: CFDictionary, _ result: UnsafeMutablePointer<CFTypeRef?>?) -> OSStatus {
+        SecItemAdd(query, result)
+    }
+
+    func copyMatching(_ query: CFDictionary, _ result: UnsafeMutablePointer<CFTypeRef?>?) -> OSStatus {
+        SecItemCopyMatching(query, result)
+    }
+
+    func delete(_ query: CFDictionary) -> OSStatus {
+        SecItemDelete(query)
+    }
+}

--- a/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
+++ b/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
@@ -121,7 +121,6 @@
 "AddKeySet.Button.Recover" = "Recover Key Set";
 
 "KeyDetails.Label.Derived" = "Derived keys";
-"KeyDetails.Label.ImportedKey" = "Imported from Omni Wallet";
 "KeyDetails.Label.EmptyState.Header" = "Key Set Has No Derived Keys";
 "KeyDetails.Label.EmptyState.Action" = "Create Derived Key";
 
@@ -138,7 +137,6 @@
 "KeyDetails.Error.NoNetworks.Message" = "In order to create derived key, you need to add some networks first. Use \"Scan\" tab to scan network metadata first and try again.";
 
 
-"PublicKeyDetails.Label.ImportedKey" = "Imported from Omni Wallet";
 "PublicKeyDetails.Label.Keys" = "%@ Keys";
 "PublicKeyDetails.Label.KeySetName" = "Key Set Name";
 "PublicKeyDetails.Label.Network" = "Network";
@@ -604,7 +602,6 @@
 "ErrorDisplayed.WrongPassword" = "Wrong Password";
 
 "AddDerivedKeys.Label.Title" = "Add Derived Keys";
-"AddDerivedKeys.Label.Header" = "Сheck the keys and scan QR code into Omni Wallet app";
 "AddDerivedKeys.Label.Footer" = "Scan QR code to add the keys";
 "AddDerivedKeys.Action.Done" = "Done";
 "AddDerivedKeys.Error.NetworkMissing" = "Some keys can not be imported until their networks are added. Please add missing networks and their metadata. ";

--- a/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
+++ b/ios/PolkadotVault/Resources/en.lproj/Localizable.strings
@@ -602,6 +602,7 @@
 "ErrorDisplayed.WrongPassword" = "Wrong Password";
 
 "AddDerivedKeys.Label.Title" = "Add Derived Keys";
+"AddDerivedKeys.Label.Header" = "Сheck the keys and scan QR code into Omni Wallet app";
 "AddDerivedKeys.Label.Footer" = "Scan QR code to add the keys";
 "AddDerivedKeys.Action.Done" = "Done";
 "AddDerivedKeys.Error.NetworkMissing" = "Some keys can not be imported until their networks are added. Please add missing networks and their metadata. ";

--- a/ios/PolkadotVault/Screens/Containers/AuthenticatedScreenContainer.swift
+++ b/ios/PolkadotVault/Screens/Containers/AuthenticatedScreenContainer.swift
@@ -59,7 +59,7 @@ extension AuthenticatedScreenContainer {
         init(seedsMediator: SeedsMediating = ServiceLocator.seedsMediator) {
             self.seedsMediator = seedsMediator
             updateViewState()
-            seedsMediator.seedNamesPublisher
+            seedsMediator.seedNames.publisher
                 .sink { [weak self] _ in
                     self?.updateViewState()
                 }

--- a/ios/PolkadotVault/StateMediators/AppLaunchMediator.swift
+++ b/ios/PolkadotVault/StateMediators/AppLaunchMediator.swift
@@ -41,7 +41,7 @@ final class AppLaunchMediator: ObservableObject, AppLaunchMediating {
     }
 
     private func initialiseOnboardedUserRun(_ completion: @escaping (Result<Void, ServiceError>) -> Void) {
-        seedsMediator.initialRefreshSeeds()
+        seedsMediator.refreshSeeds()
         backendService.performCall({
             try initNavigation(dbname: self.databaseMediator.databaseName, seedNames: self.seedsMediator.seedNames)
         }, completion: completion)

--- a/ios/PolkadotVault/StateMediators/AuthenticatedStateMediator.swift
+++ b/ios/PolkadotVault/StateMediators/AuthenticatedStateMediator.swift
@@ -7,6 +7,6 @@
 
 import Foundation
 
-final class AuthenticatedStateMediator: ObservableObject {
+class AuthenticatedStateMediator: ObservableObject {
     @Published var authenticated: Bool = false
 }

--- a/ios/PolkadotVaultTests/Core/Connectivity/ConnectivityMonitoringAdapterTests.swift
+++ b/ios/PolkadotVaultTests/Core/Connectivity/ConnectivityMonitoringAdapterTests.swift
@@ -52,7 +52,7 @@ final class ConnectivityMonitoringAdapterTests: XCTestCase {
 
 final class PathMonitorProtocolMock: PathMonitorProtocol {
     @preconcurrency
-    var pathUpdateHandler: ((NWPath) -> Void)?
+    var pathUpdateHandler: (@Sendable (NWPath) -> Void)?
 
     var startQueueCallsCount = 0
     var startQueueReceivedQueue: [DispatchQueue] = []

--- a/ios/PolkadotVaultTests/Core/Keychain/KeychainAccessAdapterTests.swift
+++ b/ios/PolkadotVaultTests/Core/Keychain/KeychainAccessAdapterTests.swift
@@ -12,13 +12,16 @@ import XCTest
 final class KeychainAccessAdapterTests: XCTestCase {
     private var keychainQueryProviderMock: KeychainQueryProviderMock!
     private var accessControlProviderMock: AccessControlProviderMock!
+    private var keychainService: KeychainServiceMock!
     private var keychainAccessAdapter: KeychainAccessAdapter!
 
     override func setUp() {
         super.setUp()
         keychainQueryProviderMock = KeychainQueryProviderMock()
         accessControlProviderMock = AccessControlProviderMock()
+        keychainService = KeychainServiceMock()
         keychainAccessAdapter = KeychainAccessAdapter(
+            keychainService: keychainService,
             acccessControlProvider: accessControlProviderMock,
             queryProvider: keychainQueryProviderMock
         )
@@ -29,6 +32,372 @@ final class KeychainAccessAdapterTests: XCTestCase {
         accessControlProviderMock = nil
         keychainAccessAdapter = nil
         super.tearDown()
+    }
+
+    func testFetchSeedNames_SuccessfulFetch() {
+        // Given
+        keychainService.copyMatchingReturnValue = errSecSuccess
+        let seedData: [[String: Any]] = [[kSecAttrAccount as String: "Seed1"], [kSecAttrAccount as String: "Seed2"]]
+        keychainService.copyMatchingData = seedData as CFTypeRef
+        keychainQueryProviderMock.queryReturnValue = [:] as CFDictionary
+
+        // When
+        let result = keychainAccessAdapter.fetchSeedNames()
+
+        // Then
+        XCTAssertEqual(keychainService.copyMatchingCallsCount, 1)
+        switch result {
+        case let .success(payload):
+            XCTAssertEqual(payload.seeds, ["Seed1", "Seed2"])
+        default:
+            XCTFail("Expected success but got \(result)")
+        }
+    }
+
+    func testFetchSeedNames_EmptyResult() {
+        // Given
+        keychainService.copyMatchingReturnValue = errSecSuccess
+        keychainQueryProviderMock.queryReturnValue = [:] as CFDictionary
+        keychainService.copyMatchingData = [] as CFTypeRef
+
+        // When
+        let result = keychainAccessAdapter.fetchSeedNames()
+
+        // Then
+        XCTAssertEqual(keychainService.copyMatchingCallsCount, 1)
+        switch result {
+        case let .success(payload):
+            XCTAssertTrue(payload.seeds.isEmpty)
+        default:
+            XCTFail("Expected success with empty result but got \(result)")
+        }
+    }
+
+    func testFetchSeedNames_Failure() {
+        // Given
+        keychainService.copyMatchingReturnValue = errSecAuthFailed
+        keychainQueryProviderMock.queryReturnValue = [:] as CFDictionary
+
+        // When
+        let result = keychainAccessAdapter.fetchSeedNames()
+
+        // Then
+        XCTAssertEqual(keychainService.copyMatchingCallsCount, 1)
+        if case let .failure(error) = result {
+            XCTAssertEqual(error, KeychainError.fetchError)
+        } else {
+            XCTFail("Expected failure but got \(result)")
+        }
+    }
+
+    func testSaveSeed_Successful() {
+        // Given
+        keychainService.addReturnValue = errSecSuccess
+        accessControlProviderMock.accessControlToReturn = SecAccessControlCreateWithFlags(
+            nil,
+            kSecAttrAccessibleWhenUnlocked,
+            .privateKeyUsage,
+            nil
+        )
+        keychainQueryProviderMock.queryReturnValue = [:] as CFDictionary
+
+        // When
+        let result = keychainAccessAdapter.saveSeed(with: "SeedName", seedPhrase: Data("seedPhrase".utf8))
+
+        // Then
+        XCTAssertEqual(keychainService.addCallsCount, 1)
+        if case .failure = result {
+            XCTFail("Expected success but got \(result)")
+        }
+    }
+
+    func testSaveSeed_FailureKeychainIssue() {
+        // Given
+        keychainService.addReturnValue = errSecAuthFailed
+        accessControlProviderMock.accessControlToReturn = SecAccessControlCreateWithFlags(
+            nil,
+            kSecAttrAccessibleWhenUnlocked,
+            .privateKeyUsage,
+            nil
+        )
+        keychainQueryProviderMock.queryReturnValue = [:] as CFDictionary
+
+        // When
+        let result = keychainAccessAdapter.saveSeed(with: "SeedName", seedPhrase: Data("seedPhrase".utf8))
+
+        // Then
+        XCTAssertEqual(keychainService.addCallsCount, 1)
+        if case .success = result {
+            XCTFail("Expected failure but got \(result)")
+        }
+    }
+
+    func testSaveSeed_FailureAccessControlNotAvailable() {
+        // Given
+        accessControlProviderMock.accessControlToThrow = KeychainError.accessControlNotAvailable
+
+        // When
+        let result = keychainAccessAdapter.saveSeed(with: "SeedName", seedPhrase: Data("seedPhrase".utf8))
+
+        // Then
+        XCTAssertEqual(accessControlProviderMock.accessControlCallsCount, 1)
+        if case .success = result {
+            XCTFail("Expected failure due to access control not available but got \(result)")
+        }
+    }
+
+    func testRetrieveSeed_Successful() {
+        // Given
+        let seedName = "SeedName"
+        let expectedSeed = "seedPhrase"
+        keychainService.copyMatchingReturnValue = errSecSuccess
+        keychainService.copyMatchingData = expectedSeed.data(using: .utf8) as CFTypeRef?
+        keychainQueryProviderMock.queryReturnValue = [:] as CFDictionary
+
+        // When
+        let result = keychainAccessAdapter.retrieveSeed(with: seedName)
+
+        // Then
+        XCTAssertEqual(keychainService.copyMatchingCallsCount, 1)
+        switch result {
+        case let .success(seed):
+            XCTAssertEqual(seed, expectedSeed)
+        default:
+            XCTFail("Expected success but got \(result)")
+        }
+    }
+
+    func testRetrieveSeed_ItemNotFound() {
+        // Given
+        let seedName = "SeedName"
+        keychainService.copyMatchingReturnValue = errSecItemNotFound
+        keychainQueryProviderMock.queryReturnValue = [:] as CFDictionary
+
+        // When
+        let result = keychainAccessAdapter.retrieveSeed(with: seedName)
+
+        // Then
+        XCTAssertEqual(keychainService.copyMatchingCallsCount, 1)
+        switch result {
+        case let .failure(error):
+            XCTAssertEqual(error, KeychainError.fetchError)
+        default:
+            XCTFail("Expected failure due to item not found but got \(result)")
+        }
+    }
+
+    func testRetrieveSeed_Failure() {
+        // Given
+        let seedName = "SeedName"
+        keychainService.copyMatchingReturnValue = errSecAuthFailed
+        keychainQueryProviderMock.queryReturnValue = [:] as CFDictionary
+
+        // When
+        let result = keychainAccessAdapter.retrieveSeed(with: seedName)
+
+        // Then
+        XCTAssertEqual(keychainService.copyMatchingCallsCount, 1)
+        if case .success = result {
+            XCTFail("Expected failure but got \(result)")
+        }
+    }
+
+    func testRetrieveSeeds_Successful() {
+        // Given
+        let seedNamesToFetch = Set(["Seed1", "Seed2"])
+        let seedData: [[String: Any]] = [
+            [kSecAttrAccount as String: "Seed1", kSecValueData as String: "seedPhrase1".data(using: .utf8)!],
+            [kSecAttrAccount as String: "Seed2", kSecValueData as String: "seedPhrase2".data(using: .utf8)!]
+        ]
+        keychainService.copyMatchingReturnValue = errSecSuccess
+        keychainService.copyMatchingData = seedData as CFTypeRef?
+        keychainQueryProviderMock.queryReturnValue = [:] as CFDictionary
+
+        // When
+        let result = keychainAccessAdapter.retrieveSeeds(with: seedNamesToFetch)
+
+        // Then
+        XCTAssertEqual(keychainService.copyMatchingCallsCount, 1)
+        switch result {
+        case let .success(seeds):
+            XCTAssertEqual(seeds.count, 2)
+            XCTAssertEqual(seeds["Seed1"], "seedPhrase1")
+            XCTAssertEqual(seeds["Seed2"], "seedPhrase2")
+        default:
+            XCTFail("Expected success but got \(result)")
+        }
+    }
+
+    func testRetrieveSeeds_EmptyResult() {
+        // Given
+        let seedNamesToFetch = Set(["Seed1", "Seed2"])
+        keychainService.copyMatchingReturnValue = errSecSuccess
+        keychainService.copyMatchingData = [] as CFTypeRef?
+        keychainQueryProviderMock.queryReturnValue = [:] as CFDictionary
+
+        // When
+        let result = keychainAccessAdapter.retrieveSeeds(with: seedNamesToFetch)
+
+        // Then
+        XCTAssertEqual(keychainService.copyMatchingCallsCount, 1)
+        switch result {
+        case let .success(seeds):
+            XCTAssertTrue(seeds.isEmpty)
+        default:
+            XCTFail("Expected success with empty result but got \(result)")
+        }
+    }
+
+    func testRetrieveSeeds_Failure() {
+        // Given
+        let seedNamesToFetch = Set(["Seed1", "Seed2"])
+        keychainService.copyMatchingReturnValue = errSecAuthFailed
+        keychainQueryProviderMock.queryReturnValue = [:] as CFDictionary
+
+        // When
+        let result = keychainAccessAdapter.retrieveSeeds(with: seedNamesToFetch)
+
+        // Then
+        XCTAssertEqual(keychainService.copyMatchingCallsCount, 1)
+        if case .success = result {
+            XCTFail("Expected failure but got \(result)")
+        }
+    }
+
+    func testRemoveSeed_Successful() {
+        // Given
+        let seedName = "SeedName"
+        keychainService.deleteReturnValue = errSecSuccess
+        keychainQueryProviderMock.queryReturnValue = [:] as CFDictionary
+
+        // When
+        let result = keychainAccessAdapter.removeSeed(seedName: seedName)
+
+        // Then
+        XCTAssertEqual(keychainService.deleteCallsCount, 1)
+        switch result {
+        case .success:
+            break // Test passes if we reach here
+        default:
+            XCTFail("Expected success but got \(result)")
+        }
+    }
+
+    func testRemoveSeed_Failure() {
+        // Given
+        let seedName = "SeedName"
+        keychainService.deleteReturnValue = errSecAuthFailed
+        keychainQueryProviderMock.queryReturnValue = [:] as CFDictionary
+
+        // When
+        let result = keychainAccessAdapter.removeSeed(seedName: seedName)
+
+        // Then
+        XCTAssertEqual(keychainService.deleteCallsCount, 1)
+        switch result {
+        case let .failure(error):
+            guard case let .deleteError(message) = error else {
+                XCTFail("Expected .deleteError but got \(error)")
+                return
+            }
+            XCTAssertFalse(message.isEmpty)
+        default:
+            XCTFail("Expected failure but got \(result)")
+        }
+    }
+
+    func testCheckIfSeedPhraseAlreadyExists_Found() {
+        // Given
+        let seedPhrase = Data("seedPhrase".utf8)
+        keychainService.copyMatchingReturnValue = errSecSuccess
+        keychainService.copyMatchingData = [seedPhrase] as CFTypeRef?
+        keychainQueryProviderMock.queryReturnValue = [:] as CFDictionary
+
+        // When
+        let result = keychainAccessAdapter.checkIfSeedPhraseAlreadyExists(seedPhrase: seedPhrase)
+
+        // Then
+        XCTAssertEqual(keychainService.copyMatchingCallsCount, 1)
+        switch result {
+        case let .success(exists):
+            XCTAssertTrue(exists)
+        default:
+            XCTFail("Expected success with true but got \(result)")
+        }
+    }
+
+    func testCheckIfSeedPhraseAlreadyExists_NotFound() {
+        // Given
+        let seedPhrase = Data("seedPhrase".utf8)
+        keychainService.copyMatchingReturnValue = errSecItemNotFound
+        keychainQueryProviderMock.queryReturnValue = [:] as CFDictionary
+
+        // When
+        let result = keychainAccessAdapter.checkIfSeedPhraseAlreadyExists(seedPhrase: seedPhrase)
+
+        // Then
+        XCTAssertEqual(keychainService.copyMatchingCallsCount, 1)
+        switch result {
+        case let .success(exists):
+            XCTAssertFalse(exists)
+        default:
+            XCTFail("Expected success with false but got \(result)")
+        }
+    }
+
+    func testCheckIfSeedPhraseAlreadyExists_Failure() {
+        // Given
+        let seedPhrase = Data("seedPhrase".utf8)
+        keychainService.copyMatchingReturnValue = errSecAuthFailed
+        keychainQueryProviderMock.queryReturnValue = [:] as CFDictionary
+
+        // When
+        let result = keychainAccessAdapter.checkIfSeedPhraseAlreadyExists(seedPhrase: seedPhrase)
+
+        // Then
+        XCTAssertEqual(keychainService.copyMatchingCallsCount, 1)
+        if case .success = result {
+            XCTFail("Expected failure but got \(result)")
+        }
+    }
+
+    func testRemoveAllSeeds_WhenDeletionSuccessful_ReturnsTrue() {
+        // Given
+        keychainService.deleteReturnValue = errSecSuccess
+        keychainQueryProviderMock.queryReturnValue = [:] as CFDictionary
+
+        // When
+        let result = keychainAccessAdapter.removeAllSeeds()
+
+        // Then
+        XCTAssertEqual(keychainService.deleteCallsCount, 1)
+        XCTAssertTrue(result)
+    }
+
+    func testRemoveAllSeeds_WhenDeletionFails_ReturnsFalse() {
+        // Given
+        keychainService.deleteReturnValue = errSecAuthFailed
+        keychainQueryProviderMock.queryReturnValue = [:] as CFDictionary
+
+        // When
+        let result = keychainAccessAdapter.removeAllSeeds()
+
+        // Then
+        XCTAssertEqual(keychainService.deleteCallsCount, 1)
+        XCTAssertFalse(result)
+    }
+
+    func testRemoveAllSeeds_WhenItemNotFound_ReturnsTrue() {
+        // Given
+        keychainService.deleteReturnValue = errSecItemNotFound
+        keychainQueryProviderMock.queryReturnValue = [:] as CFDictionary
+
+        // When
+        let result = keychainAccessAdapter.removeAllSeeds()
+
+        // Then
+        XCTAssertEqual(keychainService.deleteCallsCount, 1)
+        XCTAssertTrue(result)
     }
 }
 
@@ -58,5 +427,50 @@ final class AccessControlProviderMock: AccessControlProviding {
         } else {
             throw accessControlToThrow
         }
+    }
+}
+
+final class KeychainServiceMock: KeychainServicing {
+    // Mock return values
+    var addReturnValue: OSStatus = errSecSuccess
+    var copyMatchingReturnValue: OSStatus = errSecSuccess
+    var deleteReturnValue: OSStatus = errSecSuccess
+
+    // Mock received properties
+    var receivedAdd: [(query: CFDictionary, result: UnsafeMutablePointer<CFTypeRef?>?)] = []
+    var receivedCopyMatching: [(query: CFDictionary, result: UnsafeMutablePointer<CFTypeRef?>?)] = []
+    var receivedDelete: [CFDictionary] = []
+
+    // Number of times each function was called
+    var addCallsCount = 0
+    var copyMatchingCallsCount = 0
+    var deleteCallsCount = 0
+
+    // Mock data to be returned
+    var addData: CFTypeRef?
+    var copyMatchingData: CFTypeRef?
+
+    func add(_ query: CFDictionary, _ result: UnsafeMutablePointer<CFTypeRef?>?) -> OSStatus {
+        receivedAdd.append((query, result))
+        addCallsCount += 1
+        if let data = addData {
+            result?.pointee = data
+        }
+        return addReturnValue
+    }
+
+    func copyMatching(_ query: CFDictionary, _ result: UnsafeMutablePointer<CFTypeRef?>?) -> OSStatus {
+        receivedCopyMatching.append((query, result))
+        copyMatchingCallsCount += 1
+        if let data = copyMatchingData {
+            result?.pointee = data
+        }
+        return copyMatchingReturnValue
+    }
+
+    func delete(_ query: CFDictionary) -> OSStatus {
+        receivedDelete.append(query)
+        deleteCallsCount += 1
+        return deleteReturnValue
     }
 }

--- a/ios/PolkadotVaultTests/Core/Keychain/SeedsMediatorTests.swift
+++ b/ios/PolkadotVaultTests/Core/Keychain/SeedsMediatorTests.swift
@@ -1,0 +1,470 @@
+//
+//  SeedsMediatorTests.swift
+//  PolkadotVaultTests
+//
+//  Created by Krzysztof Rodak on 28/11/2023.
+//
+
+import Foundation
+@testable import PolkadotVault
+import XCTest
+
+final class SeedsMediatorTests: XCTestCase {
+    private var keychainAccessAdapterMock: KeychainAccessAdapterMock!
+    private var databaseMediatorMock: DatabaseMediatorMock!
+    private var authenticationStateMediatorMock: AuthenticatedStateMediatorMock!
+    private var seedsMediator: SeedsMediator!
+
+    override func setUp() {
+        super.setUp()
+        keychainAccessAdapterMock = KeychainAccessAdapterMock()
+        databaseMediatorMock = DatabaseMediatorMock()
+        authenticationStateMediatorMock = AuthenticatedStateMediatorMock()
+        seedsMediator = SeedsMediator(
+            keychainAccessAdapter: keychainAccessAdapterMock,
+            databaseMediator: databaseMediatorMock,
+            authenticationStateMediator: authenticationStateMediatorMock
+        )
+    }
+
+    override func tearDown() {
+        keychainAccessAdapterMock = nil
+        databaseMediatorMock = nil
+        authenticationStateMediatorMock = nil
+        seedsMediator = nil
+        super.tearDown()
+    }
+
+    func testRefreshSeeds_Successful() {
+        // Given
+        let seedNames = ["Seed1", "Seed2"]
+        keychainAccessAdapterMock.fetchSeedNamesReturnValue = .success(FetchSeedsPayload(seeds: seedNames))
+
+        // When
+        seedsMediator.refreshSeeds()
+
+        // Then
+        XCTAssertEqual(seedsMediator.seedNames, seedNames)
+        XCTAssertTrue(authenticationStateMediatorMock.authenticated)
+        XCTAssertEqual(authenticationStateMediatorMock.authenticatedSetCallsCount, 1)
+    }
+
+    func testRefreshSeeds_Failure() {
+        // Given
+        keychainAccessAdapterMock.fetchSeedNamesReturnValue = .failure(.fetchError)
+
+        // When
+        seedsMediator.refreshSeeds()
+
+        // Then
+        XCTAssertTrue(seedsMediator.seedNames.isEmpty)
+        XCTAssertFalse(authenticationStateMediatorMock.authenticated)
+        XCTAssertEqual(authenticationStateMediatorMock.authenticatedSetCallsCount, 1)
+    }
+
+    func testCreateSeed_Successful() {
+        // Given
+        let seedName = "Seed1"
+        let seedPhrase = "seedPhrase"
+        keychainAccessAdapterMock.saveSeedReturnValue = .success(())
+
+        // When
+        let result = seedsMediator.createSeed(
+            seedName: seedName,
+            seedPhrase: seedPhrase,
+            shouldCheckForCollision: false
+        )
+
+        // Then
+        XCTAssertTrue(result)
+        XCTAssertEqual(seedsMediator.seedNames, [seedName])
+        XCTAssertEqual(keychainAccessAdapterMock.saveSeedCallsCount, 1)
+    }
+
+    func testCreateSeed_FailureDueToEmptySeedName() {
+        // Given
+        let seedName = ""
+        let seedPhrase = "seedPhrase"
+
+        // When
+        let result = seedsMediator.createSeed(
+            seedName: seedName,
+            seedPhrase: seedPhrase,
+            shouldCheckForCollision: false
+        )
+
+        // Then
+        XCTAssertFalse(result)
+        XCTAssertTrue(seedsMediator.seedNames.isEmpty)
+    }
+
+    func testCreateSeed_FailureDueToCollision() {
+        // Given
+        let seedName = "Seed1"
+        let seedPhrase = "seedPhrase"
+        // Simulate collision
+        seedsMediator.seedNames = [seedPhrase]
+
+        // When
+        let result = seedsMediator.createSeed(seedName: seedName, seedPhrase: seedPhrase, shouldCheckForCollision: true)
+
+        // Then
+        XCTAssertFalse(result)
+        XCTAssertEqual(seedsMediator.seedNames, [seedPhrase])
+    }
+
+    func testCreateSeed_KeychainFailure() {
+        // Given
+        let seedName = "Seed1"
+        let seedPhrase = "seedPhrase"
+        keychainAccessAdapterMock.saveSeedReturnValue = .failure(.saveError(message: "Error"))
+
+        // When
+        let result = seedsMediator.createSeed(
+            seedName: seedName,
+            seedPhrase: seedPhrase,
+            shouldCheckForCollision: false
+        )
+
+        // Then
+        XCTAssertFalse(result)
+        XCTAssertTrue(seedsMediator.seedNames.isEmpty)
+        XCTAssertEqual(keychainAccessAdapterMock.saveSeedCallsCount, 1)
+    }
+
+    func testCheckSeedCollision_Exists() {
+        // Given
+        let existingSeedName = "Seed1"
+        seedsMediator.seedNames = [existingSeedName]
+
+        // When
+        let result = seedsMediator.checkSeedCollision(seedName: existingSeedName)
+
+        // Then
+        XCTAssertTrue(result)
+    }
+
+    func testCheckSeedCollision_NotExists() {
+        // Given
+        let nonExistingSeedName = "Seed2"
+        seedsMediator.seedNames = ["Seed1"]
+
+        // When
+        let result = seedsMediator.checkSeedCollision(seedName: nonExistingSeedName)
+
+        // Then
+        XCTAssertFalse(result)
+    }
+
+    func testGetSeedBackup_Success() {
+        // Given
+        let seedName = "Seed1"
+        let seedBackup = "BackupData"
+        keychainAccessAdapterMock.retrieveSeedReturnValue = .success(seedBackup)
+
+        // When
+        let result = seedsMediator.getSeedBackup(seedName: seedName)
+
+        // Then
+        XCTAssertEqual(result, seedBackup)
+    }
+
+    func testGetSeedBackup_Failure() {
+        // Given
+        let seedName = "Seed1"
+        keychainAccessAdapterMock.retrieveSeedReturnValue = .failure(.fetchError)
+
+        // When
+        let result = seedsMediator.getSeedBackup(seedName: seedName)
+
+        // Then
+        XCTAssertEqual(result, "")
+        XCTAssertFalse(authenticationStateMediatorMock.authenticated)
+    }
+
+    func testGetSeed_Success() {
+        // Given
+        let seedName = "Seed1"
+        let expectedSeed = "seedData"
+        keychainAccessAdapterMock.retrieveSeedReturnValue = .success(expectedSeed)
+
+        // When
+        let result = seedsMediator.getSeed(seedName: seedName)
+
+        // Then
+        XCTAssertEqual(result, expectedSeed)
+    }
+
+    func testGetSeed_Failure() {
+        // Given
+        let seedName = "Seed1"
+        keychainAccessAdapterMock.retrieveSeedReturnValue = .failure(.fetchError)
+
+        // When
+        let result = seedsMediator.getSeed(seedName: seedName)
+
+        // Then
+        XCTAssertEqual(result, "")
+        XCTAssertFalse(authenticationStateMediatorMock.authenticated)
+    }
+
+    func testGetSeeds_Success() {
+        // Given
+        let seedNames = Set(["Seed1", "Seed2"])
+        let expectedSeeds = ["Seed1": "seedData1", "Seed2": "seedData2"]
+        keychainAccessAdapterMock.retrieveSeedsReturnValue = .success(expectedSeeds)
+
+        // When
+        let result = seedsMediator.getSeeds(seedNames: seedNames)
+
+        // Then
+        XCTAssertEqual(result, expectedSeeds)
+    }
+
+    func testGetSeeds_Failure() {
+        // Given
+        let seedNames = Set(["Seed1", "Seed2"])
+        keychainAccessAdapterMock.retrieveSeedsReturnValue = .failure(.fetchError)
+
+        // When
+        let result = seedsMediator.getSeeds(seedNames: seedNames)
+
+        // Then
+        XCTAssertTrue(result.isEmpty)
+        XCTAssertFalse(authenticationStateMediatorMock.authenticated)
+    }
+
+    func testGetAllSeeds() {
+        // Given
+        seedsMediator.seedNames = ["Seed1", "Seed2"]
+        let expectedSeeds = ["Seed1": "seedData1", "Seed2": "seedData2"]
+        keychainAccessAdapterMock.retrieveSeedsReturnValue = .success(expectedSeeds)
+
+        // When
+        let result = seedsMediator.getAllSeeds()
+
+        // Then
+        XCTAssertEqual(result, expectedSeeds)
+    }
+
+    func testRemoveSeed_Successful() {
+        // Given
+        let seedName = "Seed1"
+        seedsMediator.seedNames = [seedName, "Seed2"]
+        keychainAccessAdapterMock.retrieveSeedReturnValue = .success("seedData")
+        keychainAccessAdapterMock.removeSeedReturnValue = .success(())
+
+        // When
+        let result = seedsMediator.removeSeed(seedName: seedName)
+
+        // Then
+        XCTAssertTrue(result)
+        XCTAssertEqual(seedsMediator.seedNames, ["Seed2"])
+    }
+
+    func testRemoveSeed_Failure() {
+        // Given
+        let seedName = "Seed1"
+        seedsMediator.seedNames = [seedName, "Seed2"]
+        keychainAccessAdapterMock.retrieveSeedReturnValue = .failure(.fetchError)
+
+        // When
+        let result = seedsMediator.removeSeed(seedName: seedName)
+
+        // Then
+        XCTAssertFalse(result)
+        XCTAssertEqual(seedsMediator.seedNames, [seedName, "Seed2"])
+    }
+
+    func testRemoveAllSeeds_Successful() {
+        // Given
+        seedsMediator.seedNames = ["Seed1", "Seed2"]
+        keychainAccessAdapterMock.retrieveSeedsReturnValue = .success(["Seed1": "seedData1", "Seed2": "seedData2"])
+        keychainAccessAdapterMock.removeAllSeedsReturnValue = true
+
+        // When
+        let result = seedsMediator.removeAllSeeds()
+
+        // Then
+        XCTAssertTrue(result)
+        XCTAssertTrue(seedsMediator.seedNames.isEmpty)
+    }
+
+    func testRemoveAllSeeds_Failure() {
+        // Given
+        seedsMediator.seedNames = ["Seed1", "Seed2"]
+        keychainAccessAdapterMock.retrieveSeedsReturnValue = .failure(.fetchError)
+
+        // When
+        let result = seedsMediator.removeAllSeeds()
+
+        // Then
+        XCTAssertFalse(result)
+        XCTAssertEqual(seedsMediator.seedNames, ["Seed1", "Seed2"])
+    }
+
+    func testCheckSeedPhraseCollision_Exists() {
+        // Given
+        let seedPhrase = "existingSeedPhrase"
+        keychainAccessAdapterMock.checkIfSeedPhraseAlreadyExistsReturnValue = .success(true)
+
+        // When
+        let result = seedsMediator.checkSeedPhraseCollision(seedPhrase: seedPhrase)
+
+        // Then
+        XCTAssertTrue(result)
+    }
+
+    func testCheckSeedPhraseCollision_NotExists() {
+        // Given
+        let seedPhrase = "newSeedPhrase"
+        keychainAccessAdapterMock.checkIfSeedPhraseAlreadyExistsReturnValue = .success(false)
+
+        // When
+        let result = seedsMediator.checkSeedPhraseCollision(seedPhrase: seedPhrase)
+
+        // Then
+        XCTAssertFalse(result)
+    }
+
+    func testCheckSeedPhraseCollision_Failure() {
+        // Given
+        let seedPhrase = "seedPhrase"
+        keychainAccessAdapterMock.checkIfSeedPhraseAlreadyExistsReturnValue = .failure(.checkError)
+
+        // When
+        let result = seedsMediator.checkSeedPhraseCollision(seedPhrase: seedPhrase)
+
+        // Then
+        XCTAssertFalse(result)
+        XCTAssertFalse(authenticationStateMediatorMock.authenticated)
+    }
+
+    func testRemoveStalledSeeds() {
+        // Given
+        seedsMediator.seedNames = ["Seed1", "Seed2"]
+        keychainAccessAdapterMock.removeAllSeedsReturnValue = true
+
+        // When
+        seedsMediator.removeStalledSeeds()
+
+        // Then
+        XCTAssertTrue(seedsMediator.seedNames.isEmpty)
+    }
+}
+
+// MARK: - Mocks
+
+final class AuthenticatedStateMediatorMock: AuthenticatedStateMediator {
+    var authenticatedSetCallsCount = 0
+    override var authenticated: Bool {
+        didSet {
+            authenticatedSetCallsCount += 1
+        }
+    }
+}
+
+final class DatabaseMediatorMock: DatabaseMediating {
+    // Properties to track method calls and arguments
+    var databaseNameCallsCount = 0
+    var isDatabaseAvailableCallsCount = 0
+    var recreateDatabaseFileCallsCount = 0
+    var wipeDatabaseCallsCount = 0
+
+    // Properties to control return values
+    var databaseNameReturnValue = "MockDatabase"
+    var isDatabaseAvailableReturnValue = false
+    var recreateDatabaseFileReturnValue = false
+    var wipeDatabaseReturnValue = false
+
+    // Implementations of protocol methods
+    var databaseName: String {
+        databaseNameCallsCount += 1
+        return databaseNameReturnValue
+    }
+
+    func isDatabaseAvailable() -> Bool {
+        isDatabaseAvailableCallsCount += 1
+        return isDatabaseAvailableReturnValue
+    }
+
+    @discardableResult
+    func recreateDatabaseFile() -> Bool {
+        recreateDatabaseFileCallsCount += 1
+        return recreateDatabaseFileReturnValue
+    }
+
+    @discardableResult
+    func wipeDatabase() -> Bool {
+        wipeDatabaseCallsCount += 1
+        return wipeDatabaseReturnValue
+    }
+}
+
+final class KeychainAccessAdapterMock: KeychainAccessAdapting {
+    // Properties to track method calls and arguments
+    var fetchSeedNamesCallsCount = 0
+    var saveSeedCallsCount = 0
+    var retrieveSeedCallsCount = 0
+    var retrieveSeedsCallsCount = 0
+    var removeSeedCallsCount = 0
+    var checkIfSeedPhraseAlreadyExistsCallsCount = 0
+    var removeAllSeedsCallsCount = 0
+
+    // Properties to store passed arguments
+    var saveSeedArguments: [(seedName: String, seedPhrase: Data)] = []
+    var retrieveSeedArguments: [String] = []
+    var retrieveSeedsArguments: [Set<String>] = []
+    var removeSeedArguments: [String] = []
+    var checkIfSeedPhraseAlreadyExistsArguments: [Data] = []
+
+    // Properties to control return values
+    var fetchSeedNamesReturnValue: Result<FetchSeedsPayload, KeychainError> = .failure(.fetchError)
+    var saveSeedReturnValue: Result<Void, KeychainError> = .failure(.saveError(message: ""))
+    var retrieveSeedReturnValue: Result<String, KeychainError> = .failure(.fetchError)
+    var retrieveSeedsReturnValue: Result<[String: String], KeychainError> = .failure(.fetchError)
+    var removeSeedReturnValue: Result<Void, KeychainError> = .failure(.deleteError(message: ""))
+    var checkIfSeedPhraseAlreadyExistsReturnValue: Result<Bool, KeychainError> = .failure(.checkError)
+    var removeAllSeedsReturnValue: Bool = false
+
+    // Implementations of protocol methods
+    func fetchSeedNames() -> Result<FetchSeedsPayload, KeychainError> {
+        fetchSeedNamesCallsCount += 1
+        return fetchSeedNamesReturnValue
+    }
+
+    func saveSeed(with seedName: String, seedPhrase: Data) -> Result<Void, KeychainError> {
+        saveSeedCallsCount += 1
+        saveSeedArguments.append((seedName, seedPhrase))
+        return saveSeedReturnValue
+    }
+
+    func retrieveSeed(with seedName: String) -> Result<String, KeychainError> {
+        retrieveSeedCallsCount += 1
+        retrieveSeedArguments.append(seedName)
+        return retrieveSeedReturnValue
+    }
+
+    func retrieveSeeds(with seedNames: Set<String>) -> Result<[String: String], KeychainError> {
+        retrieveSeedsCallsCount += 1
+        retrieveSeedsArguments.append(seedNames)
+        return retrieveSeedsReturnValue
+    }
+
+    func removeSeed(seedName: String) -> Result<Void, KeychainError> {
+        removeSeedCallsCount += 1
+        removeSeedArguments.append(seedName)
+        return removeSeedReturnValue
+    }
+
+    func checkIfSeedPhraseAlreadyExists(seedPhrase: Data) -> Result<Bool, KeychainError> {
+        checkIfSeedPhraseAlreadyExistsCallsCount += 1
+        checkIfSeedPhraseAlreadyExistsArguments.append(seedPhrase)
+        return checkIfSeedPhraseAlreadyExistsReturnValue
+    }
+
+    func removeAllSeeds() -> Bool {
+        removeAllSeedsCallsCount += 1
+        return removeAllSeedsReturnValue
+    }
+}

--- a/ios/PolkadotVaultTests/Core/Keychain/SeedsMediatorTests.swift
+++ b/ios/PolkadotVaultTests/Core/Keychain/SeedsMediatorTests.swift
@@ -158,10 +158,16 @@ final class SeedsMediatorTests: XCTestCase {
 
     func testGetSeedBackup_Success() {
         // Given
-        let seedName = "Seed1"
+        let seedName = "Seed3"
         let seedBackup = "BackupData"
         keychainAccessAdapterMock.retrieveSeedReturnValue = .success(seedBackup)
-
+        let databaseMediator = DatabaseMediator()
+        databaseMediator.recreateDatabaseFile()
+        try? initNavigation(
+            dbname: databaseMediator.databaseName,
+            seedNames: seedsMediator.seedNames
+        )
+        try? historyInitHistoryWithCert()
         // When
         let result = seedsMediator.getSeedBackup(seedName: seedName)
 


### PR DESCRIPTION
## Purpose
More abstraction around Keychain API usage (wrapper for C-based API) to to be able to mock it and finally cover most crucial logic with unit tests
