### PR TITLE
fix: disable SwiftFormat for stubs

### DIFF
--- a/ios/.swiftformat
+++ b/ios/.swiftformat
@@ -8,6 +8,8 @@
 
 # file options
 --exclude PolkadotVault/Generated/
+--exclude PolkadotVault/Stubs/Stubs.swift
+--exclude PolkadotVault/Previews/Stubs.swift
 
 # rules
 --enable blankLineAfterImports


### PR DESCRIPTION
## Purpose

The PR disables the Swift Format application for stubs as they get timeout in the release CI