### PR TITLE
Supported 16 kb page size

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,8 +15,8 @@ android {
 		applicationId "io.parity.signer"
 		minSdk 23
 		targetSdk 35
-		versionCode 70300
-		versionName "7.3.0"
+		versionCode 70301
+		versionName "7.3.1"
 		ndk {
 			abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
 		}
@@ -52,10 +52,11 @@ android {
 		}
 		jniLibs {
 			pickFirsts += ['lib/armeabi-v7a/libc++_shared.so', 'lib/arm64-v8a/libc++_shared.so', 'lib/x86/libc++_shared.so', 'lib/x86_64/libc++_shared.so']
+			useLegacyPackaging = false
 		}
 	}
 	compileSdk 36
-	ndkVersion '24.0.8215888'
+	ndkVersion '29.0.14206865'
 	namespace 'io.parity.signer'
 }
 


### PR DESCRIPTION
## Purpose
Add 16 KB page size support to comply with Google Play requirements for apps targeting Android 15+.

## Scope
- `android/build.gradle`: set `jniLibs.useLegacyPackaging = false`, bumped `ndkVersion` from 24 to 29 for 16 KB-aligned linker
- `rust/.cargo/config.toml`: added `-Wl,-z,max-page-size=16384` linker flag for all Android targets (aarch64, x86_64, armv7, i686)
- Bumped app version 7.3.0 → 7.3.1 (versionCode 70300 → 70301)

Verified: `libsigner.so` for all ABIs built with `Align 0x4000` (16 KB); APK passes `zipalign -c -P 16 4` check.