### PR TITLE
chore: ios: Sourcery integration for automatic mocks generation for better unit testing

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -36,7 +36,7 @@ jobs:
       - name:                 Install dependencies
         run:                  |
           brew install swiftgen
-          brew install swiftformat
+          brew install sourcery
 
       - name: Get cached Swift Packages managed by Xcode
         uses: actions/cache@v3

--- a/.github/workflows/testflight-prod.yml
+++ b/.github/workflows/testflight-prod.yml
@@ -30,7 +30,7 @@ jobs:
       - name:                 Install dependencies
         run:                  |
           brew install swiftgen
-          brew install swiftformat
+          brew install sourcery
 
       - name: Get cached Swift Packages managed by Xcode
         uses: actions/cache@v3

--- a/.github/workflows/testflight-qa.yml
+++ b/.github/workflows/testflight-qa.yml
@@ -30,7 +30,7 @@ jobs:
       - name:                 Install dependencies
         run:                  |
           brew install swiftgen
-          brew install swiftformat
+          brew install sourcery
 
       - name: Get cached Swift Packages managed by Xcode
         uses: actions/cache@v3

--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,7 @@ android/debug
 # iOS
 ios/PolkadotVault/Database/Database/*
 ios/PolkadotVault/Generated
+*.generated.swift
 
 # rust
 rust/target

--- a/ios/PolkadotVault.xcodeproj/project.pbxproj
+++ b/ios/PolkadotVault.xcodeproj/project.pbxproj
@@ -774,7 +774,6 @@
 				6D52E3A12946C19F00AD72F0 /* Settings */,
 				6DA2ACA32939D20F00AAEADC /* Logs */,
 				6D199C9D292A8CF300E79113 /* Scan */,
-				6DCC572428D8C0290014278A /* Backup */,
 				6D2D245028CE5F0E00862726 /* PublicKey */,
 				6DC5643E28B929E0003D540B /* KeyDetails */,
 				6D019966289C936800F4C317 /* Containers */,
@@ -1745,13 +1744,6 @@
 			path = KeyDetails;
 			sourceTree = "<group>";
 		};
