### PR TITLE
feat: android recover phrase - ignore capitalisation - debatable. 

### DIFF
--- a/android/src/main/java/io/parity/signer/screens/keysets/restore/KeysetRecoverViewModel.kt
+++ b/android/src/main/java/io/parity/signer/screens/keysets/restore/KeysetRecoverViewModel.kt
@@ -53,6 +53,7 @@ class KeysetRecoverViewModel : ViewModel() {
 			} else {
 				//valid word input handling
 				val input = rawUserInput.trim()
+					.lowercase() // word could be capitalized by keyboard autocompletion
 				val guessing = getGuessWords(input)
 				if (rawUserInput.endsWith(KeysetRecoverModel.SPACE_CHARACTER)) {
 					if (guessing.contains(input)) {


### PR DESCRIPTION
Workaround for keyboard auto capitalisation while entering recover phrase

## Problem
When typing phrase with spaces, instead of selecting words from suggestions, after entering space keyboard often capitalizing words as part of autocompletion logic (for example default google keyboard) and it doesn't match seed words, which are not capitalized.

## Proposed solution
Always lowercase input before consigning adding it into current recovering phrase.

This won't work if capitalization would mean something, but so far it's **always** lowercase, right?


