### PR TITLE
feat: ios: allow for empty state on Create Derived Key

### DIFF
--- a/ios/PolkadotVault/Components/Buttons/ActionButton.swift
+++ b/ios/PolkadotVault/Components/Buttons/ActionButton.swift
@@ -44,7 +44,6 @@ struct ActionButtonStyle: ButtonStyle {
         ActionButtonStyle(
             backgroundColor: .fill18,
             foregroundColor: isDisabled.wrappedValue ? .textAndIconsDisabled : .textAndIconsPrimary,
-
             isDisabled: isDisabled
         )
     }
@@ -52,7 +51,7 @@ struct ActionButtonStyle: ButtonStyle {
     static func emptyPrimary(isDisabled: Binding<Bool> = Binding<Bool>.constant(false)) -> ActionButtonStyle {
         ActionButtonStyle(
             backgroundColor: .clear,
-            foregroundColor: .textAndIconsPrimary,
+            foregroundColor: isDisabled.wrappedValue ? .textAndIconsDisabled : .textAndIconsPrimary,
             isDisabled: isDisabled
         )
     }


### PR DESCRIPTION
## Purpose
Adding empty state for Create Derived Key flow on network selection

## Screenshots

| Before | After |
|-|-|
|<img src="https://github.com/paritytech/parity-signer/assets/1955364/f1b4f45d-fc67-4976-9b3e-cbbdc07e8911" width="320px">|<img src="https://github.com/paritytech/parity-signer/assets/1955364/bb98d9f6-933e-4d21-bdce-7772b3fb7d40" width="320px">|