-		6DCC572428D8C0290014278A /* Backup */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Backup;
-			sourceTree = "<group>";
-		};
 		6DCC572528D8C0410014278A /* Backup */ = {
 			isa = PBXGroup;
 			children = (
@@ -2233,6 +2225,7 @@
 				"${SRCROOT}/PolkadotVaultTests/Generated/AutoMockable/AutoMockable+J.generated.swift",
 				"${SRCROOT}/PolkadotVaultTests/Generated/AutoMockable/AutoMockable+K.generated.swift",
 				"${SRCROOT}/PolkadotVaultTests/Generated/AutoMockable/AutoMockable+L.generated.swift",
+				"${SRCROOT}/PolkadotVaultTests/Generated/AutoMockable/AutoMockable+M.generated.swift",
 				"${SRCROOT}/PolkadotVaultTests/Generated/AutoMockable/AutoMockable+N.generated.swift",
 				"${SRCROOT}/PolkadotVaultTests/Generated/AutoMockable/AutoMockable+O.generated.swift",
 				"${SRCROOT}/PolkadotVaultTests/Generated/AutoMockable/AutoMockable+P.generated.swift",

--- a/ios/PolkadotVault.xcodeproj/project.pbxproj
+++ b/ios/PolkadotVault.xcodeproj/project.pbxproj
@@ -2214,15 +2214,42 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
+				"$(SRCROOT)/sourcery.yml",
+				"${SRCROOT}/PolkadotVaultTests/Generated/AutoMockable/Scripts/initial_setup.sh",
 			);
 			name = "Run Sourcery";
 			outputFileListPaths = (
 			);
 			outputPaths = (
+				"${SRCROOT}/PolkadotVaultTests/Generated/AutoMockable/AutoMockable+A.generated.swift",
+				"${SRCROOT}/PolkadotVaultTests/Generated/AutoMockable/AutoMockable+B.generated.swift",
+				"${SRCROOT}/PolkadotVaultTests/Generated/AutoMockable/AutoMockable+C.generated.swift",
+				"${SRCROOT}/PolkadotVaultTests/Generated/AutoMockable/AutoMockable+D.generated.swift",
+				"${SRCROOT}/PolkadotVaultTests/Generated/AutoMockable/AutoMockable+E.generated.swift",
+				"${SRCROOT}/PolkadotVaultTests/Generated/AutoMockable/AutoMockable+F.generated.swift",
+				"${SRCROOT}/PolkadotVaultTests/Generated/AutoMockable/AutoMockable+G.generated.swift",
+				"${SRCROOT}/PolkadotVaultTests/Generated/AutoMockable/AutoMockable+H.generated.swift",
+				"${SRCROOT}/PolkadotVaultTests/Generated/AutoMockable/AutoMockable+I.generated.swift",
+				"${SRCROOT}/PolkadotVaultTests/Generated/AutoMockable/AutoMockable+J.generated.swift",
+				"${SRCROOT}/PolkadotVaultTests/Generated/AutoMockable/AutoMockable+K.generated.swift",
+				"${SRCROOT}/PolkadotVaultTests/Generated/AutoMockable/AutoMockable+L.generated.swift",
+				"${SRCROOT}/PolkadotVaultTests/Generated/AutoMockable/AutoMockable+N.generated.swift",
+				"${SRCROOT}/PolkadotVaultTests/Generated/AutoMockable/AutoMockable+O.generated.swift",
+				"${SRCROOT}/PolkadotVaultTests/Generated/AutoMockable/AutoMockable+P.generated.swift",
+				"${SRCROOT}/PolkadotVaultTests/Generated/AutoMockable/AutoMockable+Q.generated.swift",
+				"${SRCROOT}/PolkadotVaultTests/Generated/AutoMockable/AutoMockable+R.generated.swift",
+				"${SRCROOT}/PolkadotVaultTests/Generated/AutoMockable/AutoMockable+S.generated.swift",
+				"${SRCROOT}/PolkadotVaultTests/Generated/AutoMockable/AutoMockable+T.generated.swift",
+				"${SRCROOT}/PolkadotVaultTests/Generated/AutoMockable/AutoMockable+U.generated.swift",
+				"${SRCROOT}/PolkadotVaultTests/Generated/AutoMockable/AutoMockable+V.generated.swift",
+				"${SRCROOT}/PolkadotVaultTests/Generated/AutoMockable/AutoMockable+W.generated.swift",
+				"${SRCROOT}/PolkadotVaultTests/Generated/AutoMockable/AutoMockable+X.generated.swift",
+				"${SRCROOT}/PolkadotVaultTests/Generated/AutoMockable/AutoMockable+Y.generated.swift",
+				"${SRCROOT}/PolkadotVaultTests/Generated/AutoMockable/AutoMockable+Z.generated.swift",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ $ACTION != \"indexbuild\" ]; then\n   export PATH=\"$PATH:/opt/homebrew/bin\"\n   sourcery --config \"${SRCROOT}/sourcery.yml\" && bash \"${SRCROOT}/PolkadotVaultTests/Generated/AutoMockable/Scripts/initial_setup.sh\"\nfi\n";
+			shellScript = "if [ $ACTION != \"indexbuild\" ]; then\n    sourcery --config \"${SRCROOT}/sourcery.yml\" && bash \"${SRCROOT}/PolkadotVaultTests/Generated/AutoMockable/Scripts/initial_setup.sh\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/ios/PolkadotVault.xcodeproj/project.pbxproj
+++ b/ios/PolkadotVault.xcodeproj/project.pbxproj
@@ -276,6 +276,33 @@
 		6DDF439D2987A23B00881AFF /* Unbounded-Black.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 6DDF439829879D1D00881AFF /* Unbounded-Black.ttf */; };
 		6DDF439E2987A23E00881AFF /* Unbounded-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 6DDF439A29879D1D00881AFF /* Unbounded-Bold.ttf */; };
 		6DDF439F2987A24000881AFF /* Unbounded-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 6DDF439929879D1D00881AFF /* Unbounded-Regular.ttf */; };
