### PR TITLE
fix: ios: track initial connectivity change when application is run and bring back general connectivity logs

### DIFF
--- a/ios/PolkadotVault/Core/Connectivity/ConnectivityMonitoringAdapter.swift
+++ b/ios/PolkadotVault/Core/Connectivity/ConnectivityMonitoringAdapter.swift
@@ -41,6 +41,9 @@ final class ConnectivityMonitoringAdapter: ObservableObject, ConnectivityMonitor
             guard isConnected != self.isConnected else { return }
             self.isConnected = isConnected
             notificationQueue.async {
+                if isConnected {
+                    try? historyDeviceWasOnline()
+                }
                 update(isConnected)
             }
         }

--- a/ios/PolkadotVault/Screens/Containers/MainScreenContainer.swift
+++ b/ios/PolkadotVault/Screens/Containers/MainScreenContainer.swift
@@ -94,7 +94,7 @@ extension MainScreenContainer {
 
 private extension MainScreenContainer.ViewModel {
     func initialiseAppRun() {
-        appLaunchMediator.finaliseInitialisation { result in
+        appLaunchMediator.finaliseInitialisation(connectivityMediator.isConnectivityOn) { result in
             switch result {
             case .success:
                 self.checkInitialState()


### PR DESCRIPTION
## Purpose
Fix for outstanding issue described in security report - now each connectivity change is tracked in logs, including case when application would be run on device with broken airgap and then airgap would be restored