+		6DE48E2E2B1EB97C003094D5 /* AutoMockableHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE48E2C2B1EB97C003094D5 /* AutoMockableHeader.swift */; };
+		6DE48E7E2B1F0B95003094D5 /* AutoMockable+X.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE48E642B1F0B95003094D5 /* AutoMockable+X.generated.swift */; };
+		6DE48E7F2B1F0B96003094D5 /* AutoMockable+Z.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE48E652B1F0B95003094D5 /* AutoMockable+Z.generated.swift */; };
+		6DE48E802B1F0B96003094D5 /* AutoMockable+P.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE48E662B1F0B95003094D5 /* AutoMockable+P.generated.swift */; };
+		6DE48E812B1F0B96003094D5 /* AutoMockable+G.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE48E672B1F0B95003094D5 /* AutoMockable+G.generated.swift */; };
+		6DE48E822B1F0B96003094D5 /* AutoMockable+J.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE48E682B1F0B95003094D5 /* AutoMockable+J.generated.swift */; };
+		6DE48E832B1F0B96003094D5 /* AutoMockable+C.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE48E692B1F0B95003094D5 /* AutoMockable+C.generated.swift */; };
+		6DE48E842B1F0B96003094D5 /* AutoMockable+K.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE48E6A2B1F0B95003094D5 /* AutoMockable+K.generated.swift */; };
+		6DE48E852B1F0B96003094D5 /* AutoMockable+U.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE48E6B2B1F0B95003094D5 /* AutoMockable+U.generated.swift */; };
+		6DE48E862B1F0B96003094D5 /* AutoMockable+F.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE48E6C2B1F0B95003094D5 /* AutoMockable+F.generated.swift */; };
+		6DE48E872B1F0B96003094D5 /* AutoMockable+E.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE48E6D2B1F0B95003094D5 /* AutoMockable+E.generated.swift */; };
+		6DE48E882B1F0B96003094D5 /* AutoMockable+N.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE48E6E2B1F0B95003094D5 /* AutoMockable+N.generated.swift */; };
+		6DE48E892B1F0B96003094D5 /* AutoMockable+M.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE48E6F2B1F0B95003094D5 /* AutoMockable+M.generated.swift */; };
+		6DE48E8A2B1F0B96003094D5 /* AutoMockable+V.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE48E702B1F0B95003094D5 /* AutoMockable+V.generated.swift */; };
+		6DE48E8B2B1F0B96003094D5 /* AutoMockable+I.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE48E712B1F0B95003094D5 /* AutoMockable+I.generated.swift */; };
+		6DE48E8C2B1F0B96003094D5 /* AutoMockable+R.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE48E722B1F0B95003094D5 /* AutoMockable+R.generated.swift */; };
+		6DE48E8D2B1F0B96003094D5 /* AutoMockable+S.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE48E732B1F0B95003094D5 /* AutoMockable+S.generated.swift */; };
+		6DE48E8E2B1F0B96003094D5 /* AutoMockable+B.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE48E742B1F0B95003094D5 /* AutoMockable+B.generated.swift */; };
+		6DE48E8F2B1F0B96003094D5 /* AutoMockable+Y.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE48E752B1F0B95003094D5 /* AutoMockable+Y.generated.swift */; };
+		6DE48E902B1F0B96003094D5 /* AutoMockable+A.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE48E762B1F0B95003094D5 /* AutoMockable+A.generated.swift */; };
+		6DE48E912B1F0B96003094D5 /* AutoMockable+H.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE48E772B1F0B95003094D5 /* AutoMockable+H.generated.swift */; };
+		6DE48E922B1F0B96003094D5 /* AutoMockable+T.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE48E782B1F0B95003094D5 /* AutoMockable+T.generated.swift */; };
+		6DE48E932B1F0B96003094D5 /* AutoMockable+W.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE48E792B1F0B95003094D5 /* AutoMockable+W.generated.swift */; };
+		6DE48E942B1F0B96003094D5 /* AutoMockable+O.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE48E7A2B1F0B95003094D5 /* AutoMockable+O.generated.swift */; };
+		6DE48E952B1F0B96003094D5 /* AutoMockable+Q.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE48E7B2B1F0B95003094D5 /* AutoMockable+Q.generated.swift */; };
+		6DE48E962B1F0B96003094D5 /* AutoMockable+D.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE48E7C2B1F0B95003094D5 /* AutoMockable+D.generated.swift */; };
+		6DE48E972B1F0B96003094D5 /* AutoMockable+L.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE48E7D2B1F0B95003094D5 /* AutoMockable+L.generated.swift */; };
 		6DE67D05298AA4270042415A /* BackupSelectKeyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE67D04298AA4270042415A /* BackupSelectKeyView.swift */; };
 		6DE67D07298AB7B80042415A /* SettingsBackupModal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE67D06298AB7B80042415A /* SettingsBackupModal.swift */; };
 		6DE8466E28BF73E40051346A /* DerivedKeyRowModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE8466D28BF73E40051346A /* DerivedKeyRowModel.swift */; };
@@ -623,6 +650,34 @@
 		6DDF439929879D1D00881AFF /* Unbounded-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Unbounded-Regular.ttf"; sourceTree = "<group>"; };
 		6DDF439A29879D1D00881AFF /* Unbounded-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Unbounded-Bold.ttf"; sourceTree = "<group>"; };
 		6DDF439B29879D3900881AFF /* SecondaryFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondaryFont.swift; sourceTree = "<group>"; };
+		6DE48E2C2B1EB97C003094D5 /* AutoMockableHeader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutoMockableHeader.swift; sourceTree = "<group>"; };
+		6DE48E2D2B1EB97C003094D5 /* initial_setup.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = initial_setup.sh; sourceTree = "<group>"; };
+		6DE48E642B1F0B95003094D5 /* AutoMockable+X.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AutoMockable+X.generated.swift"; sourceTree = "<group>"; };
+		6DE48E652B1F0B95003094D5 /* AutoMockable+Z.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AutoMockable+Z.generated.swift"; sourceTree = "<group>"; };
+		6DE48E662B1F0B95003094D5 /* AutoMockable+P.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AutoMockable+P.generated.swift"; sourceTree = "<group>"; };
+		6DE48E672B1F0B95003094D5 /* AutoMockable+G.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AutoMockable+G.generated.swift"; sourceTree = "<group>"; };
+		6DE48E682B1F0B95003094D5 /* AutoMockable+J.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AutoMockable+J.generated.swift"; sourceTree = "<group>"; };
+		6DE48E692B1F0B95003094D5 /* AutoMockable+C.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AutoMockable+C.generated.swift"; sourceTree = "<group>"; };
+		6DE48E6A2B1F0B95003094D5 /* AutoMockable+K.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AutoMockable+K.generated.swift"; sourceTree = "<group>"; };
+		6DE48E6B2B1F0B95003094D5 /* AutoMockable+U.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AutoMockable+U.generated.swift"; sourceTree = "<group>"; };
+		6DE48E6C2B1F0B95003094D5 /* AutoMockable+F.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AutoMockable+F.generated.swift"; sourceTree = "<group>"; };
+		6DE48E6D2B1F0B95003094D5 /* AutoMockable+E.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AutoMockable+E.generated.swift"; sourceTree = "<group>"; };
+		6DE48E6E2B1F0B95003094D5 /* AutoMockable+N.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AutoMockable+N.generated.swift"; sourceTree = "<group>"; };
+		6DE48E6F2B1F0B95003094D5 /* AutoMockable+M.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AutoMockable+M.generated.swift"; sourceTree = "<group>"; };
+		6DE48E702B1F0B95003094D5 /* AutoMockable+V.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AutoMockable+V.generated.swift"; sourceTree = "<group>"; };
+		6DE48E712B1F0B95003094D5 /* AutoMockable+I.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AutoMockable+I.generated.swift"; sourceTree = "<group>"; };
+		6DE48E722B1F0B95003094D5 /* AutoMockable+R.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AutoMockable+R.generated.swift"; sourceTree = "<group>"; };
+		6DE48E732B1F0B95003094D5 /* AutoMockable+S.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AutoMockable+S.generated.swift"; sourceTree = "<group>"; };
+		6DE48E742B1F0B95003094D5 /* AutoMockable+B.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AutoMockable+B.generated.swift"; sourceTree = "<group>"; };
+		6DE48E752B1F0B95003094D5 /* AutoMockable+Y.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AutoMockable+Y.generated.swift"; sourceTree = "<group>"; };
+		6DE48E762B1F0B95003094D5 /* AutoMockable+A.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AutoMockable+A.generated.swift"; sourceTree = "<group>"; };
+		6DE48E772B1F0B95003094D5 /* AutoMockable+H.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AutoMockable+H.generated.swift"; sourceTree = "<group>"; };
+		6DE48E782B1F0B95003094D5 /* AutoMockable+T.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AutoMockable+T.generated.swift"; sourceTree = "<group>"; };
+		6DE48E792B1F0B95003094D5 /* AutoMockable+W.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AutoMockable+W.generated.swift"; sourceTree = "<group>"; };
+		6DE48E7A2B1F0B95003094D5 /* AutoMockable+O.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AutoMockable+O.generated.swift"; sourceTree = "<group>"; };
+		6DE48E7B2B1F0B95003094D5 /* AutoMockable+Q.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AutoMockable+Q.generated.swift"; sourceTree = "<group>"; };
+		6DE48E7C2B1F0B95003094D5 /* AutoMockable+D.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AutoMockable+D.generated.swift"; sourceTree = "<group>"; };
+		6DE48E7D2B1F0B95003094D5 /* AutoMockable+L.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AutoMockable+L.generated.swift"; sourceTree = "<group>"; };
 		6DE67D04298AA4270042415A /* BackupSelectKeyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupSelectKeyView.swift; sourceTree = "<group>"; };
 		6DE67D06298AB7B80042415A /* SettingsBackupModal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsBackupModal.swift; sourceTree = "<group>"; };
 		6DE8466D28BF73E40051346A /* DerivedKeyRowModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DerivedKeyRowModel.swift; sourceTree = "<group>"; };
@@ -863,8 +918,9 @@
 			children = (
 				6D5801DC28992375006C41D8 /* PolkadotVaultTests-Bridging-Header.h */,
 				6DC2EDFA2B1196D700298F00 /* Backend */,
-				6DBD21FE289A8C67005D539B /* Helpers */,
 				6D5801DA2899235C006C41D8 /* Core */,
+				6DE48E292B1EB94B003094D5 /* Generated */,
+				6DBD21FE289A8C67005D539B /* Helpers */,
 				2DE72BD526A588C9002BB752 /* Info.plist */,
 			);
 			path = PolkadotVaultTests;
@@ -1753,6 +1809,57 @@
 			path = Buttons;
 			sourceTree = "<group>";
 		};
+		6DE48E292B1EB94B003094D5 /* Generated */ = {
+			isa = PBXGroup;
+			children = (
+				6DE48E2A2B1EB951003094D5 /* AutoMockable */,
+			);
+			path = Generated;
+			sourceTree = "<group>";
+		};
+		6DE48E2A2B1EB951003094D5 /* AutoMockable */ = {
+			isa = PBXGroup;
+			children = (
+				6DE48E762B1F0B95003094D5 /* AutoMockable+A.generated.swift */,
+				6DE48E742B1F0B95003094D5 /* AutoMockable+B.generated.swift */,
+				6DE48E7C2B1F0B95003094D5 /* AutoMockable+D.generated.swift */,
+				6DE48E6D2B1F0B95003094D5 /* AutoMockable+E.generated.swift */,
+				6DE48E692B1F0B95003094D5 /* AutoMockable+C.generated.swift */,
+				6DE48E6C2B1F0B95003094D5 /* AutoMockable+F.generated.swift */,
+				6DE48E772B1F0B95003094D5 /* AutoMockable+H.generated.swift */,
+				6DE48E712B1F0B95003094D5 /* AutoMockable+I.generated.swift */,
+				6DE48E7D2B1F0B95003094D5 /* AutoMockable+L.generated.swift */,
+				6DE48E6F2B1F0B95003094D5 /* AutoMockable+M.generated.swift */,
+				6DE48E672B1F0B95003094D5 /* AutoMockable+G.generated.swift */,
+				6DE48E682B1F0B95003094D5 /* AutoMockable+J.generated.swift */,
+				6DE48E6A2B1F0B95003094D5 /* AutoMockable+K.generated.swift */,
+				6DE48E6E2B1F0B95003094D5 /* AutoMockable+N.generated.swift */,
+				6DE48E7A2B1F0B95003094D5 /* AutoMockable+O.generated.swift */,
+				6DE48E7B2B1F0B95003094D5 /* AutoMockable+Q.generated.swift */,
+				6DE48E722B1F0B95003094D5 /* AutoMockable+R.generated.swift */,
+				6DE48E732B1F0B95003094D5 /* AutoMockable+S.generated.swift */,
+				6DE48E782B1F0B95003094D5 /* AutoMockable+T.generated.swift */,
+				6DE48E662B1F0B95003094D5 /* AutoMockable+P.generated.swift */,
+				6DE48E6B2B1F0B95003094D5 /* AutoMockable+U.generated.swift */,
+				6DE48E702B1F0B95003094D5 /* AutoMockable+V.generated.swift */,
+				6DE48E792B1F0B95003094D5 /* AutoMockable+W.generated.swift */,
+				6DE48E752B1F0B95003094D5 /* AutoMockable+Y.generated.swift */,
+				6DE48E642B1F0B95003094D5 /* AutoMockable+X.generated.swift */,
+				6DE48E652B1F0B95003094D5 /* AutoMockable+Z.generated.swift */,
+				6DE48E2B2B1EB956003094D5 /* Scripts */,
+			);
+			path = AutoMockable;
+			sourceTree = "<group>";
+		};
+		6DE48E2B2B1EB956003094D5 /* Scripts */ = {
+			isa = PBXGroup;
+			children = (
+				6DE48E2C2B1EB97C003094D5 /* AutoMockableHeader.swift */,
+				6DE48E2D2B1EB97C003094D5 /* initial_setup.sh */,
+			);
+			path = Scripts;
+			sourceTree = "<group>";
+		};
 		6DE67D03298AA41D0042415A /* Backup */ = {
 			isa = PBXGroup;
 			children = (
@@ -1921,6 +2028,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 2DE72BE626A588C9002BB752 /* Build configuration list for PBXNativeTarget "PolkadotVaultTests" */;
 			buildPhases = (
+				6DE48E282B1EB932003094D5 /* Run Sourcery */,
 				2DE72BCB26A588C9002BB752 /* Sources */,
 				2DE72BCC26A588C9002BB752 /* Frameworks */,
 				2DE72BCD26A588C9002BB752 /* Resources */,
@@ -2096,6 +2204,25 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "if [ $ACTION != \"indexbuild\" ]; then\n    bash $PROJECT_DIR/scripts/generate_database.sh\nfi\n";
+		};
+		6DE48E282B1EB932003094D5 /* Run Sourcery */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Run Sourcery";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [ $ACTION != \"indexbuild\" ]; then\n   export PATH=\"$PATH:/opt/homebrew/bin\"\n   sourcery --config \"${SRCROOT}/sourcery.yml\" && bash \"${SRCROOT}/PolkadotVaultTests/Generated/AutoMockable/Scripts/initial_setup.sh\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -2374,24 +2501,51 @@
 			buildActionMask = 2147483647;
 			files = (
 				6D8AF88628BCC53B00CF0AB2 /* RuntimePropertiesProvidingMock.swift in Sources */,
+				6DE48E822B1F0B96003094D5 /* AutoMockable+J.generated.swift in Sources */,
+				6DE48E7E2B1F0B95003094D5 /* AutoMockable+X.generated.swift in Sources */,
 				6D5801E1289924AD006C41D8 /* ConnectivityMonitoringAdapterTests.swift in Sources */,
+				6DE48E912B1F0B96003094D5 /* AutoMockable+H.generated.swift in Sources */,
 				6DAFCB002B0AEB7E00DDD165 /* ConnectivityMediatorTests.swift in Sources */,
+				6DE48E8E2B1F0B96003094D5 /* AutoMockable+B.generated.swift in Sources */,
+				6DE48E832B1F0B96003094D5 /* AutoMockable+C.generated.swift in Sources */,
 				6D8AF88228BCC4D100CF0AB2 /* AccessControlProvidingAssemblerTests.swift in Sources */,
+				6DE48E8D2B1F0B96003094D5 /* AutoMockable+S.generated.swift in Sources */,
+				6DE48E872B1F0B96003094D5 /* AutoMockable+E.generated.swift in Sources */,
+				6DE48E8B2B1F0B96003094D5 /* AutoMockable+I.generated.swift in Sources */,
+				6DE48E8A2B1F0B96003094D5 /* AutoMockable+V.generated.swift in Sources */,
 				6D57DC54289D6CE900005C63 /* NavigationTests.swift in Sources */,
+				6DE48E8F2B1F0B96003094D5 /* AutoMockable+Y.generated.swift in Sources */,
 				6DAFCB022B0AEE4900DDD165 /* ApplicationStatePublisherTests.swift in Sources */,
+				6DE48E842B1F0B96003094D5 /* AutoMockable+K.generated.swift in Sources */,
+				6DE48E962B1F0B96003094D5 /* AutoMockable+D.generated.swift in Sources */,
+				6DE48E932B1F0B96003094D5 /* AutoMockable+W.generated.swift in Sources */,
+				6DE48E2E2B1EB97C003094D5 /* AutoMockableHeader.swift in Sources */,
+				6DE48E902B1F0B96003094D5 /* AutoMockable+A.generated.swift in Sources */,
 				6D8AF88A28BCC60600CF0AB2 /* KeychainQueryProviderTests.swift in Sources */,
 				6DDD38B22B11C3C2000D2B62 /* SeedsMediatorTests.swift in Sources */,
+				6DE48E812B1F0B96003094D5 /* AutoMockable+G.generated.swift in Sources */,
 				6D57DC52289D68B800005C63 /* ActionResult+Generate.swift in Sources */,
 				6DAFCAFD2B0AE87300DDD165 /* RuntimePropertiesProviderTests.swift in Sources */,
 				6DBD2202289A8E1F005D539B /* ErrorMock.swift in Sources */,
 				6DC2EDF92B11961800298F00 /* DateFormatterTests.swift in Sources */,
 				6DBD2200289A8C74005D539B /* URL+Generate.swift in Sources */,
+				6DE48E922B1F0B96003094D5 /* AutoMockable+T.generated.swift in Sources */,
+				6DE48E892B1F0B96003094D5 /* AutoMockable+M.generated.swift in Sources */,
+				6DE48E7F2B1F0B96003094D5 /* AutoMockable+Z.generated.swift in Sources */,
 				6DAFCAF82B0A360600DDD165 /* CameraPermissionHandlerTests.swift in Sources */,
+				6DE48E952B1F0B96003094D5 /* AutoMockable+Q.generated.swift in Sources */,
+				6DE48E802B1F0B96003094D5 /* AutoMockable+P.generated.swift in Sources */,
+				6DE48E8C2B1F0B96003094D5 /* AutoMockable+R.generated.swift in Sources */,
 				6D5801E5289937BA006C41D8 /* ConnectivityMonitoringAssemblerTests.swift in Sources */,
+				6DE48E882B1F0B96003094D5 /* AutoMockable+N.generated.swift in Sources */,
 				6DAFCB042B0AEF6800DDD165 /* PasswordProtectionStatePublisherTests.swift in Sources */,
+				6DE48E862B1F0B96003094D5 /* AutoMockable+F.generated.swift in Sources */,
+				6DE48E942B1F0B96003094D5 /* AutoMockable+O.generated.swift in Sources */,
 				6D57DC50289D667800005C63 /* NavigationCoordinatorTests.swift in Sources */,
 				6DC2EDFC2B1196DF00298F00 /* BackendServiceTests.swift in Sources */,
 				6DBD21FD289A83D0005D539B /* DatabaseMediatorTests.swift in Sources */,
+				6DE48E972B1F0B96003094D5 /* AutoMockable+L.generated.swift in Sources */,
+				6DE48E852B1F0B96003094D5 /* AutoMockable+U.generated.swift in Sources */,
 				6DAFCAFA2B0AE5C000DDD165 /* KeychainAccessAdapterTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/PolkadotVault/Core/Runtime/RuntimePropertiesProvider.swift
+++ b/ios/PolkadotVault/Core/Runtime/RuntimePropertiesProvider.swift
@@ -12,6 +12,7 @@ enum ApplicationRuntimeMode: String, Equatable {
     case debug
 }
 
+// sourcery: AutoMockable
 /// Protocol that provides access to app process properties
 protocol RuntimePropertiesProviding: AnyObject {
     var runtimeMode: ApplicationRuntimeMode { get }

--- a/ios/PolkadotVault/Resources/Templates/Sourcery/AutoMockable.stencil
+++ b/ios/PolkadotVault/Resources/Templates/Sourcery/AutoMockable.stencil
@@ -1,0 +1,107 @@
+{% macro swiftifyMethodName name parameters%}{{name|replace:"(","_"|replace:")",""|replace:":","_"|replace:"`",""|snakeToCamelCase|lowerFirstWord}}{%if name|hasPrefix:"use" %}{%if parameters.count > 0 %}{%if not parameters.first.argumentLabel %}{{parameters.first.name|upperFirstLetter}}{% endif %}{% endif %}{% endif %}{% endmacro %}
+{% macro swiftyMethodName name %}{{name|replace:"(","_"|replace:")",""|replace:":","_"|replace:"`",""|snakeToCamelCase|lowerFirstWord}}{%if name|hasPrefix:"use" %}{%if parameters.count > 0 %}{%if not parameters.first.argumentLabel %}{% endif %}{% endif %}{% endif %}{% endmacro %}
+{% macro methodClosureName method %}{% call swiftifyMethodName method.selectorName method.parameters %}Closure{% endmacro %}
+{% macro underlyingMockedVariableName variable %}underlying{{ variable.name|upperFirstLetter }}{% endmacro %}
+{% macro mockedVariableName variable %}{{ variable.name }}{% endmacro %}
+{% macro strippedTypeName parameter %}{{ parameter.typeName|replace:"@escaping","" }}{% endmacro %}
+
+{# Generate methods parameters  #}
+{% macro methodReceivedParameters method %}
+{% if method.parameters.count != 0 %}
+    {% for parameter in method.parameters %}
+        {% call swiftyMethodName method.selectorName%}Received{{ parameter.name|upperFirstLetter }}.append({{parameter.name}})
+    {% endfor %}
+{% endif %}
+{% endmacro %}
+
+{% macro methodClosureCallParameters method %}{% for param in method.parameters %}{{ param.name }}{% if not forloop.last %}, {% endif %}{% endfor %}{% endmacro %}
+
+{% macro methodReceivedArgumentsType method %}({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{{ param.unwrappedTypeName }}{% else %}{{ param.typeName }}{% endif %}{% if not forloop.last %}, {% endif %}{% endfor %}){% endmacro %}
+
+{# Generates mock methods and related variables  #}
+
+{% macro mockMethods %}
+
+{% for method in type.allMethods|!definedInExtension| %}
+{# Generate CallsCount  #}
+{% if not method.isInitializer %}
+    {% if method.isStatic %}static {% endif %}var {% call swiftifyMethodName method.selectorName method.parameters %}CallsCount = 0
+{% endif %}
+{# Generate ThrowableError  #}
+{% if method.throws %}
+    {% if method.isStatic and not method.isInitializer %}static {% endif %}var {% call swiftifyMethodName method.selectorName method.parameters %}ThrowableError: Error?
+{% endif %}
+{# Generate Received variables  #}
+{% if method.parameters.count != 0 %}
+    {% for parameter in method.parameters %}
+    {% if method.isStatic and not method.isInitializer %}static {% endif %}var {% call swiftyMethodName method.selectorName%}Received{{ parameter.name|upperFirstLetter }}: [{% call strippedTypeName parameter %}] = []
+    {% endfor %}
+{% endif %}
+{# Generate return variable  #}
+{% if not method.returnTypeName.isVoid and not method.isInitializer %}
+    {% if method.isStatic %}static {% endif %}var {% call swiftifyMethodName method.selectorName method.parameters%}ReturnValue: {{ method.returnTypeName }}{% if not method.isOptionalReturnType %}!{% endif %}
+{% endif %}
+{% endfor %}
+{# Generate method body with references to variables created above  #}
+{% for method in type.allMethods|!definedInExtension %}
+
+{% if method.isInitializer %}
+    required {{ method.name }} {
+    {% call methodReceivedParameters method %}
+        {% call methodClosureName method %}?({% call methodClosureCallParameters method %})
+}
+{% else %}
+    {% if method.isStatic %}static {% endif %}func {{ method.name }}{{ ' throws' if method.throws }}{% if not method.returnTypeName.isVoid %} -> {{ method.returnTypeName }}{% endif %} {
+        {% call swiftifyMethodName method.selectorName method.parameters %}CallsCount += 1
+            {% call methodReceivedParameters method %}
+{% if method.throws %}
+        if let error = {% call swiftifyMethodName method.selectorName method.parameters%}ThrowableError {
+            throw error
+        }
+{% endif %}
+{% if method.returnTypeName.isVoid %}
+{% else %}
+        return {% call swiftifyMethodName method.selectorName method.parameters%}ReturnValue{% if method.unwrappedReturnTypeName == "Any" %} as Any {% endif %}
+{% endif %}
+    }
+{% endif %}
+{% endfor %}
+{% endmacro %}
+
+{# Generate variables code #}
+
+{% macro mockOptionalVariable variable %}
+    {% if variable.isStatic %}static {% endif %}var {% call mockedVariableName variable %}: {{ variable.typeName }}
+{% endmacro %}
+
+{% macro mockNonOptionalArrayOrDictionaryVariable variable %}
+    {% if variable.isStatic %}static {% endif %}var {% call mockedVariableName variable %}: {{ variable.typeName }} = {% if variable.isArray %}[]{% elif variable.isDictionary %}[:]{% endif %}
+{% endmacro %}
+
+{% macro mockNonOptionalVariable variable %}
+    {% if variable.isStatic %}static {% endif %}var {% call mockedVariableName variable %}: {{ variable.typeName }} {
+        get { return {% call underlyingMockedVariableName variable %} }
+        set(value) { {% call underlyingMockedVariableName variable %} = value }
+    }
+    {% if variable.isStatic %}static {% endif %}var {% call underlyingMockedVariableName variable %}: {{ variable.typeName }}{% if not variable.isOptional %}!{% endif %}
+{% endmacro %}
+
+{# Generate results and move them to individual files #}
+
+{% for type in types.protocols where type.based.AutoMockable or type|annotated:"AutoMockable" %}
+{% if type.name != "AutoMockable" %}
+// sourcery:file:AutoMockable/AutoMockable+{{ type.name[0] }}
+final class {{ type.name }}Mock: {{ type.name }} {
+{% for variable in type.allVariables|!definedInExtension %}
+    {% if variable.isOptional %}
+        {% call mockOptionalVariable variable %}
+    {% elif variable.isArray or variable.isDictionary %}
+        {% call mockNonOptionalArrayOrDictionaryVariable variable %}
+    {% else %}
+        {% call mockNonOptionalVariable variable %}
+    {% endif %}
+{% endfor %}
+{% call mockMethods %}
+}
+// sourcery:end
+{% endif %}{% endfor %}

--- a/ios/PolkadotVaultTests/Generated/AutoMockable/Scripts/AutoMockableHeader.swift
+++ b/ios/PolkadotVaultTests/Generated/AutoMockable/Scripts/AutoMockableHeader.swift
@@ -1,0 +1,8 @@
+import LocalAuthentication
+@testable import PolkadotVault
+import UIKit
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable implicit_return
+// swiftlint:disable vertical_whitespace_closing_braces
+// swiftlint:disable weak_delegate

--- a/ios/PolkadotVaultTests/Generated/AutoMockable/Scripts/initial_setup.sh
+++ b/ios/PolkadotVaultTests/Generated/AutoMockable/Scripts/initial_setup.sh
@@ -1,0 +1,13 @@
+BASEDIR=$(dirname "$0")
+HEADER=$BASEDIR/AutoMockableHeader.swift
+
+for letter in {A..Z}
+do
+  FILE=$BASEDIR/../AutoMockable+$letter.generated.swift
+  if [ ! -f "$FILE" ]; then
+    touch $FILE
+  fi
+  if [[ -s "$FILE" ]]; then
+    cat $HEADER $FILE >$BASEDIR/out && mv $BASEDIR/out $FILE
+  fi
+done

--- a/ios/PolkadotVaultTests/Helpers/Mocks/RuntimePropertiesProvidingMock.swift
+++ b/ios/PolkadotVaultTests/Helpers/Mocks/RuntimePropertiesProvidingMock.swift
@@ -7,8 +7,3 @@
 
 import Foundation
 @testable import PolkadotVault
-
-final class RuntimePropertiesProvidingMock: RuntimePropertiesProviding {
-    var runtimeMode: PolkadotVault.ApplicationRuntimeMode = .debug
-    var dynamicDerivationsEnabled: Bool = true
-}

--- a/ios/sourcery.yml
+++ b/ios/sourcery.yml
@@ -1,0 +1,9 @@
+sources:
+  include:
+    - PolkadotVault
+  exclude:
+    - PolkadotVault/Packages
+templates:
+  - PolkadotVault/Resources/Templates/Sourcery
+output:
+  PolkadotVaultTests/Generated


### PR DESCRIPTION
## Purpose
This PR integrates [Sourcery](https://github.com/krzysztofzablocki/Sourcery) and custom [Stencil](https://github.com/stencilproject/Stencil) template `AutoMockable` (based on [AutoMockable](https://github.com/V8tr/AutoMockable)), in order to automatically generate mocks for protocols with custom annotation `//sourcery: AutoMockable`. Additionally there is custom bash script to create container `AutoMockable+<Letter>.generated.swift` files where generated mocks will be located, based on first letter of protocol name to store them into, to not deal with really big files when there are more mocks (as this is usually an issue, based on my previous experience with tool). This script also adds custom header for file to import any necessary Apple / 3rd party frameworks required by mocks.

This will save time on writing mocks manually, as there is no built-in functionality like this in Xcode.

## Scope
- integrate Sourcery
- add AutoMockable custom script
- add custom bash script to split mocks
- exclude generated files from Git repo, to not pollute PRs with unnecessary mocks code
- replace one mock with example autogenerated code

## Screenshots
| Example generated mock | File hierarchy in test target |
|-|-|
|<img src="https://github.com/paritytech/parity-signer/assets/1955364/0dbe5427-771b-4639-9215-57baf1525df7" width="320px">|<img src="https://github.com/paritytech/parity-signer/assets/1955364/d73ee1bc-fd8f-4131-8963-3f3050c99dd4" width="320px">|
